### PR TITLE
fix: #356 Display logic field when set empty value in parent field.

### DIFF
--- a/src/components/ADempiere/Field/index.vue
+++ b/src/components/ADempiere/Field/index.vue
@@ -5,7 +5,7 @@
     <el-col></el-col> container-->
   <el-col
     v-if="!inTable"
-    v-show="isDisplayed()"
+    v-show="isDisplayed"
     key="is-panel-template"
     :xs="sizeFieldResponsive.xs"
     :sm="sizeFieldResponsive.sm"
@@ -19,7 +19,7 @@
     >
       <template slot="label">
         <field-operator-comparison
-          v-if="isAdvancedQuery && isDisplayed()"
+          v-if="isAdvancedQuery && isDisplayed"
           key="is-field-operator-comparison"
           :field-attributes="fieldAttributes"
           :field-value="field.value"
@@ -96,7 +96,7 @@ import FieldOperatorComparison from '@/components/ADempiere/Field/fieldPopovers/
 import FieldTranslated from '@/components/ADempiere/Field/fieldPopovers/fieldTranslated'
 import { FIELD_ONLY } from '@/components/ADempiere/Field/references'
 import { DEFAULT_SIZE } from '@/components/ADempiere/Field/fieldSize'
-import { fieldIsDisplayed } from '@/utils/ADempiere'
+import { fieldIsDisplayed } from '@/utils/ADempiere/dictionaryUtils'
 import { showMessage } from '@/utils/ADempiere/notification'
 import { recursiveTreeSearch } from '@/utils/ADempiere/valueUtils'
 
@@ -169,10 +169,16 @@ export default {
         // DOM properties
         required: this.isMandatory(),
         readonly: this.isReadOnly(),
-        displayed: this.isDisplayed(),
+        displayed: this.isDisplayed,
         disabled: !this.field.isActive,
         isSelectCreated: this.isSelectCreated
       }
+    },
+    isDisplayed() {
+      if (this.isAdvancedQuery) {
+        return this.field.isShowedFromUser
+      }
+      return fieldIsDisplayed(this.field) && (this.isMandatory() || this.field.isShowedFromUser || this.inTable)
     },
     isSelectCreated() {
       return this.isAdvancedQuery &&
@@ -195,7 +201,7 @@ export default {
       return false
     },
     sizeFieldResponsive() {
-      if (!this.isDisplayed()) {
+      if (!this.isDisplayed) {
         return DEFAULT_SIZE
       }
 
@@ -345,12 +351,6 @@ export default {
       })
       this.valueActionDocument = ''
     },
-    isDisplayed() {
-      if (this.isAdvancedQuery) {
-        return this.field.isShowedFromUser
-      }
-      return fieldIsDisplayed(this.field) && (this.isMandatory() || this.field.isShowedFromUser || this.inTable)
-    },
     isReadOnly() {
       if (this.isAdvancedQuery) {
         if (['NULL', 'NOT_NULL'].includes(this.field.operator)) {
@@ -421,7 +421,7 @@ export default {
       return Boolean(field)
     },
     focus(columnName) {
-      if (this.isDisplayed() && this.isMandatory() && !this.isReadOnly()) {
+      if (this.isDisplayed && this.isMandatory() && !this.isReadOnly()) {
         this.$refs[columnName].activeFocus(columnName)
       }
     },

--- a/src/store/modules/ADempiere/context.js
+++ b/src/store/modules/ADempiere/context.js
@@ -16,7 +16,7 @@ const context = {
      */
     setContext(state, payload) {
       let key = ''
-      if (payload.parentUuid && !isEmptyValue(payload.value)) {
+      if (payload.parentUuid) {
         key += payload.parentUuid + '|'
 
         // set context for window

--- a/src/store/modules/ADempiere/panel.js
+++ b/src/store/modules/ADempiere/panel.js
@@ -496,23 +496,22 @@ const panel = {
       // get field
       const field = fieldList.find(fieldItem => fieldItem.columnName === columnName)
 
-      if (!(isAdvancedQuery && ['IN', 'NOT_IN'].includes(field.operator))) {
-        newValue = parsedValueComponent({
-          fieldType: field.componentPath,
-          referenceType: field.referenceType,
-          value: newValue
-        })
-
-        if (field.isRange) {
-          valueTo = parsedValueComponent({
+      if (!(panelType === 'table' || isAdvancedQuery)) {
+        if (!['IN', 'NOT_IN'].includes(field.operator)) {
+          newValue = parsedValueComponent({
             fieldType: field.componentPath,
             referenceType: field.referenceType,
-            value: valueTo
+            value: newValue
           })
+          if (field.isRange) {
+            valueTo = parsedValueComponent({
+              fieldType: field.componentPath,
+              referenceType: field.referenceType,
+              value: valueTo
+            })
+          }
         }
-      }
 
-      if (!(panelType === 'table' || isAdvancedQuery)) {
         //  Call context management
         dispatch('setContext', {
           parentUuid,
@@ -555,9 +554,7 @@ const panel = {
               }
             })
         }
-      }
 
-      if (!isAdvancedQuery) {
         //  Change Dependents
         dispatch('changeDependentFieldsList', {
           parentUuid,

--- a/src/utils/ADempiere/evaluator.js
+++ b/src/utils/ADempiere/evaluator.js
@@ -120,7 +120,7 @@ class evaluator {
       })
       // in context exists this column name
       if (value === null || value === undefined) {
-        console.info(`.The column ${first} not exists in context.`)
+        // console.info(`.The column ${first} not exists in context.`)
         return _defaultUndefined
       }
       firstEval = value // replace with it's value
@@ -184,10 +184,6 @@ class evaluator {
       value2 = true
     } else if (value2 === 'N') {
       value2 = false
-    }
-
-    if ([value1, operand, value2].includes(null)) {
-      return false
     }
 
     let isValueLogic


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, not the `master` branch
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your `master` branch!
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number): #356 

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

## Description
<!-- Please describe your pull request. -->
Fix display logics that depend on other fields that are activated when a value is set and then this value is set as empty.

### Screenshots
<!-- A picture tells a thousand words -->
 **Before this PR**
![Peek 20-02-2020 18-09](https://user-images.githubusercontent.com/20288327/74985890-c8998100-540e-11ea-8236-9431fa5d2351.gif)

**After this PR**
![Peek 20-02-2020 18-11](https://user-images.githubusercontent.com/20288327/74985895-cb947180-540e-11ea-9c31-82d4710f7d4e.gif)
