### PR TITLE
fix: The fields of type Yes-No and Number, take the fields as empty .

### DIFF
--- a/src/components/ADempiere/DataTable/index.vue
+++ b/src/components/ADempiere/DataTable/index.vue
@@ -784,7 +784,9 @@ export default {
           isSendServer: false
         })
       } else {
-        const fieldsEmpty = this.$store.getters.getFieldListEmptyMandatory({ containerUuid: this.containerUuid })
+        const fieldsEmpty = this.$store.getters.getFieldListEmptyMandatory({
+          containerUuid: this.containerUuid
+        })
         this.$message({
           message: this.$t('notifications.mandatoryFieldMissing') + fieldsEmpty,
           type: 'info'

--- a/src/components/ADempiere/Field/FieldMixin.js
+++ b/src/components/ADempiere/Field/FieldMixin.js
@@ -57,17 +57,36 @@ export const fieldMixin = {
      * @param {string} label, or displayColumn to show in select
      */
     handleChange(value, valueTo = undefined, label = undefined) {
+      let newValue = value
+      let isSendCallout = true
+      let isSendToServer = true
+      let isChangedOldValue = false
+      if (value === 'NotSend') {
+        newValue = this.value
+        if (this.componentPath === 'FieldYesNo') {
+          isChangedOldValue = true
+          newValue = Boolean(newValue)
+        }
+        isSendToServer = false
+        isSendCallout = false
+      }
+      if (this.metadata.isAdvancedQuery) {
+        isSendToServer = false
+        isSendCallout = false
+      }
+
       const sendParameters = {
         parentUuid: this.metadata.parentUuid,
         containerUuid: this.metadata.containerUuid,
         field: this.metadata,
         panelType: this.metadata.panelType,
         columnName: this.metadata.columnName,
-        newValue: value === 'NotSend' ? this.value : value,
-        valueTo: valueTo,
+        newValue,
+        valueTo,
         isAdvancedQuery: this.metadata.isAdvancedQuery,
-        isSendToServer: !(value === 'NotSend' || this.metadata.isAdvancedQuery),
-        isSendCallout: !(value === 'NotSend' || this.metadata.isAdvancedQuery)
+        isSendToServer,
+        isSendCallout,
+        isChangedOldValue
       }
 
       if (this.metadata.inTable) {
@@ -80,8 +99,7 @@ export const fieldMixin = {
       } else {
         this.$store.dispatch('notifyFieldChange', {
           ...sendParameters,
-          displayColumn: label,
-          isChangedOldValue: this.metadata.componentPath === 'FieldYesNo' && Boolean(value === 'NotSend')
+          displayColumn: label
         })
       }
     }

--- a/src/store/modules/ADempiere/panel.js
+++ b/src/store/modules/ADempiere/panel.js
@@ -647,7 +647,8 @@ const panel = {
           }
         } else {
           const fieldsEmpty = getters.getFieldListEmptyMandatory({
-            containerUuid
+            containerUuid,
+            fieldsList: fieldList
           })
           showMessage({
             message: language.t('notifications.mandatoryFieldMissing') + fieldsEmpty,
@@ -930,37 +931,37 @@ const panel = {
 
       return field
     },
-    getEmptyMandatory: (state, getters) => (containerUuid) => {
-      return getters.getFieldsListFromPanel(containerUuid).find(itemField => {
-        if ((itemField.isMandatory || itemField.isMandatoryFromLogic) && isEmptyValue(itemField.value)) {
-          return true
-        }
-      })
-    },
     // Obtain empty obligatory fields
-    getFieldListEmptyMandatory: (state, getters) => (parameters) => {
-      const { containerUuid, evaluateShowed = true, row } = parameters
+    getFieldListEmptyMandatory: (state, getters) => ({
+      containerUuid,
+      fieldsList = [],
+      isEvaluateShowed = true,
+      row
+    }) => {
+      if (fieldsList.length <= 0) {
+        fieldsList = getters.getFieldsListFromPanel(containerUuid)
+      }
+
       // all optionals (not mandatory) fields
-      var fieldList = getters.getFieldsListFromPanel(containerUuid).filter(fieldItem => {
+      fieldsList = fieldsList.filter(fieldItem => {
         const isMandatory = fieldItem.isMandatory || fieldItem.isMandatoryFromLogic
         if (isMandatory) {
-          if (evaluateShowed) {
+          if (isEvaluateShowed) {
             return fieldIsDisplayed(fieldItem)
           }
           return isMandatory
         }
       })
-      fieldList = fieldList.filter(fieldItem => {
-        var value = fieldItem.value
+      fieldsList = fieldsList.filter(fieldItem => {
+        let value = fieldItem.value
         // used when evaluate data in table
         if (row) {
           value = row[fieldItem.columnName]
         }
-        if (isEmptyValue(value)) {
-          return true
-        }
+        return isEmptyValue(value)
       })
-      return fieldList.map(fieldItem => {
+
+      return fieldsList.map(fieldItem => {
         return fieldItem.name
       })
     },

--- a/src/store/modules/ADempiere/window.js
+++ b/src/store/modules/ADempiere/window.js
@@ -75,16 +75,16 @@ const window = {
               ...tabItem,
               containerUuid: tabItem.uuid,
               parentUuid: windowUuid,
-              windowUuid: windowUuid,
+              windowUuid,
               tabGroup: tabItem.fieldGroup,
-              firstTabUuid: firstTabUuid,
+              firstTabUuid,
               // relations
               isParentTab: Boolean(firstTab === tabItem.tableName),
               // app properties
               isAssociatedTabSequence: false, // show modal with order tab
               isShowedRecordNavigation: !(tabItem.isSingleRow),
               isLoadFieldList: false,
-              index: index
+              index
             }
             delete tab.processesList
 
@@ -217,7 +217,7 @@ const window = {
             ...responseWindow,
             ...tabProperties,
             isShowedRecordNavigation: undefined,
-            firstTabUuid: firstTabUuid,
+            firstTabUuid,
             windowIndex: state.windowIndex + 1
           }
           commit('addWindow', newWindow)
@@ -242,14 +242,14 @@ const window = {
       return getTabMetadata(containerUuid)
         .then(tabResponse => {
           const additionalAttributes = {
-            parentUuid: parentUuid,
-            containerUuid: containerUuid,
+            parentUuid,
+            containerUuid,
             isShowedFromUser: true,
-            panelType: panelType,
+            panelType,
             tableName: tabResponse.tableName,
             //
             isReadOnlyFromForm: false,
-            isAdvancedQuery: isAdvancedQuery
+            isAdvancedQuery
           }
 
           let fieldUuidsequence = 0
@@ -291,7 +291,7 @@ const window = {
               sequence: (fieldUuidsequence + 10),
               name: 'UUID',
               columnName: 'UUID',
-              isAdvancedQuery: isAdvancedQuery,
+              isAdvancedQuery,
               componentPath: 'FieldText'
             }
             const field = getFieldTemplate(attributesOverwrite)
@@ -301,18 +301,18 @@ const window = {
           //  Panel for save on store
           const panel = {
             ...getters.getTab(parentUuid, containerUuid),
-            isAdvancedQuery: isAdvancedQuery,
+            isAdvancedQuery,
             fieldLinkColumnName: fieldLinkColumnName,
             fieldList: fieldsList,
-            panelType: panelType,
+            panelType,
             // app attributes
             isShowedTotals: false
           }
 
           dispatch('addPanel', panel)
           dispatch('setTabIsLoadField', {
-            parentUuid: parentUuid,
-            containerUuid: containerUuid
+            parentUuid,
+            containerUuid
           })
           return panel
         })

--- a/src/utils/ADempiere/contextUtils.js
+++ b/src/utils/ADempiere/contextUtils.js
@@ -210,14 +210,12 @@ export function getPreference({
 
   //        SYSTEM PREFERENCES
   // Login setting
-  if (!isEmptyValue(parentUuid)) {
-    // get # globals context only window
-    retValue = getContext({
-      columnName: '#' + columnName
-    })
-    if (!isEmptyValue(retValue)) {
-      return retValue
-    }
+  // get # globals context only window
+  retValue = getContext({
+    columnName: '#' + columnName
+  })
+  if (!isEmptyValue(retValue)) {
+    return retValue
   }
 
   //  Accounting setting

--- a/src/utils/ADempiere/dictionaryUtils.js
+++ b/src/utils/ADempiere/dictionaryUtils.js
@@ -22,28 +22,28 @@ export function generateField(fieldToGenerate, moreAttributes, typeRange = false
   const referenceType = componentReference.alias[0]
 
   let parsedDefaultValue = fieldToGenerate.defaultValue
-  if (isEmptyValue(parsedDefaultValue)) {
-    parsedDefaultValue = getPreference({
-      parentUuid: fieldToGenerate.parentUuid,
-      containerUuid: fieldToGenerate.containerUuid,
-      columnName: fieldToGenerate.columnName
-    })
+  if (!moreAttributes.isAdvancedQuery) {
+    if (String(parsedDefaultValue).includes('@')) {
+      parsedDefaultValue = parseContext({
+        ...moreAttributes,
+        columnName: fieldToGenerate.columnName,
+        value: parsedDefaultValue
+      }).value
+    }
     if (isEmptyValue(parsedDefaultValue)) {
+      parsedDefaultValue = getPreference({
+        parentUuid: fieldToGenerate.parentUuid,
+        containerUuid: fieldToGenerate.containerUuid,
+        columnName: fieldToGenerate.columnName
+      })
+    }
+    if (isEmptyValue(parsedDefaultValue) && !isEmptyValue(fieldToGenerate.elementName)) {
       parsedDefaultValue = getPreference({
         parentUuid: fieldToGenerate.parentUuid,
         containerUuid: fieldToGenerate.containerUuid,
         columnName: fieldToGenerate.elementName
       })
     }
-  } else if (String(parsedDefaultValue).includes('@')) {
-    // if (String(parsedDefaultValue).includes('@SQL=')) {
-    //   parsedDefaultValue.replace('@SQL=', '')
-    // }
-    parsedDefaultValue = parseContext({
-      ...moreAttributes,
-      columnName: fieldToGenerate.columnName,
-      value: parsedDefaultValue
-    }).value
   }
   parsedDefaultValue = parsedValueComponent({
     fieldType: componentReference.type,
@@ -53,28 +53,30 @@ export function generateField(fieldToGenerate, moreAttributes, typeRange = false
   })
 
   let parsedDefaultValueTo = fieldToGenerate.defaultValueTo
-  if (isEmptyValue(parsedDefaultValueTo)) {
-    parsedDefaultValueTo = getPreference({
-      parentUuid: fieldToGenerate.parentUuid,
-      containerUuid: fieldToGenerate.containerUuid,
-      columnName: `${fieldToGenerate.columnName}_To`
-    })
-    if (isEmptyValue()) {
+  if (!moreAttributes.isAdvancedQuery) {
+    // if (String(parsedDefaultValueTo).includes('@SQL=')) {
+    //   parsedDefaultValueTo.replace('@SQL=', '')
+    if (String(parsedDefaultValueTo).includes('@')) {
+      parsedDefaultValueTo = parseContext({
+        ...moreAttributes,
+        columnName: `${fieldToGenerate.columnName}_To`,
+        value: parsedDefaultValueTo
+      }).value
+    }
+    if (isEmptyValue(parsedDefaultValueTo)) {
+      parsedDefaultValueTo = getPreference({
+        parentUuid: fieldToGenerate.parentUuid,
+        containerUuid: fieldToGenerate.containerUuid,
+        columnName: `${fieldToGenerate.columnName}_To`
+      })
+    }
+    if (isEmptyValue(parsedDefaultValueTo) && !isEmptyValue(fieldToGenerate.elementName)) {
       parsedDefaultValueTo = getPreference({
         parentUuid: fieldToGenerate.parentUuid,
         containerUuid: fieldToGenerate.containerUuid,
         columnName: `${fieldToGenerate.elementName}_To`
       })
     }
-  } else if (String(parsedDefaultValueTo).includes('@')) {
-    // if (String(parsedDefaultValueTo).includes('@SQL=')) {
-    //   parsedDefaultValueTo.replace('@SQL=', '')
-    // }
-    parsedDefaultValueTo = parseContext({
-      ...moreAttributes,
-      columnName: fieldToGenerate.columnName,
-      value: fieldToGenerate.defaultValueTo
-    }).value
   }
   parsedDefaultValueTo = parsedValueComponent({
     fieldType: componentReference.type,

--- a/src/utils/ADempiere/valueUtils.js
+++ b/src/utils/ADempiere/valueUtils.js
@@ -282,7 +282,10 @@ export const recursiveTreeSearch = ({
  * @param {*} param0
  */
 export function parsedValueComponent({ fieldType, value, referenceType, isMandatory = false }) {
-  if (value === undefined || value === null) {
+  if ((value === undefined || value === null) && !isMandatory) {
+    if (fieldType === 'FieldYesNo') {
+      return Boolean(value)
+    }
     return undefined
   }
   var returnValue
@@ -290,7 +293,7 @@ export function parsedValueComponent({ fieldType, value, referenceType, isMandat
   switch (fieldType) {
     // data type Number
     case 'FieldNumber':
-      if (String(value).trim() === '') {
+      if (String(value).trim() === '' || value === undefined || value === null) {
         returnValue = undefined
         if (isMandatory) {
           returnValue = 0
@@ -322,7 +325,7 @@ export function parsedValueComponent({ fieldType, value, referenceType, isMandat
       if (typeof value === 'object' && value.hasOwnProperty('query')) {
         returnValue = value
       }
-      returnValue = String(value)
+      returnValue = value ? String(value) : undefined
       break
 
     // data type Date


### PR DESCRIPTION
Greetings, being in create new record mode, in some windows in this case Sales Orders, when making a change in any field appeared the message of the missing mandatory fields to place value, however from this list should be excluded all fields of type Yes-No as having boolean values always have a value either True or False, and the Number fields that are marked as mandatory because if they have no default values this must be 0.

Display before fixes
![Peek 03-02-2020 16-26](https://user-images.githubusercontent.com/20288327/73689008-a7613280-46a3-11ea-922e-6c240f83c650.gif)

Display after fixes
![Peek 03-02-2020 16-31](https://user-images.githubusercontent.com/20288327/73689017-ac25e680-46a3-11ea-86e2-af6cdda0e4f3.gif)

