### PR TITLE
fix: Correction of the date field type range when clearing the value.

### DIFF
--- a/src/components/ADempiere/Field/FieldDate.vue
+++ b/src/components/ADempiere/Field/FieldDate.vue
@@ -19,7 +19,6 @@
 </template>
 
 <script>
-import { clientDateTime } from '@/utils/ADempiere'
 import { fieldMixin } from '@/components/ADempiere/Field/FieldMixin'
 
 export default {
@@ -44,7 +43,7 @@ export default {
           text: this.$t('components.date.Week'),
           onClick(picker) {
             const date = new Date()
-            var monthEndDay = new Date(date.getFullYear(), date.getMonth() + 1, 0)
+            const monthEndDay = new Date(date.getFullYear(), date.getMonth() + 1, 0)
             picker.$emit('pick', monthEndDay)
           }
         }]
@@ -60,14 +59,13 @@ export default {
         }, {
           text: this.$t('components.date.Week'),
           onClick(picker) {
-            var start_date, end_date, date, currenDate, first, last
-            start_date = new Date()
+            const start_date = new Date()
             start_date.setHours(0, 0, 0, 0)
-            end_date = new Date()
-            date = null
-            currenDate = date ? new Date(date) : new Date()
-            first = currenDate.getDate() - currenDate.getDay('monday')
-            last = first - 7
+            const end_date = new Date()
+            const date = null
+            const currenDate = date ? new Date(date) : new Date()
+            const first = currenDate.getDate() - currenDate.getDay('monday')
+            const last = first - 7
             start_date.setDate(last)
             end_date.setDate(first - 1)
             picker.$emit('pick', [start_date, end_date])
@@ -75,17 +73,17 @@ export default {
         }, {
           text: this.$t('components.date.LastMonth'),
           onClick(picker) {
-            var date = new Date()
-            var monthEndDay = new Date(date.getFullYear(), date.getMonth(), 0)
-            var monthStartDay = new Date(date.getFullYear(), date.getMonth() - 1, 1)
+            const date = new Date()
+            const monthEndDay = new Date(date.getFullYear(), date.getMonth(), 0)
+            const monthStartDay = new Date(date.getFullYear(), date.getMonth() - 1, 1)
             picker.$emit('pick', [monthStartDay, monthEndDay])
           }
         }, {
           text: this.$t('components.date.CurrentMonth'),
           onClick(picker) {
-            var date = new Date()
-            var monthEndDay = new Date(date.getFullYear(), date.getMonth() + 1, 0)
-            var monthStartDay = new Date(date.getFullYear(), date.getMonth(), 1)
+            const date = new Date()
+            const monthEndDay = new Date(date.getFullYear(), date.getMonth() + 1, 0)
+            const monthStartDay = new Date(date.getFullYear(), date.getMonth(), 1)
             picker.$emit('pick', [monthStartDay, monthEndDay])
           }
         }]
@@ -143,15 +141,18 @@ export default {
     }
   },
   methods: {
-    clientDateTime,
     parsedDateValue(value) {
+      // not return undefined to v-model
+      if (this.isEmptyValue(value)) {
+        return null
+      }
+
+      // instance date from long value
       if (typeof value === 'number') {
         value = new Date(value).toUTCString()
       }
-      if (this.isEmptyValue(value)) {
-        value = undefined
-      }
 
+      // generate range value
       if (this.metadata.isRange) {
         let valueTo = this.metadata.valueTo
         if (typeof valueTo === 'number') {
@@ -162,26 +163,30 @@ export default {
         }
         value = [value, valueTo]
       }
+
       return value
     },
     // validate values before send values to store or server
     preHandleChange(value) {
-      var valueFirst, valueTo
-      valueFirst = value
+      let startValue, endValue
+      startValue = value
 
-      if ((this.metadata.isRange && !this.metadata.inTable) && Array.isArray(value)) {
-        valueFirst = value[0]
-        valueTo = value[1]
+      if (this.metadata.isRange && !this.metadata.inTable && Array.isArray(value)) {
+        startValue = value[0]
+        endValue = value[1]
       }
-      if (valueFirst === null) {
-        valueFirst = undefined
-        valueTo = undefined
+
+      if (startValue === null) {
+        startValue = undefined
+        endValue = undefined
       }
-      if (typeof valueFirst !== 'object' && valueFirst !== undefined) {
-        valueFirst = new Date(valueFirst)
-        valueTo = new Date(valueTo)
+
+      if (typeof startValue !== 'object' && startValue !== undefined) {
+        startValue = new Date(startValue)
+        endValue = new Date(endValue)
       }
-      this.handleChange(valueFirst, valueTo)
+
+      this.handleChange(startValue, endValue)
     }
   }
 }

--- a/src/components/ADempiere/Field/FieldMixin.js
+++ b/src/components/ADempiere/Field/FieldMixin.js
@@ -47,6 +47,11 @@ export const fieldMixin = {
     preHandleChange(value) {
       this.handleChange(value)
     },
+    /**
+     * @param {mixed} value, main value in component
+     * @param {mixed} valueTo, used in end value in range
+     * @param {string} label, or displayColumn to show in select
+     */
     handleChange(value, valueTo = undefined, label = undefined) {
       const sendParameters = {
         parentUuid: this.metadata.parentUuid,


### PR DESCRIPTION
Clearing the value of a date field of the range type does not clear its value, nor allows it to be changed later, while generating errors in the console.

* Error generated:

![Peek 11-12-2019 16-36](https://user-images.githubusercontent.com/20288327/70659220-053e4480-1c36-11ea-98e9-1bdf061ce973.gif)

* Correct operation:

![Peek 11-12-2019 16-39](https://user-images.githubusercontent.com/20288327/70659056-b7c1d780-1c35-11ea-9a78-a547abac71b0.gif)
