### PR TITLE
bugfix max page size for pagination

### DIFF
--- a/src/components/ADempiere/DataTable/index.vue
+++ b/src/components/ADempiere/DataTable/index.vue
@@ -330,7 +330,7 @@ export default {
       currentTable: 0,
       visible: this.getShowContextMenuTable,
       searchTable: '', // text from search
-      defaultMaxPagination: 100,
+      defaultMaxPagination: 50,
       option: supportedTypes,
       menuTable: '1',
       activeName: this.$route.query.action === 'advancedQuery' ? '1' : '',


### PR DESCRIPTION
#239 Hello everyone, in this PR the maximum number of items to be displayed on the pagination corresponding to the table of records of the windows is changed.

behavioral example:
![pagination-fixed](https://user-images.githubusercontent.com/23490674/72819900-6e0cd980-3c44-11ea-86d3-e318af1f19e5.gif)

**Note:** This change was made manually in the application code, however, it is considered that the maximum number of records to be displayed per page should be added dynamically, so in the future it changes again the code would not be modified.