### PR TITLE
Change breadcrumb menu options trigger

### DIFF
--- a/src/components/Breadcrumb/index.vue
+++ b/src/components/Breadcrumb/index.vue
@@ -11,12 +11,10 @@
           </a>
         </el-breadcrumb-item>
         <el-breadcrumb-item key="1">
-          <el-dropdown placement="bottom" trigger="click" :hide-on-click="true" class="el-dropdown-link" @command="handleLink">
-            <i class="el-icon-more" />
-            <el-dropdown-menu slot="dropdown">
-              <el-dropdown-item v-for="(item, index) in dropdownList" :key="index" :command="item">{{ generateTitle(item.meta.title) }}</el-dropdown-item>
-            </el-dropdown-menu>
-          </el-dropdown>
+          <el-popover placement="bottom" trigger="hover" class="breadcrumb-popover">
+            <el-dropdown-item v-for="(item, index) in dropdownList" :key="index" :command="item">{{ generateTitle(item.meta.title) }}</el-dropdown-item>
+            <i slot="reference" class="el-icon-more" />
+          </el-popover>
         </el-breadcrumb-item>
         <el-breadcrumb-item key="2">
           <span v-if="lastItem.redirect==='noRedirect'" class="no-redirect">
@@ -107,7 +105,7 @@ export default {
     color: #97a8be;
     cursor: text;
   }
-  .el-dropdown-link {
+  .breadcrumb-popover {
     cursor: pointer;
     .el-icon-more {
       transform: none;


### PR DESCRIPTION
Hello everyone, in this PR the trigger that activates the menu display with the other breadcrumb options is changed when it has more than 3 items to display, this because most of the triggers of the application are activated with the _'hover'_ effect and this was activated by clicking.
Below is an example of the functionality.

With the click trigger
![adempiere-vue-breadcrumb-click](https://user-images.githubusercontent.com/23490674/70064756-6d4eb400-15c0-11ea-8a66-5aafb622d3b0.gif)

With the hover trigger
![adempiere-vue-breadcrumb-hover](https://user-images.githubusercontent.com/23490674/70064769-73449500-15c0-11ea-8402-d3049976f582.gif)
