### PR TITLE
fix: Read only to field type Text Long.

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "screenfull": "4.2.0",
     "showdown": "1.9.0",
     "sortablejs": "1.10.1",
-    "tui-editor": "1.3.3",
+    "tui-editor": "1.4.10",
     "vue": "2.6.10",
     "vue-count-to": "1.0.13",
     "vue-i18n": "7.3.2",


### PR DESCRIPTION
Fix of the issue https://github.com/adempiere/adempiere-vue/issues/246 in relation to the only reading of the long text type fields, it does not allow its edition however it does not appear disabled.

![Peek 22-01-2020 19-13](https://user-images.githubusercontent.com/20288327/72943151-a9460000-3d4b-11ea-95b0-cff5fb85e1e1.gif)
