### PR TITLE
feat: Add text long editor to Markdown.

### DIFF
--- a/src/components/ADempiere/Field/FieldNumber.vue
+++ b/src/components/ADempiere/Field/FieldNumber.vue
@@ -11,7 +11,6 @@
     :precision="precision"
     controls-position="right"
     :class="'display-type-' + cssClass"
-    @blur="validateInput"
     @change="preHandleChange"
   />
 </template>
@@ -22,12 +21,6 @@ import { fieldMixin } from '@/components/ADempiere/Field/FieldMixin'
 export default {
   name: 'FieldNumber',
   mixins: [fieldMixin],
-  props: {
-    validateInput: {
-      type: Function,
-      default: () => undefined
-    }
-  },
   data() {
     return {
       pattern: undefined,

--- a/src/components/ADempiere/Field/FieldText.vue
+++ b/src/components/ADempiere/Field/FieldText.vue
@@ -43,7 +43,7 @@ export default {
     typeTextBox() {
       // String, Url, FileName...
       var typeInput = 'text'
-      if (['Memo', 'Text', 'TextLong'].includes(this.metadata.referenceType)) {
+      if (['Memo', 'Text'].includes(this.metadata.referenceType)) {
         typeInput = 'textarea'
       }
       if (this.metadata.isEncrypted) {

--- a/src/components/ADempiere/Field/fieldSize.js
+++ b/src/components/ADempiere/Field/fieldSize.js
@@ -81,13 +81,13 @@ export const FIELD_DISPLAY_SIZES = [
     }
   },
   {
-    type: 'FieldTextArea',
+    type: 'FieldTextLong',
     size: {
       xs: 24,
-      sm: 12,
-      md: 8,
-      lg: 6,
-      xl: 6
+      sm: 24,
+      md: 24,
+      lg: 24,
+      xl: 24
     }
   },
   {

--- a/src/components/ADempiere/Field/index.vue
+++ b/src/components/ADempiere/Field/index.vue
@@ -162,6 +162,9 @@ export default {
       }
 
       if (this.panelType === 'window') {
+        if (this.field.componentPath === 'FieldTextLong') {
+          return sizeField
+        }
         // two columns if is mobile or desktop and show record navigation
         if (this.getWidth <= 768 || (this.getWidth >= 768 && this.getterIsShowedRecordNavigation)) {
           newSizes.xs = 12

--- a/src/components/ADempiere/Field/references.js
+++ b/src/components/ADempiere/Field/references.js
@@ -206,7 +206,7 @@ const REFERENCES = [
   },
   {
     id: 36,
-    type: 'FieldText',
+    type: 'FieldTextLong',
     support: true,
     description: 'Text (Long) - Text > 2000 characters',
     alias: ['TextLong', 'Text Long']


### PR DESCRIPTION
Hello, support is given to the editor for the long text field, as it is displayed supports both html and markdown.

![Peek 20-11-2019 12-22](https://user-images.githubusercontent.com/20288327/69279748-6df84b00-0bbb-11ea-9968-6192ccfc6aee.gif)

![20191120-173701-480x852](https://user-images.githubusercontent.com/20288327/69280780-781b4900-0bbd-11ea-89d0-96fe14244905.gif)
