### PR TITLE
Solve empty menu in relationships

### DIFF
--- a/src/components/ADempiere/ContextMenu/contextMenuMixin.js
+++ b/src/components/ADempiere/ContextMenu/contextMenuMixin.js
@@ -74,8 +74,13 @@ export const contextMixin = {
     relations() {
       if (this.$route.params.menuParentUuid !== undefined) {
         return this.$store.getters.getRelations(this.$route.params.menuParentUuid)
+      } else {
+        return this.$store.getters.getRelations(this.menuParentUuid).filter(relations => {
+          if (!relations.hidden) {
+            return relations
+          }
+        })
       }
-      return this.$store.getters.getRelations(this.menuParentUuid)
     },
     getterContextMenu() {
       return this.$store.getters.getContextMenu(this.containerUuid)

--- a/src/components/ADempiere/DataTable/menu/mixinMenu.js
+++ b/src/components/ADempiere/DataTable/menu/mixinMenu.js
@@ -57,6 +57,7 @@ export const menuTableMixin = {
   },
   computed: {
     isProcessTable() {
+      console.log(this.$route)
       if (this.isProcessMenu) {
         return true
       }
@@ -215,13 +216,6 @@ export const menuTableMixin = {
       }
     },
     tableProcess(process) {
-      // if (!this.isOption) {
-      //   if (this.getDataSelection.length <= 1) {
-      //     this.showModal(process)
-      //   }
-      // } else {
-      //   this.showModal(process)
-      // }
       this.showModal(process)
     },
     showTotals() {
@@ -313,7 +307,7 @@ export const menuTableMixin = {
       exportFileZip({
         header: Header,
         data,
-        filename: '',
+        title: this.$route.meta.title,
         exportType: 'zip'
       })
     },

--- a/src/views/dashboard/admin/index.vue
+++ b/src/views/dashboard/admin/index.vue
@@ -2,7 +2,7 @@
   <div class="dashboard-editor-container">
     <el-row :gutter="8">
       <template v-for="(dashboardAttributes, index) in dashboardList">
-        <el-col :key="index" :xs="{ span: 24 }" :sm="{ span: 24 }" :md="{ span: 24 }" :lg="{ span: 12 }" :xl="{ span: 12 }" style="padding-right:8px;margin-bottom:30px;">
+        <el-col :key="index" :xs="{ span: 24 }" :sm="{ span: 24 }" :md="{ span: 24 }" :lg="{ span: 12 }" :xl="{ span: 12 }" style="padding-right:8px;margin-bottom:2px;">
           <dashboard :metadata="dashboardAttributes" />
         </el-col>
       </template>


### PR DESCRIPTION
- Hi!. The context menu error of displaying empty folders in the reference options was solved
- The default name of the window was also added when exporting in Zip
- **ADempiere-Vue**
![Peek 2020-01-20 16-25](https://user-images.githubusercontent.com/45974454/72757353-19b31c80-3ba6-11ea-9629-0ed89cb7eebd.gif)
