### PR TITLE
Set record values to panel after advanced query

### DIFF
--- a/src/store/modules/ADempiere/panel.js
+++ b/src/store/modules/ADempiere/panel.js
@@ -633,14 +633,14 @@ const panel = {
                   }
                 })
                 if (response && response.length) {
-                  dispatch('notifyPanelChange', {
-                    parentUuid,
-                    containerUuid,
-                    isAdvancedQuery: false,
-                    newValues: response[0],
-                    isSendToServer: false,
-                    isSendCallout: true,
-                    panelType: 'window'
+                  const currentRoute = router.app.$route
+                  router.push({
+                    name: currentRoute.name,
+                    query: {
+                      action: response[0].UUID,
+                      tabParent: currentRoute.query.tabParent,
+                      tabChild: currentRoute.query.tabChild
+                    }
                   })
                 }
               })


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, not the `master` branch
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your `master` branch!
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

## Description
After performing a search using the 'Advanced Query' tool, the first record shown in the table will be sent to the main panel.

### Screenshots
<!-- A picture tells a thousand words -->
 **Before this PR**
![Screenshot_20200225_085437](https://user-images.githubusercontent.com/23490674/75250163-1c5cef00-57ae-11ea-9652-b8f9cbb261e9.png)

**After this PR**
![Screenshot_20200225_085708](https://user-images.githubusercontent.com/23490674/75250167-2121a300-57ae-11ea-936e-927b52e2c53f.png)
