### PR TITLE
fix: Context menu icons are lost when the main menu is hidden.

### DIFF
--- a/src/components/ADempiere/ContextMenu/index.vue
+++ b/src/components/ADempiere/ContextMenu/index.vue
@@ -57,7 +57,7 @@ export default {
       return this.$store.state.app.device === 'mobile'
     },
     templateDevice() {
-      var template = 'contextMenuDesktop'
+      let template = 'contextMenuDesktop'
       if (this.isMobile) {
         template = 'contextMenuMobile'
       }
@@ -67,7 +67,7 @@ export default {
 }
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
   .el-submenu .el-menu-item {
     height: 50px;
     line-height: 50px;
@@ -79,7 +79,12 @@ export default {
     text-overflow: ellipsis;
   }
 </style>
-<style>
+<style lang="scss">
+  // this forces to show the arrow icon when the main menu is hidden
+  #app .hideSidebar .el-submenu > .el-submenu__title .el-submenu__icon-arrow {
+    display: initial;
+  }
+
   .Run-Report {
     position: absolute;
     right: 102%;

--- a/src/components/ADempiere/ContextMenu/items.vue
+++ b/src/components/ADempiere/ContextMenu/items.vue
@@ -5,11 +5,13 @@
     :index="item.meta.uuid"
     @click="handleClick(item)"
   >
-    <svg-icon v-if="isMobile" :icon-class="classIconMenuRight" /> {{ item.meta.title }}
+    <svg-icon v-if="isMobile" :icon-class="classIconMenuRight" />
+    {{ item.meta.title }}
   </el-menu-item>
   <el-submenu v-else :index="item.meta.title" popper-append-to-body>
     <template slot="title">
-      <svg-icon v-if="isMobile" icon-class="nested" /> {{ item.meta.title }}
+      <svg-icon v-if="isMobile" icon-class="nested" />
+      {{ item.meta.title }}
     </template>
     <item v-for="(child, key) in item.children" :key="key" :item="child">
       {{ child.meta.title }}
@@ -33,17 +35,20 @@ export default {
       return this.$store.state.app.device === 'mobile'
     },
     classIconMenuRight(iconMenu) {
-      var typeMenu = this.item.meta.type
-      iconMenu = icon.find(function(element) {
-        return element.type === typeMenu
+      iconMenu = icon.find(element => {
+        return element.type === this.item.meta.type
       })
       return iconMenu.icon
     }
   },
   methods: {
     handleClick(item) {
-      console.log(item)
-      this.$router.push({ name: item.name, query: { tabParent: 0 }})
+      this.$router.push({
+        name: item.name,
+        query: {
+          tabParent: 0
+        }
+      })
     }
   }
 }


### PR DESCRIPTION
The context menu arrow icons are displayed correctly when the main menu is displayed, but when the main menu is hidden, these context menu (arrow) icons are lost.

The following gif image shows the unwanted behavior:
![Peek 20-01-2020 10-00](https://user-images.githubusercontent.com/20288327/72732324-d20f9f00-3b6b-11ea-9959-2539fcde076a.gif)

Here you can see the corrected behaviour:
![Peek 20-01-2020 09-51](https://user-images.githubusercontent.com/20288327/72732106-6cbbae00-3b6b-11ea-8cce-4674994ec657.gif)
