### PR TITLE
add ADempiere template to make components, views and store modules files

### DIFF
--- a/plop-templates/ADempiere/component/index.hbs
+++ b/plop-templates/ADempiere/component/index.hbs
@@ -1,0 +1,25 @@
+{{#if template}}
+<template>
+  <div />
+</template>
+{{/if}}
+
+{{#if script}}
+<script>
+export default {
+  name: '{{ properCase name }}',
+  props: {},
+  data() {
+    return {}
+  },
+  computed: {},
+  methods: {}
+}
+</script>
+{{/if}}
+
+{{#if style}}
+<style lang="scss" scoped>
+
+</style>
+{{/if}}

--- a/plop-templates/ADempiere/component/prompt.js
+++ b/plop-templates/ADempiere/component/prompt.js
@@ -1,0 +1,55 @@
+const { notEmpty } = require('../../utils.js')
+
+module.exports = {
+  description: 'Generate ADempiere .vue component',
+  prompts: [{
+    type: 'input',
+    name: 'name',
+    message: 'ADempiere Component name: ',
+    validate: notEmpty('name')
+  },
+  {
+    type: 'checkbox',
+    name: 'blocks',
+    message: 'Blocks:',
+    choices: [{
+      name: '<template>',
+      value: 'template',
+      checked: true
+    },
+    {
+      name: '<script>',
+      value: 'script',
+      checked: true
+    },
+    {
+      name: 'style',
+      value: 'style',
+      checked: true
+    }
+    ],
+    validate(value) {
+      if (value.indexOf('script') === -1 && value.indexOf('template') === -1) {
+        return 'Components require at least a <script> or <template> tag.'
+      }
+      return true
+    }
+  }
+  ],
+  actions: data => {
+    const name = '{{properCase name}}'
+    const actions = [{
+      type: 'add',
+      path: `src/components/ADempiere/${name}/index.vue`,
+      templateFile: 'plop-templates/component/index.hbs',
+      data: {
+        name: name,
+        template: data.blocks.includes('template'),
+        script: data.blocks.includes('script'),
+        style: data.blocks.includes('style')
+      }
+    }]
+
+    return actions
+  }
+}

--- a/plop-templates/ADempiere/store/index.hbs
+++ b/plop-templates/ADempiere/store/index.hbs
@@ -1,0 +1,16 @@
+const {{name}} = {
+	{{#if state}}
+	state: {},
+	{{/if}}
+	{{#if mutations}}
+	mutations: {},
+	{{/if}}
+	{{#if actions}}
+	actions: {},
+	{{/if}}
+	{{#if getters}}
+	getters: {}
+	{{/if}}
+}
+
+export default {{name}}

--- a/plop-templates/ADempiere/store/index.hbs
+++ b/plop-templates/ADempiere/store/index.hbs
@@ -1,16 +1,22 @@
 const {{name}} = {
-	{{#if state}}
-	state: {},
-	{{/if}}
-	{{#if mutations}}
-	mutations: {},
-	{{/if}}
-	{{#if actions}}
-	actions: {},
-	{{/if}}
-	{{#if getters}}
-	getters: {}
-	{{/if}}
+  {{#if state}}
+  state: {
+    {{name}}: {}
+  },
+  {{/if}}
+  {{#if mutations}}
+  mutations: {},
+  {{/if}}
+  {{#if actions}}
+  actions: {},
+  {{/if}}
+  {{#if getters}}
+  getters: {
+    get{{name}}: (state) => {
+      return state.{{name}}
+    }
+  }
+  {{/if}}
 }
 
 export default {{name}}

--- a/plop-templates/ADempiere/store/prompt.js
+++ b/plop-templates/ADempiere/store/prompt.js
@@ -1,0 +1,61 @@
+const { notEmpty } = require('../../utils.js')
+
+module.exports = {
+  description: 'Generate a ADempiere Store Module',
+  prompts: [{
+    type: 'input',
+    name: 'name',
+    message: 'ADempiere Store Module name: ',
+    validate: notEmpty('name')
+  },
+  {
+    type: 'checkbox',
+    name: 'blocks',
+    message: 'Blocks:',
+    choices: [{
+      name: 'state',
+      value: 'state',
+      checked: true
+    },
+    {
+      name: 'mutations',
+      value: 'mutations',
+      checked: true
+    },
+    {
+      name: 'actions',
+      value: 'actions',
+      checked: true
+    },
+    {
+      name: 'getters',
+      value: 'getters',
+      checked: true
+    }
+    ],
+    validate(value) {
+      if (value.indexOf('state') === -1 && value.indexOf('mutations') === -1) {
+        return 'Store Module require at least a state or mutations.'
+      }
+      return true
+    }
+  }
+  ],
+  actions: data => {
+    const name = '{{name}}'
+    const actions = [{
+      type: 'add',
+      path: `src/store/modules/ADempiere/${name}.js`,
+      templateFile: 'plop-templates/store/index.hbs',
+      data: {
+        name: name,
+        state: data.blocks.includes('state'),
+        mutations: data.blocks.includes('mutations'),
+        actions: data.blocks.includes('actions'),
+        getters: data.blocks.includes('getters')
+      }
+    }]
+
+    return actions
+  }
+}

--- a/plop-templates/ADempiere/store/prompt.js
+++ b/plop-templates/ADempiere/store/prompt.js
@@ -46,7 +46,7 @@ module.exports = {
     const actions = [{
       type: 'add',
       path: `src/store/modules/ADempiere/${name}.js`,
-      templateFile: 'plop-templates/store/index.hbs',
+      templateFile: 'plop-templates/ADempiere/store/index.hbs',
       data: {
         name: name,
         state: data.blocks.includes('state'),

--- a/plop-templates/ADempiere/view/index.hbs
+++ b/plop-templates/ADempiere/view/index.hbs
@@ -1,0 +1,27 @@
+{{#if template}}
+<template>
+  <div />
+</template>
+{{/if}}
+
+{{#if script}}
+<script>
+export default {
+  name: '{{ properCase name }}',
+  props: {},
+  data() {
+    return {}
+  },
+  computed: {},
+  created() {},
+  mounted() {},
+  methods: {}
+}
+</script>
+{{/if}}
+
+{{#if style}}
+<style lang="scss" scoped>
+
+</style>
+{{/if}}

--- a/plop-templates/ADempiere/view/prompt.js
+++ b/plop-templates/ADempiere/view/prompt.js
@@ -1,0 +1,55 @@
+const { notEmpty } = require('../../utils.js')
+
+module.exports = {
+  description: 'Generate a ADempiere View',
+  prompts: [{
+    type: 'input',
+    name: 'name',
+    message: 'ADempiere View name: ',
+    validate: notEmpty('name')
+  },
+  {
+    type: 'checkbox',
+    name: 'blocks',
+    message: 'Blocks:',
+    choices: [{
+      name: '<template>',
+      value: 'template',
+      checked: true
+    },
+    {
+      name: '<script>',
+      value: 'script',
+      checked: true
+    },
+    {
+      name: 'style',
+      value: 'style',
+      checked: true
+    }
+    ],
+    validate(value) {
+      if (value.indexOf('script') === -1 && value.indexOf('template') === -1) {
+        return 'View require at least a <script> or <template> tag.'
+      }
+      return true
+    }
+  }
+  ],
+  actions: data => {
+    const name = '{{name}}'
+    const actions = [{
+      type: 'add',
+      path: `src/views/ADempiere/${name}/index.vue`,
+      templateFile: 'plop-templates/view/index.hbs',
+      data: {
+        name: name,
+        template: data.blocks.includes('template'),
+        script: data.blocks.includes('script'),
+        style: data.blocks.includes('style')
+      }
+    }]
+
+    return actions
+  }
+}

--- a/plopfile.js
+++ b/plopfile.js
@@ -1,7 +1,13 @@
 const viewGenerator = require('./plop-templates/view/prompt')
 const componentGenerator = require('./plop-templates/component/prompt')
+const ADempiereView = require('./plop-templates/ADempiere/view/prompt')
+const ADempiereComponent = require('./plop-templates/ADempiere/component/prompt')
+const ADempiereStore = require('./plop-templates/ADempiere/store/prompt')
 
 module.exports = function(plop) {
   plop.setGenerator('view', viewGenerator)
   plop.setGenerator('component', componentGenerator)
+  plop.setGenerator('ADempiere View', ADempiereView)
+  plop.setGenerator('ADempiere Component', ADempiereComponent)
+  plop.setGenerator('ADempiere Store Module', ADempiereStore)
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Documentation content changes
- [x] Other, please describe: File templates.

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, not the `master` branch
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your `master` branch!
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

## Description
Hello everyone, in this PR has been added new plop templates for make easy new Components, Store Modules and Views files in ADempiere vue. 


### Screenshots
<!-- A picture tells a thousand words -->
 **Before this PR**
![Screenshot_20200220_162254](https://user-images.githubusercontent.com/23490674/74975567-a3e8dd80-53fd-11ea-9100-f7a6da30bf24.png)

**After this PR**
![Screenshot_20200220_162200](https://user-images.githubusercontent.com/23490674/74975587-a9debe80-53fd-11ea-979e-460f57838ae9.png)
