### PR TITLE
Add validation to personal lock by role

### DIFF
--- a/src/components/ADempiere/ContextMenu/contextMenuMixin.js
+++ b/src/components/ADempiere/ContextMenu/contextMenuMixin.js
@@ -162,6 +162,9 @@ export const contextMixin = {
     },
     metadataReport() {
       return this.$store.getters.getCachedReport(this.$route.params.instanceUuid)
+    },
+    isPersonalLock() {
+      return this.$store.getters['user/getIsPersonalLock']
     }
   },
   watch: {
@@ -544,16 +547,18 @@ export const contextMixin = {
       })
     },
     validatePrivateAccess(response) {
-      if (response.isLocked) {
-        this.actions.find(item => item.action === 'unlockRecord').hidden = false
-        this.actions.find(item => item.action === 'unlockRecord').tableName = response.tableName
-        this.actions.find(item => item.action === 'unlockRecord').recordId = response.recordId
-        this.actions.find(item => item.action === 'lockRecord').hidden = true
-      } else {
-        this.actions.find(item => item.action === 'lockRecord').hidden = false
-        this.actions.find(item => item.action === 'lockRecord').tableName = response.tableName
-        this.actions.find(item => item.action === 'lockRecord').recordId = response.recordId
-        this.actions.find(item => item.action === 'unlockRecord').hidden = true
+      if (this.isPersonalLock) {
+        if (response.isLocked) {
+          this.actions.find(item => item.action === 'unlockRecord').hidden = false
+          this.actions.find(item => item.action === 'unlockRecord').tableName = response.tableName
+          this.actions.find(item => item.action === 'unlockRecord').recordId = response.recordId
+          this.actions.find(item => item.action === 'lockRecord').hidden = true
+        } else {
+          this.actions.find(item => item.action === 'lockRecord').hidden = false
+          this.actions.find(item => item.action === 'lockRecord').tableName = response.tableName
+          this.actions.find(item => item.action === 'lockRecord').recordId = response.recordId
+          this.actions.find(item => item.action === 'unlockRecord').hidden = true
+        }
       }
     }
   }

--- a/src/store/modules/ADempiere/data.js
+++ b/src/store/modules/ADempiere/data.js
@@ -778,7 +778,7 @@ const data = {
         userUuid
       })
         .then(privateAccessResponse => {
-          if (isEmptyValue(privateAccessResponse.recordId)) {
+          if (isEmptyValue(privateAccessResponse.recordId) || privateAccessResponse !== recordId) {
             return {
               isLocked: false,
               tableName,

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -267,6 +267,9 @@ const getters = {
   },
   getUserUuid: (state) => {
     return state.userUuid
+  },
+  getIsPersonalLock: (state) => {
+    return state.rol.isPersonalLock
   }
 }
 


### PR DESCRIPTION
Hello everyone, in this PR a validation is added so that only the roles that have the 'Personal Access' field active can have access to the option to lock/unlock records.

![Screenshot_20200117_104356](https://user-images.githubusercontent.com/23490674/72620966-b8294e80-3916-11ea-992f-6241e89b8b66.png)
