### PR TITLE
fix: Mandatory logic on first field load.

### DIFF
--- a/src/components/ADempiere/Field/FieldText.vue
+++ b/src/components/ADempiere/Field/FieldText.vue
@@ -9,7 +9,7 @@
     :readonly="Boolean(metadata.readonly)"
     :disabled="isDisabled"
     :maxlength="maxLength"
-    :show-password="metadata.isEncrypted ? true : false"
+    :show-password="Boolean(metadata.isEncrypted)"
     @change="preHandleChange"
   />
 </template>

--- a/src/components/ADempiere/Panel/filterFields.vue
+++ b/src/components/ADempiere/Panel/filterFields.vue
@@ -57,13 +57,13 @@ export default {
           })
       } else if (this.panelType === 'window') {
         // compare group fields to window
-        return this.$store.getters.getFieldsListNotMandatory(this.containerUuid)
+        return this.$store.getters.getFieldsListNotMandatory({ containerUuid: this.containerUuid })
           .filter(fieldItem => {
             return fieldItem.groupAssigned === this.groupField
           })
       }
       // get fields not mandatory
-      return this.$store.getters.getFieldsListNotMandatory(this.containerUuid)
+      return this.$store.getters.getFieldsListNotMandatory({ containerUuid: this.containerUuid })
     },
     getFieldSelected() {
       return this.getterFieldListOptional

--- a/src/store/modules/ADempiere/panel.js
+++ b/src/store/modules/ADempiere/panel.js
@@ -529,25 +529,15 @@ const panel = {
         }
       }
 
-      // the field has not changed, then the action is broken
-      if (newValue === field.value && isEmptyValue(displayColumn)) {
-        return
-      }
-
-      commit('changeFieldValue', {
-        field,
-        newValue,
-        valueTo,
-        displayColumn,
-        isChangedOldValue
-      })
-
       //  Change Dependents
-      const dependents = fieldList.filter(fieldItem => {
-        return field.dependentFieldsList.includes(fieldItem.columnName)
-      })
+      let dependentsList = []
+      if (field.dependentFieldsList.length) {
+        dependentsList = fieldList.filter(fieldItem => {
+          return field.dependentFieldsList.includes(fieldItem.columnName)
+        })
+      }
       //  Iterate for change logic
-      dependents.forEach(dependent => {
+      dependentsList.forEach(dependent => {
         //  isDisplayed Logic
         let isDisplayedFromLogic, isMandatoryFromLogic, isReadOnlyFromLogic
         if (dependent.displayLogic.trim() !== '') {
@@ -583,6 +573,19 @@ const panel = {
           isMandatoryFromLogic,
           isReadOnlyFromLogic
         })
+      })
+
+      // the field has not changed, then the action is broken
+      if (newValue === field.value && isEmptyValue(displayColumn)) {
+        return
+      }
+
+      commit('changeFieldValue', {
+        field,
+        newValue,
+        valueTo,
+        displayColumn,
+        isChangedOldValue
       })
 
       // request callouts
@@ -838,9 +841,8 @@ const panel = {
       var fieldList = getters.getFieldsListFromPanel(containerUuid).filter(fieldItem => {
         const isMandatory = fieldItem.isMandatory || fieldItem.isMandatoryFromLogic
         if (isMandatory) {
-          const isDisplayed = fieldIsDisplayed(fieldItem)
           if (evaluateShowed) {
-            return isDisplayed
+            return fieldIsDisplayed(fieldItem)
           }
           return isMandatory
         }
@@ -859,15 +861,18 @@ const panel = {
         return fieldItem.name
       })
     },
-    // all available fields not mandatory to show, used in components panel/filterFields.vue
-    getFieldsListNotMandatory: (state, getters) => (containerUuid, evaluateShowed = true) => {
+    /**
+     * Show all available fields not mandatory to show, used in components panel/filterFields.vue
+     * @param {string} containerUuid
+     * @param {boolean} isEvaluateShowed
+     */
+    getFieldsListNotMandatory: (state, getters) => ({ containerUuid, isEvaluateShowed = true }) => {
       // all optionals (not mandatory) fields
       return getters.getFieldsListFromPanel(containerUuid).filter(fieldItem => {
         const isMandatory = fieldItem.isMandatory || fieldItem.isMandatoryFromLogic
         if (!isMandatory) {
-          const isDisplayed = fieldIsDisplayed(fieldItem)
-          if (evaluateShowed) {
-            return isDisplayed
+          if (isEvaluateShowed) {
+            return fieldIsDisplayed(fieldItem)
           }
           return !isMandatory
         }


### PR DESCRIPTION
When adding a mandatory logic in a field that depends on the value of another, in this example the field Integer has the mandatory logic IsActive="Y", and opening the window for the first time did not enable the required attribute in the field Integer, because the field IsActive by default has the value Y, when making the field of panel values did not run the change of logic as the value remained the same.
![Peek 14-01-2020 17-04](https://user-images.githubusercontent.com/20288327/72383022-e7f70d00-36f0-11ea-8a8c-8a2d3451f3e8.gif)

