### PR TITLE
fix: #347 Loses values when create entity using callout generate error or warning.

### DIFF
--- a/src/components/ADempiere/DataTable/index.vue
+++ b/src/components/ADempiere/DataTable/index.vue
@@ -446,8 +446,6 @@ export default {
     },
     fieldList() {
       if (this.getterPanel && this.getterPanel.fieldList) {
-        // TODO: Change to destructuring and add isParent attribure to change
-        // orderBy sequence value to seqNoGrid value if isParent is false
         return this.sortFields(
           this.getterPanel.fieldList,
           this.panelType !== 'browser' ? 'seqNoGrid' : 'sequence'

--- a/src/components/ADempiere/DataTable/index.vue
+++ b/src/components/ADempiere/DataTable/index.vue
@@ -446,6 +446,8 @@ export default {
     },
     fieldList() {
       if (this.getterPanel && this.getterPanel.fieldList) {
+        // TODO: Change to destructuring and add isParent attribure to change
+        // orderBy sequence value to seqNoGrid value if isParent is false
         return this.sortFields(
           this.getterPanel.fieldList,
           this.panelType !== 'browser' ? 'seqNoGrid' : 'sequence'

--- a/src/components/ADempiere/DataTable/menu/menuTableMixin.js
+++ b/src/components/ADempiere/DataTable/menu/menuTableMixin.js
@@ -2,6 +2,7 @@ import { supportedTypes, exportFileFromJson, exportFileZip } from '@/utils/ADemp
 import { showNotification } from '@/utils/ADempiere/notification'
 import { recursiveTreeSearch } from '@/utils/ADempiere/valueUtils'
 import { FIELDS_QUANTITY } from '@/components/ADempiere/Field/references'
+import { sortFields } from '@/utils/ADempiere/dictionaryUtils'
 
 export const menuTableMixin = {
   props: {
@@ -84,6 +85,8 @@ export const menuTableMixin = {
         if (this.panelType === 'browser') {
           sortAttribute = 'seqNoGrid'
         }
+        // TODO: Change to destructuring and add isParent attribure to change
+        // orderBy sequence value to seqNoGrid value if isParent is false
         return this.sortFields(
           this.panelMetadata.fieldList,
           sortAttribute
@@ -164,6 +167,7 @@ export const menuTableMixin = {
   },
   methods: {
     showNotification,
+    sortFields,
     closeMenu() {
       // TODO: Validate to dispatch one action
       this.$store.dispatch('showMenuTable', {

--- a/src/store/modules/ADempiere/calloutControl.js
+++ b/src/store/modules/ADempiere/calloutControl.js
@@ -16,17 +16,10 @@ const callOutControl = {
       oldValue
     }) {
       const window = rootGetters.getWindow(parentUuid)
-      let attributesList = []
-      if (inTable) {
-        attributesList = rootGetters.getParametersToServer({
-          containerUuid,
-          row
-        })
-      } else {
-        attributesList = rootGetters.getParametersToServer({
-          containerUuid
-        })
-      }
+      const attributesList = rootGetters.getParametersToServer({
+        containerUuid,
+        row
+      })
 
       return runCallOutRequest({
         windowUuid: parentUuid,
@@ -40,13 +33,11 @@ const callOutControl = {
         windowNo: window.windowIndex
       })
         .then(calloutResponse => {
-          const newValues = {}
-          Object.keys(calloutResponse.values).forEach(key => {
-            if (calloutResponse.values[key] !== undefined) {
-              newValues[key] = calloutResponse.values[key]
-            }
-          })
           if (inTable) {
+            const newValues = {
+              ...row,
+              ...calloutResponse.values
+            }
             dispatch('notifyRowTableChange', {
               parentUuid,
               containerUuid,
@@ -58,7 +49,7 @@ const callOutControl = {
               parentUuid,
               containerUuid,
               panelType: 'window',
-              newValues,
+              newValues: calloutResponse.values,
               isSendToServer: false,
               withOutColumnNames,
               isSendCallout: false,

--- a/src/utils/ADempiere/dictionaryUtils.js
+++ b/src/utils/ADempiere/dictionaryUtils.js
@@ -447,8 +447,6 @@ export function assignedGroup(fieldList, assignedGroup) {
     return fieldList
   }
 
-  // TODO: Change to destructuring and add isParent attribure to change orderBy
-  // sequence value to seqNoGrid value if isParent is false
   fieldList = sortFields(fieldList, 'sequence', 'asc', fieldList[0].panelType)
 
   let firstChangeGroup = false
@@ -499,8 +497,6 @@ export function assignedGroup(fieldList, assignedGroup) {
  * @param {string} orderBy
  * @param {string} type
  * @param {string} panelType
- * TODO: Change to destructuring and add isParent attribure to change orderBy
- * sequence value to seqNoGrid value if isParent is false
  * @returns {array}
  */
 export function sortFields(arr, orderBy = 'sequence', type = 'asc', panelType = 'window') {

--- a/src/utils/ADempiere/dictionaryUtils.js
+++ b/src/utils/ADempiere/dictionaryUtils.js
@@ -446,6 +446,9 @@ export function assignedGroup(fieldList, assignedGroup) {
   if (fieldList === undefined || fieldList.length <= 0) {
     return fieldList
   }
+
+  // TODO: Change to destructuring and add isParent attribure to change orderBy
+  // sequence value to seqNoGrid value if isParent is false
   fieldList = sortFields(fieldList, 'sequence', 'asc', fieldList[0].panelType)
 
   let firstChangeGroup = false
@@ -496,6 +499,8 @@ export function assignedGroup(fieldList, assignedGroup) {
  * @param {string} orderBy
  * @param {string} type
  * @param {string} panelType
+ * TODO: Change to destructuring and add isParent attribure to change orderBy
+ * sequence value to seqNoGrid value if isParent is false
  * @returns {array}
  */
 export function sortFields(arr, orderBy = 'sequence', type = 'asc', panelType = 'window') {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, not the `master` branch
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your `master` branch!
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number): fix #347 

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

## Description
<!-- Please describe your pull request. -->
If when creating a record in the table of child tabs a change is made to a field containing a callout or an error or warning is generated due to a callout, it maintains the values entered by the user.

### Screenshots
<!-- A picture tells a thousand words -->
 **Before this PR**
![Peek 19-02-2020 13-09](https://user-images.githubusercontent.com/20288327/74864312-c60f2c80-5325-11ea-8c7a-68ec33db8231.gif)

**After this PR**
![Peek 19-02-2020 14-34](https://user-images.githubusercontent.com/20288327/74864321-c90a1d00-5325-11ea-9dec-2a7e134ac374.gif)
