### PR TITLE
feat: Add operators comparison to advanced search.

### DIFF
--- a/src/api/ADempiere/data.js
+++ b/src/api/ADempiere/data.js
@@ -76,7 +76,7 @@ export function getEntity({ tableName, recordId, recordUuid }) {
  * @param {string} tableName
  * @param {string} query
  * @param {string} whereClause
- * @param {array}  conditions
+ * @param {array}  conditionsList
  * @param {string} orderByClause
  * @param {string} nextPageToken
  */
@@ -84,7 +84,7 @@ export function getEntitiesList({
   tableName,
   query,
   whereClause,
-  conditions: conditionsList = [],
+  conditionsList = [],
   orderByClause,
   nextPageToken: pageToken,
   pageSize
@@ -98,6 +98,27 @@ export function getEntitiesList({
     pageToken,
     pageSize
   })
+}
+
+/**
+ * Get all operator or get key value type from value
+ * @param {number} keyToFind
+		EQUAL = 0;
+		NOT_EQUAL = 1;
+		LIKE = 2;
+		NOT_LIKE = 3;
+		GREATER = 4;
+		GREATER_EQUAL = 5;
+		LESS = 6;
+		LESS_EQUAL = 7;
+		BETWEEN = 8;
+		NOT_NULL = 9;
+		NULL = 10;
+		IN = 11;
+		NOT_IN = 12;
+ */
+export function getConditionOperators(keyToFind) {
+  return Instance.call(this).getConditionOperators(keyToFind)
 }
 
 /**

--- a/src/components/ADempiere/Field/FieldSelect.vue
+++ b/src/components/ADempiere/Field/FieldSelect.vue
@@ -6,8 +6,10 @@
     :placeholder="metadata.help"
     :loading="isLoading"
     value-key="key"
-    class="select-base"
+    :class="classStyle"
     clearable
+    :multiple="isSelectMultiple"
+    :collapse-tags="!isSelectMultiple"
     :disabled="isDisabled"
     @change="preHandleChange"
     @visible-change="getDataLookupList"
@@ -60,6 +62,16 @@ export default {
     isMobile() {
       return this.$store.state.app.device === 'mobile'
     },
+    isSelectMultiple() {
+      return ['IN', 'NOT_IN'].includes(this.metadata.operator) && this.metadata.isAdvancedQuery
+    },
+    classStyle() {
+      let styleClass = 'custom-field-select'
+      if (this.isSelectMultiple) {
+        styleClass += ' custom-field-select-multiple'
+      }
+      return styleClass
+    },
     getterLookupItem() {
       if (this.isEmptyValue(this.metadata.reference.directQuery)) {
         return this.blanckOption
@@ -99,6 +111,17 @@ export default {
     }
   },
   watch: {
+    isSelectMultiple(isMultiple) {
+      if (isMultiple) {
+        let valueInArray = []
+        if (!this.isEmptyValue(this.value)) {
+          valueInArray = [
+            this.value
+          ]
+        }
+        this.value = valueInArray
+      }
+    },
     valueModel(value) {
       if (this.metadata.inTable) {
         this.value = value
@@ -159,7 +182,8 @@ export default {
       return selected
     },
     async getDataLookupItem() {
-      if (this.isEmptyValue(this.metadata.reference.directQuery)) {
+      if (this.isEmptyValue(this.metadata.reference.directQuery) ||
+        (this.metadata.isAdvancedQuery && this.isSelectMultiple)) {
         return
       }
       this.isLoading = true
@@ -235,7 +259,16 @@ export default {
 </script>
 
 <style scoped>
-  .select-base {
+  .custom-field-select {
     width: 100%;
+  }
+</style>
+<style lang="scss">
+  .custom-field-select-multiple {
+    overflow: auto;
+    max-height: 100px;
+    .el-select__tags {
+      max-height: 100px;
+    }
   }
 </style>

--- a/src/components/ADempiere/Field/FieldSelect.vue
+++ b/src/components/ADempiere/Field/FieldSelect.vue
@@ -9,6 +9,7 @@
     :class="classStyle"
     clearable
     :multiple="isSelectMultiple"
+    :allow-create="metadata.isSelectCreated"
     :collapse-tags="!isSelectMultiple"
     :disabled="isDisabled"
     @change="preHandleChange"
@@ -113,13 +114,19 @@ export default {
   watch: {
     isSelectMultiple(isMultiple) {
       if (isMultiple) {
-        let valueInArray = []
+        const valueInArray = []
         if (!this.isEmptyValue(this.value)) {
-          valueInArray = [
-            this.value
-          ]
+          valueInArray.push(this.value)
         }
         this.value = valueInArray
+      } else {
+        if (Array.isArray(this.value)) {
+          if (this.value.length) {
+            this.value = this.value[0]
+          } else {
+            this.value = undefined
+          }
+        }
       }
     },
     valueModel(value) {
@@ -258,12 +265,11 @@ export default {
 }
 </script>
 
-<style scoped>
+<style lang="scss">
   .custom-field-select {
     width: 100%;
   }
-</style>
-<style lang="scss">
+
   .custom-field-select-multiple {
     overflow: auto;
     max-height: 100px;

--- a/src/components/ADempiere/Field/FieldSelectMultiple.vue
+++ b/src/components/ADempiere/Field/FieldSelectMultiple.vue
@@ -1,0 +1,34 @@
+<template>
+  <el-select
+    v-model="value"
+    multiple
+    filterable
+    allow-create
+    :placeholder="metadata.help"
+    class="custom-field-select custom-field-select-multiple"
+    @change="preHandleChange"
+  >
+    <el-option
+      v-for="(option, key) in value"
+      :key="key"
+      :value="option"
+    />
+  </el-select>
+</template>
+
+<script>
+import { fieldMixin } from '@/components/ADempiere/Field/FieldMixin'
+
+/**
+ * This component is a list type field, for IN and NOT IN search with advanced query
+ */
+export default {
+  name: 'FieldSelectMultiple',
+  mixins: [fieldMixin],
+  methods: {
+    preHandleChange(value) {
+      this.handleChange(value)
+    }
+  }
+}
+</script>

--- a/src/components/ADempiere/Field/fieldOperatorComparison.vue
+++ b/src/components/ADempiere/Field/fieldOperatorComparison.vue
@@ -54,7 +54,8 @@ export default {
   watch: {
     'fieldAttributes.operator'(newValue) {
       this.value = newValue
-      if (!this.isEmptyValue(this.fieldAttributes.value)) {
+      if (!this.isEmptyValue(this.fieldAttributes.value) ||
+        ['NULL', 'NOT_NULL'].includes(this.fieldAttributes.operator)) {
         this.handleChange(this.fieldAttributes.value)
       }
     }

--- a/src/components/ADempiere/Field/fieldOperatorComparison.vue
+++ b/src/components/ADempiere/Field/fieldOperatorComparison.vue
@@ -1,0 +1,97 @@
+<template>
+  <span>
+    <el-popover
+      ref="operatorComarison"
+      placement="top"
+      width="200"
+      trigger="click"
+    >
+      <span class="custom-tittle-popover">
+        {{ $t('operators.operator') }}:
+      </span>
+      <el-select
+        v-model="value"
+        @change="changeOperator"
+      >
+        <el-option
+          v-for="(item, key) in operatorsList"
+          :key="key"
+          :value="item"
+          :label="$t('operators.' + item)"
+        />
+      </el-select>
+    </el-popover>
+    <span v-popover:operatorComarison>
+      {{ fieldAttributes.name }}
+    </span>
+  </span>
+</template>
+
+<script>
+import { FIELD_OPERATORS_LIST } from '@/utils/ADempiere/dataUtils'
+
+export default {
+  name: 'FieldOperatorComparison',
+  props: {
+    fieldAttributes: {
+      type: Object,
+      required: true
+    }
+  },
+  data() {
+    return {
+      value: this.fieldAttributes.operator
+    }
+  },
+  computed: {
+    operatorsList() {
+      const { conditionsList } = FIELD_OPERATORS_LIST.find(item => {
+        return item.type === this.fieldAttributes.componentPath
+      })
+      return conditionsList
+    }
+  },
+  watch: {
+    'fieldAttributes.operator'(newValue) {
+      this.value = newValue
+      if (!this.isEmptyValue(this.fieldAttributes.value)) {
+        this.handleChange(this.fieldAttributes.value)
+      }
+    }
+  },
+  methods: {
+    changeOperator(value) {
+      this.$store.dispatch('changeFieldAttribure', {
+        containerUuid: this.fieldAttributes.containerUuid,
+        columnName: this.fieldAttributes.columnName,
+        isAdvancedQuery: true,
+        attributeName: 'operator',
+        attributeValue: value
+      })
+    },
+    /**
+     * @param {mixed} value, main value in component
+     * @param {mixed} valueTo, used in end value in range
+     * @param {string} label, or displayColumn to show in select
+     */
+    handleChange(value) {
+      const sendParameters = {
+        parentUuid: this.fieldAttributes.parentUuid,
+        containerUuid: this.fieldAttributes.containerUuid,
+        field: this.fieldAttributes,
+        panelType: this.fieldAttributes.panelType,
+        columnName: this.fieldAttributes.columnName,
+        newValue: value === 'NotSend' ? this.value : value,
+        isAdvancedQuery: this.fieldAttributes.isAdvancedQuery,
+        isSendToServer: !(value === 'NotSend' || this.fieldAttributes.isAdvancedQuery),
+        isSendCallout: !(value === 'NotSend' || this.fieldAttributes.isAdvancedQuery)
+      }
+
+      this.$store.dispatch('notifyFieldChange', {
+        ...sendParameters,
+        isChangedOldValue: this.fieldAttributes.componentPath === 'FieldYesNo' && Boolean(value === 'NotSend')
+      })
+    }
+  }
+}
+</script>

--- a/src/components/ADempiere/Field/fieldTranslated.vue
+++ b/src/components/ADempiere/Field/fieldTranslated.vue
@@ -9,10 +9,10 @@
     >
       <div>
         <span class="custom-tittle-popover">
-          {{ name }}
+          {{ fieldAttributes.name }}
         </span>
-        <template v-if="!isEmptyValue(help)">
-          : {{ help }}
+        <template v-if="!isEmptyValue(fieldAttributes.help)">
+          : {{ fieldAttributes.help }}
         </template>
       </div>
       <el-form-item
@@ -66,29 +66,13 @@ import { getLanguage } from '@/lang/index'
 export default {
   name: 'FieldTranslated',
   props: {
-    containerUuid: {
-      type: String,
+    fieldAttributes: {
+      type: Object,
       required: true
-    },
-    columnName: {
-      type: String,
-      required: true
-    },
-    name: {
-      type: String,
-      default: undefined
-    },
-    help: {
-      type: String,
-      default: undefined
     },
     recordUuid: {
       type: String,
       default: undefined
-    },
-    tableName: {
-      type: String,
-      required: true
     }
   },
   data() {
@@ -112,7 +96,7 @@ export default {
     },
     getterTranslationValues() {
       const values = this.$store.getters.getTranslationByLanguage({
-        containerUuid: this.containerUuid,
+        containerUuid: this.fieldAttributes.containerUuid,
         language: this.langValue,
         recordUuid: this.recordUuid
       })
@@ -126,7 +110,7 @@ export default {
       if (this.isEmptyValue(values)) {
         return undefined
       }
-      return values[this.columnName]
+      return values[this.fieldAttributes.columnName]
     }
   },
   watch: {
@@ -154,9 +138,9 @@ export default {
     getTranslationsFromServer() {
       this.isLoading = true
       this.$store.dispatch('getTranslationsFromServer', {
-        containerUuid: this.containerUuid,
+        containerUuid: this.fieldAttributes.containerUuid,
         recordUuid: this.recordUuid,
-        tableName: this.tableName,
+        tableName: this.fieldAttributes.tableName,
         language: this.langValue
       })
         .finally(() => {
@@ -165,9 +149,9 @@ export default {
     },
     changeTranslationValue(value) {
       this.$store.dispatch('changeTranslationValue', {
-        containerUuid: this.containerUuid,
+        containerUuid: this.fieldAttributes.containerUuid,
         language: this.langValue,
-        columnName: this.columnName,
+        columnName: this.fieldAttributes.columnName,
         value
       })
     }

--- a/src/components/ADempiere/Field/index.vue
+++ b/src/components/ADempiere/Field/index.vue
@@ -18,22 +18,24 @@
       :required="isMandatory()"
     >
       <template slot="label">
-        <field-context-info
-          v-if="(field.contextInfo && field.contextInfo.isActive) || field.reference.zoomWindowList.length"
+        <field-operator-comparison
+          v-if="isAdvancedQuery && isDisplayed()"
           :field-attributes="fieldAttributes"
           :field-value="field.value"
         />
-        <template v-else>
+        <field-context-info
+          v-else-if="(field.contextInfo && field.contextInfo.isActive) || field.reference.zoomWindowList.length"
+          :field-attributes="fieldAttributes"
+          :field-value="field.value"
+        />
+        <span v-else>
           {{ isFieldOnly() }}
-        </template>
+        </span>
+
         <field-translated
           v-if="field.isTranslated && !isAdvancedQuery"
-          :name="field.name"
-          :help="field.help"
-          :container-uuid="containerUuid"
-          :column-name="field.columnName"
+          :field-attributes="fieldAttributes"
           :record-uuid="field.optionCRUD"
-          :table-name="field.tableName"
         />
       </template>
       <component
@@ -57,6 +59,7 @@
 <script>
 import FieldContextInfo from '@/components/ADempiere/Field/fieldContextInfo'
 import FieldTranslated from '@/components/ADempiere/Field/fieldTranslated'
+import FieldOperatorComparison from '@/components/ADempiere/Field/fieldOperatorComparison'
 import { FIELD_ONLY } from '@/components/ADempiere/Field/references'
 import { DEFAULT_SIZE } from '@/components/ADempiere/Field/fieldSize'
 import { fieldIsDisplayed } from '@/utils/ADempiere'
@@ -71,7 +74,8 @@ export default {
   name: 'Field',
   components: {
     FieldContextInfo,
-    FieldTranslated
+    FieldTranslated,
+    FieldOperatorComparison
   },
   props: {
     parentUuid: {

--- a/src/components/ADempiere/Field/index.vue
+++ b/src/components/ADempiere/Field/index.vue
@@ -6,7 +6,7 @@
   <el-col
     v-if="!inTable"
     v-show="isDisplayed()"
-    key="panel-template"
+    key="is-panel-template"
     :xs="sizeFieldResponsive.xs"
     :sm="sizeFieldResponsive.sm"
     :md="sizeFieldResponsive.md"
@@ -49,7 +49,7 @@
   <component
     :is="componentRender"
     v-else
-    key="table-template"
+    key="is-table-template"
     :class="classField"
     :metadata="fieldAttributes"
     :value-model="recordDataFields"
@@ -124,6 +124,9 @@ export default {
   computed: {
     // load the component that is indicated in the attributes of received property
     componentRender() {
+      if (this.isSelectCreated) {
+        return () => import(`@/components/ADempiere/Field/FieldSelectMultiple`)
+      }
       return () => import(`@/components/ADempiere/Field/${this.field.componentPath}`)
     },
     fieldAttributes() {
@@ -136,8 +139,14 @@ export default {
         required: this.isMandatory(),
         readonly: this.isReadOnly(),
         displayed: this.isDisplayed(),
-        disabled: !this.field.isActive
+        disabled: !this.field.isActive,
+        isSelectCreated: this.isSelectCreated
       }
+    },
+    isSelectCreated() {
+      return this.field.isAdvancedQuery &&
+        !['FieldYesNo', 'FieldSelect', 'FieldBinary'].includes(this.field.componentPath) &&
+        ['IN', 'NOT_IN'].includes(this.field.operator)
     },
     getWidth() {
       return this.$store.getters.getWidthLayout

--- a/src/components/ADempiere/Field/index.vue
+++ b/src/components/ADempiere/Field/index.vue
@@ -146,7 +146,7 @@ export default {
       }
     },
     isSelectCreated() {
-      return this.field.isAdvancedQuery &&
+      return this.isAdvancedQuery &&
         !['FieldBinary', 'FieldDate', 'FieldSelect', 'FieldYesNo'].includes(this.field.componentPath) &&
         ['IN', 'NOT_IN'].includes(this.field.operator)
     },

--- a/src/components/ADempiere/Field/index.vue
+++ b/src/components/ADempiere/Field/index.vue
@@ -20,15 +20,17 @@
       <template slot="label">
         <field-operator-comparison
           v-if="isAdvancedQuery && isDisplayed()"
+          key="is-field-operator-comparison"
           :field-attributes="fieldAttributes"
           :field-value="field.value"
         />
         <field-context-info
           v-else-if="(field.contextInfo && field.contextInfo.isActive) || field.reference.zoomWindowList.length"
+          key="is-field-context-info"
           :field-attributes="fieldAttributes"
           :field-value="field.value"
         />
-        <span v-else>
+        <span v-else key="is-field-name">
           {{ isFieldOnly() }}
         </span>
 
@@ -145,7 +147,7 @@ export default {
     },
     isSelectCreated() {
       return this.field.isAdvancedQuery &&
-        !['FieldYesNo', 'FieldSelect', 'FieldBinary'].includes(this.field.componentPath) &&
+        !['FieldBinary', 'FieldDate', 'FieldSelect', 'FieldYesNo'].includes(this.field.componentPath) &&
         ['IN', 'NOT_IN'].includes(this.field.operator)
     },
     getWidth() {

--- a/src/lang/ADempiere/en.js
+++ b/src/lang/ADempiere/en.js
@@ -273,7 +273,7 @@ export default {
       notes: 'Notes',
       changeLog: 'Change Log',
       workflowLog: 'Workflow Log',
-      changeDetail: 'Detalle del cambio',
+      changeDetail: 'Change detail',
       logWorkflow: {
         message: 'Message',
         responsible: 'Responsible',
@@ -303,16 +303,16 @@ export default {
     operator: 'Comparison operator',
     EQUAL: 'Equal to "="',
     NOT_EQUAL: 'Not equal to "<>"',
-    LIKE: 'Like',
-    NOT_LIKE: 'Not like',
+    LIKE: 'Like "~"',
+    NOT_LIKE: 'Not like "!~"',
     GREATER: 'Greater than ">"',
     GREATER_EQUAL: 'Greater than equal to ">="',
     LESS: 'Less than "<"',
     LESS_EQUAL: 'Less than equal to "<="',
-    BETWEEN: 'Between',
+    BETWEEN: 'Between ">-<"',
     NOT_NULL: 'Is not null',
     NULL: 'Is null',
-    IN: 'In',
-    NOT_IN: 'Not in'
+    IN: 'Include',
+    NOT_IN: 'Not include'
   }
 }

--- a/src/lang/ADempiere/en.js
+++ b/src/lang/ADempiere/en.js
@@ -312,7 +312,7 @@ export default {
     BETWEEN: 'Between',
     NOT_NULL: 'Is not null',
     NULL: 'Is null',
-    IN: 'In list',
-    NOT_IN: 'Not in list'
+    IN: 'In',
+    NOT_IN: 'Not in'
   }
 }

--- a/src/lang/ADempiere/en.js
+++ b/src/lang/ADempiere/en.js
@@ -298,5 +298,21 @@ export default {
   sequence: {
     available: 'Available',
     sequence: 'Sequence'
+  },
+  operators: {
+    operator: 'Comparison operator',
+    EQUAL: 'Equal to "="',
+    NOT_EQUAL: 'Not equal to "<>"',
+    LIKE: 'Like',
+    NOT_LIKE: 'Not like',
+    GREATER: 'Greater than ">"',
+    GREATER_EQUAL: 'Greater than equal to ">="',
+    LESS: 'Less than "<"',
+    LESS_EQUAL: 'Less than equal to "<="',
+    BETWEEN: 'Between',
+    NOT_NULL: 'Is not null',
+    NULL: 'Is null',
+    IN: 'In list',
+    NOT_IN: 'Not in list'
   }
 }

--- a/src/lang/ADempiere/es.js
+++ b/src/lang/ADempiere/es.js
@@ -287,7 +287,7 @@ export default {
     BETWEEN: 'Entre ">-<',
     NOT_NULL: 'Diferente de nulo',
     NULL: 'Es nulo',
-    IN: 'En la lista',
-    NOT_IN: 'Diferente de la lista'
+    IN: 'En',
+    NOT_IN: 'Diferente de en'
   }
 }

--- a/src/lang/ADempiere/es.js
+++ b/src/lang/ADempiere/es.js
@@ -276,18 +276,18 @@ export default {
   },
   operators: {
     operator: 'Operador de comparación',
-    EQUAL: 'Igual que "="',
-    NOT_EQUAL: 'Diferente que "<>"',
-    LIKE: 'Como "~"',
-    NOT_LIKE: 'Diferente de como "!~"',
+    EQUAL: 'Igual a "="',
+    NOT_EQUAL: 'Diferente a "<>"',
+    LIKE: 'Contiene "~"',
+    NOT_LIKE: 'No contiene "!~"',
     GREATER: 'Mayor que ">"',
     GREATER_EQUAL: 'Mayor o igual que ">="',
     LESS: 'Menor que "<"',
     LESS_EQUAL: 'Menor o igual que "<="',
-    BETWEEN: 'Entre ">-<',
-    NOT_NULL: 'Diferente de nulo',
-    NULL: 'Es nulo',
-    IN: 'En',
-    NOT_IN: 'Diferente de en'
+    BETWEEN: 'Entre ">-<"',
+    NULL: 'No tiene valor',
+    NOT_NULL: 'Tiene un valor',
+    IN: 'Incluye',
+    NOT_IN: 'No incluye'
   }
 }

--- a/src/lang/ADempiere/es.js
+++ b/src/lang/ADempiere/es.js
@@ -273,5 +273,21 @@ export default {
   sequence: {
     available: 'Disponibles',
     sequence: 'Secuencia'
+  },
+  operators: {
+    operator: 'Operador de comparación',
+    EQUAL: 'Igual que "="',
+    NOT_EQUAL: 'Diferente que "<>"',
+    LIKE: 'Como "~"',
+    NOT_LIKE: 'Diferente de como "!~"',
+    GREATER: 'Mayor que ">"',
+    GREATER_EQUAL: 'Mayor o igual que ">="',
+    LESS: 'Menor que "<"',
+    LESS_EQUAL: 'Menor o igual que "<="',
+    BETWEEN: 'Entre ">-<',
+    NOT_NULL: 'Diferente de nulo',
+    NULL: 'Es nulo',
+    IN: 'En la lista',
+    NOT_IN: 'Diferente de la lista'
   }
 }

--- a/src/store/modules/ADempiere/data.js
+++ b/src/store/modules/ADempiere/data.js
@@ -450,12 +450,12 @@ const data = {
      * @param {string} query, criteria to search record data
      * @param {string} whereClause, criteria to search record data
      * @param {string} orderByClause, criteria to search record data
-     * @param {array}  conditions, conditions to criteria
+     * @param {array}  conditionsList, conditions list to criteria
      */
     getObjectListFromCriteria({ commit, dispatch, getters, rootGetters }, parameters) {
       const {
         parentUuid, containerUuid,
-        tableName, query, whereClause, orderByClause, conditions = [],
+        tableName, query, whereClause, orderByClause, conditionsList = [],
         isShowNotification = true, isParentTab = true, isAddRecord = false
       } = parameters
       if (isShowNotification) {
@@ -483,7 +483,7 @@ const data = {
       commit('addInGetting', {
         containerUuid,
         tableName,
-        conditions
+        conditionsList
       })
 
       // gets the default value of the fields (including whether it is empty or undefined)
@@ -496,7 +496,7 @@ const data = {
         tableName,
         query,
         whereClause,
-        conditions,
+        conditionsList,
         orderByClause,
         nextPageToken
       })

--- a/src/store/modules/ADempiere/panel.js
+++ b/src/store/modules/ADempiere/panel.js
@@ -137,17 +137,18 @@ const panel = {
       groupField
     }) {
       const panel = getters.getPanel(containerUuid, isAdvancedQuery)
-      var newPanel = panel
-      var showsFieldsWithValue = false
-      var hiddenFieldsWithValue = false
-      var newFields = panel.fieldList.map(itemField => {
+      const newPanel = panel
+      let showsFieldsWithValue = false
+      let hiddenFieldsWithValue = false
+      newPanel.fieldList = panel.fieldList.map(itemField => {
         const isMandatory = itemField.isMandatory || itemField.isMandatoryFromLogic
         if (!isMandatory && fieldIsDisplayed(itemField)) {
           if (itemField.groupAssigned === groupField) {
             if (fieldsUser.length && fieldsUser.includes(itemField.columnName)) {
               // if it isShowedFromUser it is false, and it has some value, it means
               // that it is going to show, therefore the SmartBrowser must be searched
-              if (!isEmptyValue(itemField.value) && !itemField.isShowedFromUser) {
+              if ((!isEmptyValue(itemField.value) && !itemField.isShowedFromUser) ||
+                (isAdvancedQuery && ['NULL', 'NOT_NULL'].includes(itemField.operator))) {
                 showsFieldsWithValue = true
               }
               if (isAdvancedQuery) {
@@ -158,7 +159,8 @@ const panel = {
             }
             // if it isShowedFromUser it is true, and it has some value, it means
             // that it is going to hidden, therefore the SmartBrowser must be searched
-            if (!isEmptyValue(itemField.value) && itemField.isShowedFromUser) {
+            if ((!isEmptyValue(itemField.value) && itemField.isShowedFromUser) ||
+              (isAdvancedQuery && ['NULL', 'NOT_NULL'].includes(itemField.operator))) {
               hiddenFieldsWithValue = true
             }
             if (isAdvancedQuery) {
@@ -171,7 +173,8 @@ const panel = {
             if (fieldsUser.length && fieldsUser.includes(itemField.columnName)) {
               // if it isShowedFromUser it is false, and it has some value, it means
               // that it is going to show, therefore the SmartBrowser must be searched
-              if (!isEmptyValue(itemField.value) && !itemField.isShowedFromUser) {
+              if ((!isEmptyValue(itemField.value) && !itemField.isShowedFromUser) ||
+                (isAdvancedQuery && ['NULL', 'NOT_NULL'].includes(itemField.operator))) {
                 showsFieldsWithValue = true
               }
               if (isAdvancedQuery) {
@@ -180,7 +183,8 @@ const panel = {
               itemField.isShowedFromUser = true
               return itemField
             }
-            if (!isEmptyValue(itemField.value) && itemField.isShowedFromUser) {
+            if ((!isEmptyValue(itemField.value) && itemField.isShowedFromUser) ||
+              (isAdvancedQuery && ['NULL', 'NOT_NULL'].includes(itemField.operator))) {
               hiddenFieldsWithValue = true
             }
             if (isAdvancedQuery) {
@@ -191,29 +195,29 @@ const panel = {
         }
         return itemField
       })
-      panel.fieldList = newFields
       commit('changePanel', {
         containerUuid,
-        newPanel,
-        panel
+        panel,
+        newPanel
       })
+
       if (showsFieldsWithValue || hiddenFieldsWithValue) {
         // Updated record result
         if (panel.panelType === 'browser') {
           dispatch('getBrowserSearch', {
-            containerUuid: panel.uuid,
+            containerUuid,
             isClearSelection: true
           })
         } else if (panel.panelType === 'table' && panel.isAdvancedQuery) {
           dispatch('getObjectListFromCriteria', {
             parentUuid: panel.parentUuid,
-            containerUuid: panel.uuid,
+            containerUuid,
             tableName: panel.tableName,
             query: panel.query,
             whereClause: panel.whereClause,
             conditionsList: getters.getParametersToServer({
               containerUuid,
-              isAdvancedQuery: true,
+              isAdvancedQuery,
               isEvaluateMandatory: false
             })
           })

--- a/src/store/modules/ADempiere/panel.js
+++ b/src/store/modules/ADempiere/panel.js
@@ -218,7 +218,7 @@ const panel = {
             })
           })
             .catch(error => {
-              console.warn(`Error getting Advanced Query (changeFieldShowedFromUser): ${error.message}. Code: ${error.code}`)
+              console.warn(`Error getting Advanced Query (changeFieldShowedFromUser): ${error.message}. Code: ${error.code}.`)
             })
         }
       }
@@ -608,7 +608,7 @@ const panel = {
                     message: error.message,
                     type: 'error'
                   })
-                  console.warn(`Create Entity Error ${error.code}: ${error.message}`)
+                  console.warn(`Create Entity Error ${error.code}: ${error.message}.`)
                 })
             } else {
               dispatch('updateCurrentEntity', {
@@ -650,7 +650,9 @@ const panel = {
         }
       } else {
         if (panelType === 'table' || isAdvancedQuery) {
-          if (field.isShowedFromUser && (field.oldValue !== field.value || field.operator !== field.oldOperator)) {
+          if (field.isShowedFromUser && (field.oldValue !== field.value ||
+            ['NULL', 'NOT_NULL'].includes(field.operator) ||
+            field.operator !== field.oldOperator)) {
             // change action to advanced query on field value is changed in this panel
             if (router.currentRoute.query.action !== 'advancedQuery') {
               router.push({
@@ -693,7 +695,7 @@ const panel = {
                 }
               })
               .catch(error => {
-                console.warn(`Error getting Advanced Query (notifyFieldChange): ${error.message}. Code: ${error.code}`)
+                console.warn(`Error getting Advanced Query (notifyFieldChange): ${error.message}. Code: ${error.code}.`)
               })
           }
         }
@@ -1295,7 +1297,8 @@ const panel = {
                   return true
                 }
               } else {
-                if (!isEmptyValue(fieldItem.value)) {
+                if (!isEmptyValue(fieldItem.value) || (isAdvancedQuery &&
+                   ['NULL', 'NOT_NULL'].includes(fieldItem.operator))) {
                   return true
                 }
               }

--- a/src/store/modules/ADempiere/panel.js
+++ b/src/store/modules/ADempiere/panel.js
@@ -473,8 +473,8 @@ const panel = {
      * @param {array}   withOutColumnNames
      */
     notifyFieldChange({ commit, dispatch, getters }, {
-      parentUuid, containerUuid, panelType = 'window', isAdvancedQuery = false, columnName,
-      newValue, valueTo, displayColumn,
+      parentUuid, containerUuid, panelType = 'window', isAdvancedQuery = false,
+      columnName, newValue, valueTo, displayColumn,
       isSendToServer = true, isSendCallout = true,
       isChangedOldValue = false, withOutColumnNames = []
     }) {
@@ -483,18 +483,20 @@ const panel = {
       // get field
       const field = fieldList.find(fieldItem => fieldItem.columnName === columnName)
 
-      newValue = parsedValueComponent({
-        fieldType: field.componentPath,
-        referenceType: field.referenceType,
-        value: newValue
-      })
-
-      if (field.isRange) {
-        valueTo = parsedValueComponent({
+      if (!(isAdvancedQuery && ['IN', 'NOT_IN'].includes(field.operator))) {
+        newValue = parsedValueComponent({
           fieldType: field.componentPath,
           referenceType: field.referenceType,
-          value: valueTo
+          value: newValue
         })
+
+        if (field.isRange) {
+          valueTo = parsedValueComponent({
+            fieldType: field.componentPath,
+            referenceType: field.referenceType,
+            value: valueTo
+          })
+        }
       }
 
       if (!(panelType === 'table' || isAdvancedQuery)) {
@@ -591,7 +593,7 @@ const panel = {
             })
           }
           if (field.panelType === 'window' && fieldIsDisplayed(field)) {
-            var uuid = getters.getUuid(containerUuid)
+            const uuid = getters.getUuid(containerUuid)
             if (isEmptyValue(uuid)) {
               dispatch('createNewEntity', {
                 parentUuid,
@@ -789,6 +791,9 @@ const panel = {
         })
       })
     },
+    /**
+     * @deprecated used changeFieldAttribure
+     */
     notifyFieldChangeDisplayColumn({ commit, getters }, {
       containerUuid,
       isAdvancedQuery,

--- a/src/store/modules/ADempiere/windowControl.js
+++ b/src/store/modules/ADempiere/windowControl.js
@@ -606,9 +606,10 @@ const windowControl = {
         }
       }
 
-      const conditions = []
-      if (tab.isParentTab && !isEmptyValue(tab.tableName) && !isEmptyValue(value)) {
-        conditions.push({
+      const conditionsList = []
+      // TODO: evaluate if overwrite values to conditions
+      if (!isLoadAllRecords && tab.isParentTab && !isEmptyValue(tab.tableName) && !isEmptyValue(value)) {
+        conditionsList.push({
           columnName: columnName,
           value: value
         })
@@ -620,8 +621,7 @@ const windowControl = {
         query: parsedQuery,
         whereClause: parsedWhereClause,
         orderByClause: tab.orderByClause,
-        // TODO: evaluate if overwrite values to conditions
-        conditions: isLoadAllRecords ? [] : conditions,
+        conditionsList,
         isParentTab: tab.isParentTab,
         isAddRecord: isAddRecord,
         isShowNotification: isShowNotification

--- a/src/utils/ADempiere/dataUtils.js
+++ b/src/utils/ADempiere/dataUtils.js
@@ -2,67 +2,54 @@
 export const OPERATORS = [
   {
     operator: 'EQUAL',
-    name: 'Equal to',
     symbol: '='
   },
   {
     operator: 'NOT_EQUAL',
-    name: 'Not equal to',
     symbol: '<>'
   },
   {
     operator: 'LIKE',
-    name: 'Like',
     symbol: '%'
   },
   {
     operator: 'NOT_LIKE',
-    name: 'Not like',
     symbol: '!%'
   },
   {
     operator: 'GREATER',
-    name: 'Greater than.',
     symbol: '>'
   },
   {
     operator: 'GREATER_EQUAL',
-    name: 'Greater than equal to.',
     symbol: '>='
   },
   {
     operator: 'LESS',
-    name: 'Less than.',
     symbol: '<'
   },
   {
     operator: 'LESS_EQUAL',
-    name: 'Less than equal to.',
     symbol: '<='
   },
   {
     operator: 'BETWEEN',
-    name: 'BETWEEN',
-    symbol: ''
+    symbol: '>-<'
   },
   {
     operator: 'NOT_NULL',
-    name: 'Non-NULL',
     symbol: ''
   },
   {
     operator: 'NULL',
-    name: 'Is NULL',
     symbol: ''
   },
   {
     operator: 'IN',
-    name: 'In',
     symbol: '()'
   },
   {
     operator: 'NOT_IN',
-    name: 'Not in',
     symbol: '!()'
   }
 ]
@@ -72,70 +59,51 @@ export const FIELD_OPERATORS_LIST = [
   {
     type: 'FieldBinary',
     isRange: false,
-    description: 'Binary Data',
-    conditionsList: ['EQUAL', 'NOT_EQUAL', 'NULL', 'NOT_NULL']
-  },
-  {
-    id: 28,
-    type: 'FieldButton',
-    isRange: false,
-    description: 'Command Button - starts a process',
-    conditionsList: ['EQUAL', 'NOT_EQUAL', 'NULL', 'NOT_NULL']
-  },
-  {
-    id: 15,
-    type: 'FieldDate',
-    isRange: false,
-    description: 'Date mm/dd/yyyy',
-    conditionsList: ['EQUAL', 'NOT_EQUAL', 'GREATER', 'GREATER_EQUAL', 'LESS', 'LESS_EQUAL', 'NULL', 'NOT_NULL']
-  },
-  {
-    id: 32,
-    type: 'FieldImage',
-    isRange: false,
-    description: 'Binary Image Data',
-    conditionsList: ['EQUAL', 'NOT_EQUAL', 'NULL', 'NOT_NULL']
-  },
-  {
-    id: 12,
-    type: 'FieldNumber',
-    isRange: false,
-    description: 'Number with 4 decimals',
-    conditionsList: ['EQUAL', 'NOT_EQUAL', 'GREATER', 'GREATER_EQUAL', 'LESS', 'LESS_EQUAL', 'NULL', 'NOT_NULL']
-  },
-  {
-    id: 17,
-    type: 'FieldSelect',
-    isRange: false,
-    description: 'Reference List',
     conditionsList: ['EQUAL', 'NOT_EQUAL', 'IN', 'NOT_IN', 'NULL', 'NOT_NULL']
   },
   {
-    id: 34,
+    type: 'FieldButton',
+    isRange: false,
+    conditionsList: ['EQUAL', 'NOT_EQUAL', 'IN', 'NOT_IN', 'NULL', 'NOT_NULL']
+  },
+  {
+    type: 'FieldDate',
+    isRange: false,
+    conditionsList: ['EQUAL', 'NOT_EQUAL', 'GREATER', 'GREATER_EQUAL', 'LESS', 'LESS_EQUAL', 'IN', 'NOT_IN', 'NULL', 'NOT_NULL']
+  },
+  {
+    type: 'FieldImage',
+    isRange: false,
+    conditionsList: ['EQUAL', 'NOT_EQUAL', 'IN', 'NOT_IN', 'NULL', 'NOT_NULL']
+  },
+  {
+    type: 'FieldNumber',
+    isRange: false,
+    conditionsList: ['EQUAL', 'NOT_EQUAL', 'GREATER', 'GREATER_EQUAL', 'LESS', 'LESS_EQUAL', 'IN', 'NOT_IN', 'NULL', 'NOT_NULL']
+  },
+  {
+    type: 'FieldSelect',
+    isRange: false,
+    conditionsList: ['EQUAL', 'NOT_EQUAL', 'IN', 'NOT_IN', 'IN', 'NOT_IN', 'NULL', 'NOT_NULL']
+  },
+  {
     type: 'FieldText',
     isRange: false,
-    description: 'Reference List',
-    conditionsList: ['EQUAL', 'NOT_EQUAL', 'LIKE', 'NOT_LIKE', 'NULL', 'NOT_NULL']
+    conditionsList: ['EQUAL', 'NOT_EQUAL', 'LIKE', 'NOT_LIKE', 'IN', 'NOT_IN', 'NULL', 'NOT_NULL']
   },
   {
-    id: 36,
     type: 'FieldTextLong',
     isRange: false,
-    description: 'Text (Long) - Text > 2000 characters',
-    conditionsList: ['EQUAL', 'NOT_EQUAL', 'LIKE', 'NOT_LIKE', 'NULL', 'NOT_NULL']
+    conditionsList: ['EQUAL', 'NOT_EQUAL', 'LIKE', 'NOT_LIKE', 'IN', 'NOT_IN', 'NULL', 'NOT_NULL']
   },
   {
-    id: 24,
     type: 'FieldTime',
     isRange: false,
-    description: 'Time',
-    conditionsList: ['EQUAL', 'NOT_EQUAL', 'GREATER', 'GREATER_EQUAL', 'LESS', 'LESS_EQUAL', 'NULL', 'NOT_NULL']
+    conditionsList: ['EQUAL', 'NOT_EQUAL', 'GREATER', 'GREATER_EQUAL', 'LESS', 'LESS_EQUAL', 'IN', 'NOT_IN', 'NULL', 'NOT_NULL']
   },
   {
-    id: 20,
     type: 'FieldYesNo',
     isRange: false,
-    description: 'CheckBox',
     conditionsList: ['EQUAL', 'NOT_EQUAL', 'NULL', 'NOT_NULL']
   }
 ]

--- a/src/utils/ADempiere/dataUtils.js
+++ b/src/utils/ADempiere/dataUtils.js
@@ -1,0 +1,141 @@
+
+export const OPERATORS = [
+  {
+    operator: 'EQUAL',
+    name: 'Equal to',
+    symbol: '='
+  },
+  {
+    operator: 'NOT_EQUAL',
+    name: 'Not equal to',
+    symbol: '<>'
+  },
+  {
+    operator: 'LIKE',
+    name: 'Like',
+    symbol: '%'
+  },
+  {
+    operator: 'NOT_LIKE',
+    name: 'Not like',
+    symbol: '!%'
+  },
+  {
+    operator: 'GREATER',
+    name: 'Greater than.',
+    symbol: '>'
+  },
+  {
+    operator: 'GREATER_EQUAL',
+    name: 'Greater than equal to.',
+    symbol: '>='
+  },
+  {
+    operator: 'LESS',
+    name: 'Less than.',
+    symbol: '<'
+  },
+  {
+    operator: 'LESS_EQUAL',
+    name: 'Less than equal to.',
+    symbol: '<='
+  },
+  {
+    operator: 'BETWEEN',
+    name: 'BETWEEN',
+    symbol: ''
+  },
+  {
+    operator: 'NOT_NULL',
+    name: 'Non-NULL',
+    symbol: ''
+  },
+  {
+    operator: 'NULL',
+    name: 'Is NULL',
+    symbol: ''
+  },
+  {
+    operator: 'IN',
+    name: 'In',
+    symbol: '()'
+  },
+  {
+    operator: 'NOT_IN',
+    name: 'Not in',
+    symbol: '!()'
+  }
+]
+
+// Components associated with search type
+export const FIELD_OPERATORS_LIST = [
+  {
+    type: 'FieldBinary',
+    isRange: false,
+    description: 'Binary Data',
+    conditionsList: ['EQUAL', 'NOT_EQUAL', 'NULL', 'NOT_NULL']
+  },
+  {
+    id: 28,
+    type: 'FieldButton',
+    isRange: false,
+    description: 'Command Button - starts a process',
+    conditionsList: ['EQUAL', 'NOT_EQUAL', 'NULL', 'NOT_NULL']
+  },
+  {
+    id: 15,
+    type: 'FieldDate',
+    isRange: false,
+    description: 'Date mm/dd/yyyy',
+    conditionsList: ['EQUAL', 'NOT_EQUAL', 'GREATER', 'GREATER_EQUAL', 'LESS', 'LESS_EQUAL', 'NULL', 'NOT_NULL']
+  },
+  {
+    id: 32,
+    type: 'FieldImage',
+    isRange: false,
+    description: 'Binary Image Data',
+    conditionsList: ['EQUAL', 'NOT_EQUAL', 'NULL', 'NOT_NULL']
+  },
+  {
+    id: 12,
+    type: 'FieldNumber',
+    isRange: false,
+    description: 'Number with 4 decimals',
+    conditionsList: ['EQUAL', 'NOT_EQUAL', 'GREATER', 'GREATER_EQUAL', 'LESS', 'LESS_EQUAL', 'NULL', 'NOT_NULL']
+  },
+  {
+    id: 17,
+    type: 'FieldSelect',
+    isRange: false,
+    description: 'Reference List',
+    conditionsList: ['EQUAL', 'NOT_EQUAL', 'IN', 'NOT_IN', 'NULL', 'NOT_NULL']
+  },
+  {
+    id: 34,
+    type: 'FieldText',
+    isRange: false,
+    description: 'Reference List',
+    conditionsList: ['EQUAL', 'NOT_EQUAL', 'LIKE', 'NOT_LIKE', 'NULL', 'NOT_NULL']
+  },
+  {
+    id: 36,
+    type: 'FieldTextLong',
+    isRange: false,
+    description: 'Text (Long) - Text > 2000 characters',
+    conditionsList: ['EQUAL', 'NOT_EQUAL', 'LIKE', 'NOT_LIKE', 'NULL', 'NOT_NULL']
+  },
+  {
+    id: 24,
+    type: 'FieldTime',
+    isRange: false,
+    description: 'Time',
+    conditionsList: ['EQUAL', 'NOT_EQUAL', 'GREATER', 'GREATER_EQUAL', 'LESS', 'LESS_EQUAL', 'NULL', 'NOT_NULL']
+  },
+  {
+    id: 20,
+    type: 'FieldYesNo',
+    isRange: false,
+    description: 'CheckBox',
+    conditionsList: ['EQUAL', 'NOT_EQUAL', 'NULL', 'NOT_NULL']
+  }
+]

--- a/src/utils/ADempiere/dictionaryUtils.js
+++ b/src/utils/ADempiere/dictionaryUtils.js
@@ -109,7 +109,11 @@ export function generateField(fieldToGenerate, moreAttributes, typeRange = false
     // app attributes
     isShowedFromUser,
     isShowedTableFromUser: fieldToGenerate.isDisplayed,
-    isFixedTableColumn: false
+    isFixedTableColumn: false,
+    // Advanced query
+    operator: 'EQUAL', // current operator
+    oldOperator: undefined, // old operator
+    defaultOperator: 'EQUAL'
   }
 
   // evaluate simple logics without context

--- a/src/utils/ADempiere/valueUtils.js
+++ b/src/utils/ADempiere/valueUtils.js
@@ -334,7 +334,7 @@ export function parsedValueComponent({ fieldType, value, referenceType, isMandat
       if (!isNaN(value)) {
         value = Number(value)
       }
-      if (typeof value === 'number') {
+      if (typeof value === 'number' || typeof value === 'string') {
         value = new Date(value)
       }
       if (typeof value === 'object' && value.hasOwnProperty('query')) {


### PR DESCRIPTION
Greetings new functionality is added with the operators in the advanced search, as shown in the gif image, when displaying the search panel can be selected from the list by deploying the popover by clicking on the name of the field.

![Peek 31-01-2020 11-25](https://user-images.githubusercontent.com/20288327/73551378-b3878e80-441c-11ea-9df2-263b3404c2f4.gif)

The operators IN and NOT IN , except for the select (lookups), the date, switch (yes and not), make the fields change to a multiple select that allows to create new values, so you can have multiple values for the same field. However, the date components keep the same component with the difference that allows to select different dates.

https://github.com/adempiere/adempiere-vue/issues/110