### PR TITLE
bugfix close affix tags views

### DIFF
--- a/src/layout/components/TagsView/index.vue
+++ b/src/layout/components/TagsView/index.vue
@@ -16,7 +16,7 @@
           :to="{ name: tag.name, path: tag.path, query: tag.query, fullPath: tag.fullPath, params: tag.params }"
           tag="span"
           class="tags-view-item"
-          @click.middle.native="closeSelectedTag(tag)"
+          @click.middle.native="!isAffix(tag) ? closeSelectedTag(tag) : ''"
           @contextmenu.prevent.native="openMenu(tag,$event)"
         >
           <div class="tag-title">{{ generateTitle(tag.title) }}</div>
@@ -32,11 +32,11 @@
           :to="{ name: tag.name, path: tag.path, query: tag.query, fullPath: tag.fullPath, params: tag.params }"
           tag="span"
           class="tags-view-item"
-          @click.middle.native="closeSelectedTag(tag)"
+          @click.middle.native="!isAffix(tag) ? closeSelectedTag(tag) : ''"
           @contextmenu.prevent.native="openMenu(tag,$event)"
         >
           <div class="tag-title">{{ generateTitle(tag.title) }}</div>
-          <div v-if="!tag.meta.affix" class="el-icon-close" @click.prevent.stop="closeSelectedTag(tag)" />
+          <div v-if="!isAffix(tag)" class="el-icon-close" @click.prevent.stop="closeSelectedTag(tag)" />
         </router-link>
       </template>
     </scroll-pane>
@@ -44,7 +44,7 @@
       <li @click="refreshSelectedTag(selectedTag)">
         {{ $t('tagsView.refresh') }}
       </li>
-      <li v-if="!(selectedTag.meta&&selectedTag.meta.affix)" @click="closeSelectedTag(selectedTag)">
+      <li v-if="!isAffix(selectedTag)" @click="closeSelectedTag(selectedTag)">
         {{
           $t('tagsView.close') }}
       </li>
@@ -115,6 +115,9 @@ export default {
       } else {
         return route.name === this.$route.name
       }
+    },
+    isAffix(tag) {
+      return tag.meta && tag.meta.affix
     },
     filterAffixTags(routes, basePath = '/') {
       let tags = []


### PR DESCRIPTION
**Current behavior**:
Currently when you press the central mouse click, on the tags views that are marked as fixed they close.
![affix-tag](https://user-images.githubusercontent.com/23490674/73749586-0cfc0000-4732-11ea-884d-e2ccf6be7985.gif)

**Behavior with this change**:
With this change this error is corrected, since the routes marked as fixed should not be closed.
![affix-tag-no-close](https://user-images.githubusercontent.com/23490674/73750032-de325980-4732-11ea-9a59-d7f7ced3761c.gif)
