### PR TITLE
bugfix load data when references zoom in

### DIFF
--- a/src/components/ADempiere/Panel/index.vue
+++ b/src/components/ADempiere/Panel/index.vue
@@ -395,6 +395,7 @@ export default {
 
         if (route.query.action && route.query.action === 'reference') {
           const referenceInfo = this.$store.getters.getReferencesInfo(route.query.windowUuid, route.query.recordUuid, route.query.referenceUuid)
+          route.params.isReadParameters = true
           parameters.isLoadAllRecords = false
           parameters.isReference = true
           parameters.referenceUuid = referenceInfo.uuid


### PR DESCRIPTION
#237 Hello everyone, in this PR the error of loading references is resolved when they are approached from the context menu.

behavioral example:
![bugfix-references-data](https://user-images.githubusercontent.com/23490674/72814820-14a0ac80-3c3c-11ea-8a55-247fa272641b.gif)
