### PR TITLE
support dashboards associated to the selected role

### DIFF
--- a/src/views/dashboard/admin/index.vue
+++ b/src/views/dashboard/admin/index.vue
@@ -28,6 +28,14 @@ export default {
   computed: {
     getterDashboard() {
       return this.$store.getters.getDashboardByRole(this.roleUuid)
+    },
+    getterRol() {
+      return this.$store.getters.getRoleUuid
+    }
+  },
+  watch: {
+    getterRol(value) {
+      this.getDashboardListFromServer()
     }
   },
   mounted() {
@@ -35,14 +43,11 @@ export default {
   },
   methods: {
     getDashboardListFromServer() {
-      if (this.getterDashboard) {
-        this.dashboardList = this.getterDashboard.dashboardList
-      } else {
-        this.$store.dispatch('listDashboard', this.roleUuid)
-          .then(response => {
-            this.dashboardList = response.dashboardsList
-          })
-      }
+      this.$store.dispatch('listDashboard')
+        .then(response => {
+          this.dashboardList = response.dashboardsList
+          this.$forceUpdate()
+        })
     }
   }
 }

--- a/src/views/profile/components/RolesNavbar.vue
+++ b/src/views/profile/components/RolesNavbar.vue
@@ -62,6 +62,7 @@ export default {
       })
       this.$store.dispatch('user/changeRoles', valueSelected)
         .then(response => {
+          this.$store.dispatch('listDashboard', response.uuid)
           this.showMessage({
             message: this.$t('notifications.successChangeRole'),
             type: 'success'


### PR DESCRIPTION
Hello! The dashboards were supported. The corresponding dahsboard is brought to the role
#279 
- _**ADempiere-Vue**_
![vue1](https://user-images.githubusercontent.com/45974454/73306954-a8054f00-41f3-11ea-8c53-248ed938ebd3.gif)
