### PR TITLE
fix #314 Wrong display of the Window references in the context menu.

### DIFF
--- a/src/components/ADempiere/ContextMenu/contextMenuDesktop.vue
+++ b/src/components/ADempiere/ContextMenu/contextMenuDesktop.vue
@@ -12,7 +12,7 @@
       @shortkey.native="actionContextMenu"
     >
       <template>
-        <el-submenu v-if="relationsList !== undefined && relationsList.length" class="el-menu-item" index="1">
+        <el-submenu v-if="!isEmptyValue(relationsList)" class="el-menu-item" index="1">
           <template slot="title">
             {{ $t('components.contextMenuRelations') }}
           </template>
@@ -33,12 +33,24 @@
                 {{ action.name }}
               </template>
               <el-scrollbar wrap-class="scroll-child">
-                <el-menu-item v-for="(child, key) in action.childs" :key="key" :index="child.uuid" @click="runAction(child)">
+                <el-menu-item
+                  v-for="(child, key) in action.childs"
+                  :key="key"
+                  :index="child.uuid"
+                  @click="runAction(child)"
+                >
                   {{ child.name }}
                 </el-menu-item>
               </el-scrollbar>
             </el-submenu>
-            <el-menu-item v-else v-show="!action.hidden" :key="index" :index="action.name" :disabled="action.disabled" @click="runAction(action)">
+            <el-menu-item
+              v-else
+              v-show="!action.hidden"
+              :key="index"
+              :index="action.name"
+              :disabled="action.disabled"
+              @click="runAction(action)"
+            >
               {{ action.name }}
             </el-menu-item>
           </template>
@@ -53,7 +65,9 @@
             index="xlsx"
             @click.native="exporBrowser('xlsx')"
           >
-            <template slot="title">{{ $t('components.contextMennuWindowReport') }}</template>
+            <template slot="title">
+              {{ $t('components.contextMennuWindowReport') }}
+            </template>
             <template v-for="(format, index) in option">
               <el-menu-item :key="index" :index="index">
                 {{ format }}
@@ -91,12 +105,17 @@
           <template slot="title">
             {{ $t('components.contextMenuReferences') }}
           </template>
-          <template v-if="references && references.referencesList && references.referencesList.length">
-            <template v-for="(reference, index) in references.referencesList">
-              <el-menu-item :key="index" :index="reference.displayName" @click="runAction(reference)">
+          <template v-if="references && !isEmptyValue(references.referencesList)">
+            <el-scrollbar wrap-class="scroll-child">
+              <el-menu-item
+                v-for="(reference, index) in references.referencesList"
+                :key="index"
+                :index="reference.displayName"
+                @click="runAction(reference)"
+              >
                 {{ reference.displayName }}
               </el-menu-item>
-            </template>
+            </el-scrollbar>
           </template>
           <el-menu-item v-else index="not-references" disabled>
             {{ $t('components.withOutReferences') }}

--- a/src/components/ADempiere/ContextMenu/contextMenuDesktop.vue
+++ b/src/components/ADempiere/ContextMenu/contextMenuDesktop.vue
@@ -87,17 +87,20 @@
         <el-menu-item v-else disabled index="2">
           {{ $t('components.contextMenuActions') }}
         </el-menu-item>
-        <el-submenu :disabled="!isReferencesLoaded" class="el-menu-item" index="3">
+        <el-submenu :disabled="!(isReferecesContent && isLoadedReferences)" class="el-menu-item" index="3">
           <template slot="title">
             {{ $t('components.contextMenuReferences') }}
           </template>
-          <template v-if="references && references.referencesList">
+          <template v-if="references && references.referencesList && references.referencesList.length">
             <template v-for="(reference, index) in references.referencesList">
               <el-menu-item :key="index" :index="reference.displayName" @click="runAction(reference)">
                 {{ reference.displayName }}
               </el-menu-item>
             </template>
           </template>
+          <el-menu-item v-else index="not-references" disabled>
+            {{ $t('components.withOutReferences') }}
+          </el-menu-item>
         </el-submenu>
       </template>
     </el-menu>

--- a/src/components/ADempiere/ContextMenu/contextMenuMixin.js
+++ b/src/components/ADempiere/ContextMenu/contextMenuMixin.js
@@ -54,7 +54,7 @@ export const contextMixin = {
       downloads: this.$store.getters.getProcessResult.url,
       metadataMenu: {},
       recordUuid: this.$route.query.action,
-      isReferencesLoaded: false,
+      isLoadedReferences: false,
       exportDefault: 'xls',
       ROUTES
     }
@@ -264,31 +264,30 @@ export const contextMixin = {
     },
     getReferences() {
       if (this.isReferecesContent) {
-        var references = this.getterReferences
+        const references = this.getterReferences
         if (references && references.length) {
           this.references = references
-          this.isReferencesLoaded = true
+          this.isLoadedReferences = true
         } else {
+          this.isLoadedReferences = false
           this.$store.dispatch('getReferencesListFromServer', {
             parentUuid: this.parentUuid,
             containerUuid: this.containerUuid,
             recordUuid: this.recordUuid
           })
             .then(() => {
-              this.references = this.$store.getters.getReferencesList(this.parentUuid, this.recordUuid)
-              if (this.references.referencesList.length) {
-                this.isReferencesLoaded = true
-              } else {
-                this.isReferencesLoaded = false
-              }
+              this.references = this.getterReferences
             })
             .catch(error => {
-              console.warn('References Load Error ' + error.code + ': ' + error.message)
+              console.warn(`References Load Error ${error.code}: ${error.message}.`)
+            })
+            .finally(() => {
+              this.isLoadedReferences = true
             })
         }
       } else {
         this.references = []
-        this.isReferencesLoaded = false
+        this.isLoadedReferences = false
       }
     },
     typeFormat(key) {

--- a/src/components/ADempiere/ContextMenu/contextMenuMobile.vue
+++ b/src/components/ADempiere/ContextMenu/contextMenuMobile.vue
@@ -30,15 +30,31 @@
           <el-menu-item-group>
             <el-scrollbar wrap-class="scroll">
               <template v-for="(action, index) in actions">
-                <el-submenu v-if="action.childs" :key="index" :index="action.name" :disabled="action.disabled">
+                <el-submenu
+                  v-if="action.childs"
+                  :key="index"
+                  :index="action.name"
+                  :disabled="action.disabled"
+                >
                   <template slot="title">
                     {{ action.name }}
                   </template>
-                  <el-menu-item v-for="(child, key) in action.childs" :key="key" :index="child.uuid" @click="runAction(child)">
+                  <el-menu-item
+                    v-for="(child, key) in action.childs"
+                    :key="key"
+                    :index="child.uuid"
+                    @click="runAction(child)"
+                  >
                     {{ child.name }}
                   </el-menu-item>
                 </el-submenu>
-                <el-menu-item v-else :key="index" :index="action.name" :disabled="action.disabled" @click="runAction(action)">
+                <el-menu-item
+                  v-else
+                  :key="index"
+                  :index="action.name"
+                  :disabled="action.disabled"
+                  @click="runAction(action)"
+                >
                   <svg-icon v-if="action.type === 'process'" icon-class="component" />
                   {{ action.name }}
                 </el-menu-item>
@@ -61,12 +77,17 @@
           <template slot="title">
             {{ $t('components.contextMenuReferences') }}
           </template>
-          <template v-if="references && references.referencesList && references.referencesList.length">
-            <template v-for="(reference, index) in references.referencesList">
-              <el-menu-item :key="index" :index="reference.displayName" @click="runAction(reference)">
+          <template v-if="references && isEmptyValue(references.referencesList)">
+            <el-scrollbar wrap-class="scroll-child">
+              <el-menu-item
+                v-for="(reference, index) in references.referencesList"
+                :key="index"
+                :index="reference.displayName"
+                @click="runAction(reference)"
+              >
                 {{ reference.displayName }}
               </el-menu-item>
-            </template>
+            </el-scrollbar>
           </template>
           <el-menu-item v-else index="not-references" disabled>
             {{ $t('components.withOutReferences') }}

--- a/src/components/ADempiere/ContextMenu/contextMenuMobile.vue
+++ b/src/components/ADempiere/ContextMenu/contextMenuMobile.vue
@@ -57,17 +57,20 @@
             </el-scrollbar>
           </el-menu-item-group>
         </el-submenu>
-        <el-submenu :disabled="!isReferecesContent && !isReferencesLoaded" class="el-menu-item" index="3">
+        <el-submenu :disabled="!(isReferecesContent && isLoadedReferences)" class="el-menu-item" index="3">
           <template slot="title">
             {{ $t('components.contextMenuReferences') }}
           </template>
-          <template v-if="references && references.referencesList">
+          <template v-if="references && references.referencesList && references.referencesList.length">
             <template v-for="(reference, index) in references.referencesList">
               <el-menu-item :key="index" :index="reference.displayName" @click="runAction(reference)">
                 {{ reference.displayName }}
               </el-menu-item>
             </template>
           </template>
+          <el-menu-item v-else index="not-references" disabled>
+            {{ $t('components.withOutReferences') }}
+          </el-menu-item>
         </el-submenu>
       </el-menu>
     </right-menu>

--- a/src/lang/ADempiere/en.js
+++ b/src/lang/ADempiere/en.js
@@ -122,6 +122,7 @@ export default {
     contextMenuRelations: 'Relations',
     contextMenuActions: 'Actions',
     contextMenuReferences: 'References',
+    withOutReferences: 'Without references for record',
     RunProcess: 'Run',
     ChangeParameters: 'Change Parameters',
     RunProcessAs: 'Run As',

--- a/src/lang/ADempiere/es.js
+++ b/src/lang/ADempiere/es.js
@@ -122,6 +122,7 @@ export default {
     contextMenuRelations: 'Relaciones',
     contextMenuActions: 'Acciones',
     contextMenuReferences: 'Referencias',
+    withOutReferences: 'Sin referencias para el registro',
     contextMenuDownload: 'Descargar',
     contextMenuShareLink: 'Compartir Link',
     contextMenuRefresh: 'Actualizar',


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, not the `master` branch
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your `master` branch!
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number). fix #314.

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

## Description
<!-- Please describe your pull request. -->
When a window has no references associated with the record, it is not disabled from the context memo, an item indicating 'Without references for record' is displayed.

When the window has many reference items in the context menu, the content is adjusted to a more appropriate size and easier to handle, adding a vertical scroll for better navigation in the list.

### Screenshots
<!-- A picture tells a thousand words -->
 **Before this PR**
![Peek 07-02-2020 10-11](https://user-images.githubusercontent.com/20288327/74037113-ffde4b80-4993-11ea-8e16-b8a86623ef48.gif)

**After this PR**
![Peek 07-02-2020 09-58](https://user-images.githubusercontent.com/20288327/74037174-24d2be80-4994-11ea-888e-30e0d7f4665b.gif)

