### PR TITLE
Unify popovers with field info an zoom in

### DIFF
--- a/src/components/ADempiere/DataTable/index.vue
+++ b/src/components/ADempiere/DataTable/index.vue
@@ -330,7 +330,7 @@ export default {
       searchTable: '', // text from search
       defaultMaxPagination: 100,
       menuTable: '1',
-      activeName: '',
+      activeName: this.$route.query.action === 'advancedQuery' ? '1' : '',
       isOptional: false,
       isFixed: false,
       isLoadPanelFromServer: false,

--- a/src/components/ADempiere/Field/index.vue
+++ b/src/components/ADempiere/Field/index.vue
@@ -16,29 +16,22 @@
   >
     <!-- POPOVER FOR FIELD CONTEXT INFO -->
     <el-popover
-      v-if="field.contextInfo && field.contextInfo.isActive"
+      v-if="(field.contextInfo && field.contextInfo.isActive) || field.reference.zoomWindowList.length"
       ref="contextOptions"
       placement="top"
       :title="$t('components.contextFieldTitle')"
-      width="400"
+      width="300"
       trigger="click"
     >
-      <p v-html="field.contextInfo.messageText.msgText" />
-    </el-popover>
-    <!-- POPOVER FOR ZOOM IN FIELD -->
-    <el-popover
-      v-if="field.reference.zoomWindowList.length"
-      ref="zoomIn"
-      placement="bottom"
-      :title="$t('table.ProcessActivity.zoomIn')"
-      trigger="click"
-    >
-      <template v-for="(zoomItem, index) in field.reference.zoomWindowList">
-        <el-button :key="index" type="text" @click="redirect(zoomItem)">{{ zoomItem.name }}</el-button>
+      <p v-if="field.contextInfo && field.contextInfo.isActive" class="pre-formatted" v-html="field.contextInfo.messageText.msgText" />
+      <template v-if="field.reference.zoomWindowList.length">
+        <div class="el-popover__title"> {{ $t('table.ProcessActivity.zoomIn') }}</div>
+        <template v-for="(zoomItem, index) in field.reference.zoomWindowList">
+          <el-button :key="index" type="text" @click="redirect(zoomItem)">{{ zoomItem.name }}</el-button>
+        </template>
       </template>
     </el-popover>
     <el-form-item
-      v-popover:zoomIn
       v-popover:contextOptions
       :label="isFieldOnly()"
       :required="isMandatory()"
@@ -351,5 +344,8 @@ export default {
    */
   .el-form--label-top .el-form-item__label {
     padding-bottom: 0px !important;
+  }
+  .pre-formatted {
+    white-space: pre;
   }
 </style>

--- a/src/components/ADempiere/Field/index.vue
+++ b/src/components/ADempiere/Field/index.vue
@@ -19,7 +19,7 @@
       v-if="(field.contextInfo && field.contextInfo.isActive) || field.reference.zoomWindowList.length"
       ref="contextOptions"
       placement="top"
-      :title="field.contextInfo.isActive ? $t('components.contextFieldTitle') : ''"
+      :title="isFieldOnly()"
       width="300"
       trigger="click"
     >

--- a/src/components/ADempiere/Field/index.vue
+++ b/src/components/ADempiere/Field/index.vue
@@ -19,7 +19,7 @@
       v-if="(field.contextInfo && field.contextInfo.isActive) || field.reference.zoomWindowList.length"
       ref="contextOptions"
       placement="top"
-      :title="$t('components.contextFieldTitle')"
+      :title="field.contextInfo.isActive ? $t('components.contextFieldTitle') : ''"
       width="300"
       trigger="click"
     >
@@ -27,7 +27,7 @@
       <template v-if="field.reference.zoomWindowList.length">
         <div class="el-popover__title"> {{ $t('table.ProcessActivity.zoomIn') }}</div>
         <template v-for="(zoomItem, index) in field.reference.zoomWindowList">
-          <el-button :key="index" type="text" @click="redirect(zoomItem)">{{ zoomItem.name }}</el-button>
+          <el-button :key="index" type="text" @click="redirect({ window: zoomItem, columnName: field.columnName, value: field.value })">{{ zoomItem.name }}</el-button>
         </template>
       </template>
     </el-popover>
@@ -306,10 +306,10 @@ export default {
         this.$refs[columnName].activeFocus(columnName)
       }
     },
-    redirect(item) {
-      this.$store.dispatch('getWindowByUuid', { routes: this.permissionRoutes, windowUuid: item.uuid })
-      var windowRoute = this.$store.getters.getWindowRoute(item.uuid)
-      this.$router.push({ name: windowRoute.name, query: { action: 'create-new', tabParent: 0 }})
+    redirect({ window, columnName, value }) {
+      this.$store.dispatch('getWindowByUuid', { routes: this.permissionRoutes, windowUuid: window.uuid })
+      var windowRoute = this.$store.getters.getWindowRoute(window.uuid)
+      this.$router.push({ name: windowRoute.name, query: { action: 'advancedQuery', tabParent: 0, [columnName]: value }})
     }
   }
 }

--- a/src/components/ADempiere/Panel/index.vue
+++ b/src/components/ADempiere/Panel/index.vue
@@ -416,13 +416,13 @@ export default {
             if (route.query.hasOwnProperty(fieldItem.columnName) && fieldItem.isAdvancedQuery) {
               fieldItem.isShowedFromUser = true
 
-              if (route.query.action === 'advancedQuery' === fieldItem.isAdvancedQuery) {
-                fieldItem.value = parsedValueComponent({
+              if (route.query.action === 'advancedQuery' && fieldItem.isAdvancedQuery) {
+                this.dataRecords[fieldItem.columnName] = parsedValueComponent({
                   fieldType: fieldItem.componentPath,
                   value: route.query[fieldItem.columnName]
                 })
                 if (fieldItem.isRange && route.query[fieldItem.columnName + '_To']) {
-                  fieldItem.valueTo = parsedValueComponent({
+                  this.dataRecords[fieldItem.columnName] = parsedValueComponent({
                     fieldType: fieldItem.componentPath,
                     value: route.query[fieldItem.columnName + '_To']
                   })
@@ -431,6 +431,16 @@ export default {
             }
           })
           parameters.isWindow = false
+          this.$store.dispatch('notifyPanelChange', {
+            parentUuid: this.parentUuid,
+            containerUuid: this.containerUuid,
+            isAdvancedQuery: route.query.action === 'advancedQuery',
+            newValues: this.dataRecords,
+            isSendToServer: false,
+            isSendCallout: false,
+            fieldList: this.fieldList,
+            panelType: this.panelType
+          })
         } else if (this.panelType === 'process' || this.panelType === 'browser') {
           if (!this.isEmptyValue(route.query)) {
             this.$store.dispatch('notifyPanelChange', {

--- a/src/store/modules/ADempiere/panel.js
+++ b/src/store/modules/ADempiere/panel.js
@@ -366,6 +366,8 @@ const panel = {
         dispatch('notifyFieldChange', {
           isSendToServer: isSendToServer,
           isSendCallout: isSendCallout,
+          isAdvancedQuery: isAdvancedQuery,
+          panelType: panelType,
           parentUuid: parentUuid,
           containerUuid: containerUuid,
           columnName: actionField.columnName,
@@ -642,9 +644,9 @@ const panel = {
             type: 'info'
           })
         }
-      } else if (!params.isDontSendToQuery) {
+      } else {
         if (panelType === 'table' || isAdvancedQuery) {
-          if (fieldIsDisplayed(field) && field.isShowedFromUser) {
+          if (field.isShowedFromUser) {
             // change action to advanced query on field value is changed in this panel
             if (router.currentRoute.query.action !== 'advancedQuery') {
               router.push({


### PR DESCRIPTION
#190 Hello, in this PR the two popover of the fields that had previously been joined, the one of context information and the field zoom in.

Example:
![adempiere-vue-popover](https://user-images.githubusercontent.com/23490674/69965374-7ec58c80-14ea-11ea-9be4-47012aa92854.gif)
