### PR TITLE
feat: Service routes are supported instead of individual ports.

### DIFF
--- a/src/api/ADempiere/constants.js
+++ b/src/api/ADempiere/constants.js
@@ -1,14 +1,11 @@
 
 export const ADDRESS_HOST = 'http://localhost'
+export const PROXY_PORT = '8989'
 
-export const PORT_DICTIONARY = '8990'
-export const HOST_GRPC_DICTIONARY = ADDRESS_HOST + ':' + PORT_DICTIONARY
+export const DICTIONARY_ADDRESS = `${ADDRESS_HOST}:${PROXY_PORT}/dictionary`
 
-export const PORT_DATA = '8991'
-export const HOST_GRPC_DATA = ADDRESS_HOST + ':' + PORT_DATA
+export const BUSINESS_DATA_ADDRESS = `${ADDRESS_HOST}:${PROXY_PORT}/businessdata`
 
-export const PORT_AUTHENTICATION = '8989'
-export const HOST_GRPC_AUTHENTICATION = ADDRESS_HOST + ':' + PORT_AUTHENTICATION
+export const ACCESS_ADDRESS = `${ADDRESS_HOST}:${PROXY_PORT}/access`
 
-export const PORT_ENROLLMENT = '8992'
-export const HOST_GRPC_ENROLLMENT = ADDRESS_HOST + ':' + PORT_ENROLLMENT
+export const ENROLLMENT_ADDRESS = `${ADDRESS_HOST}:${PROXY_PORT}/enrollment`

--- a/src/api/ADempiere/data.js
+++ b/src/api/ADempiere/data.js
@@ -1,12 +1,12 @@
 import { getLanguage } from '@/lang/index'
 import { getToken } from '@/utils/auth'
 import BusinessData from '@adempiere/grpc-data-client'
-import { HOST_GRPC_DATA } from '@/api/ADempiere/constants'
+import { BUSINESS_DATA_ADDRESS } from '@/api/ADempiere/constants'
 
 // Get Instance for connection
 function Instance() {
   return new BusinessData(
-    HOST_GRPC_DATA,
+    BUSINESS_DATA_ADDRESS,
     getToken(),
     getLanguage() || 'en_US'
   )

--- a/src/api/ADempiere/dictionary.js
+++ b/src/api/ADempiere/dictionary.js
@@ -1,12 +1,12 @@
 import { getLanguage } from '@/lang/index'
 import { getToken } from '@/utils/auth'
 import Dictionary from '@adempiere/grpc-dictionary-client'
-import { HOST_GRPC_DICTIONARY } from '@/api/ADempiere/constants'
+import { DICTIONARY_ADDRESS } from '@/api/ADempiere/constants'
 
 // Get Instance for connection
 function Instance() {
   return new Dictionary(
-    HOST_GRPC_DICTIONARY,
+    DICTIONARY_ADDRESS,
     getToken(),
     getLanguage() || 'en_US'
   )

--- a/src/api/ADempiere/enrollment.js
+++ b/src/api/ADempiere/enrollment.js
@@ -1,12 +1,12 @@
 import Enrollment from '@adempiere/grpc-enrollment-client'
-import { HOST_GRPC_ENROLLMENT } from '@/api/ADempiere/constants'
+import { ENROLLMENT_ADDRESS } from '@/api/ADempiere/constants'
 
 // Get Instance for connection
 function Instance() {
   return new Enrollment(
-    HOST_GRPC_ENROLLMENT,
+    ENROLLMENT_ADDRESS,
     3.9,
-    'ADempier-Vue'
+    'ADempiere-Vue'
   )
 }
 

--- a/src/api/user.js
+++ b/src/api/user.js
@@ -1,11 +1,11 @@
 import { getLanguage } from '@/lang/index'
 import Access from '@adempiere/grpc-access-client'
-import { HOST_GRPC_AUTHENTICATION } from '@/api/ADempiere/constants'
+import { ACCESS_ADDRESS } from '@/api/ADempiere/constants'
 
 // Instance for connection
 function Instance() {
   return new Access(
-    HOST_GRPC_AUTHENTICATION,
+    ACCESS_ADDRESS,
     'Version Epale',
     getLanguage() || 'en_US'
   )


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

This change when changing the routes of the services, must be updated the proxy that is used, by default the envoy-proxy from this change https://github.com/erpcya/gRPC-Envoy-Proxy/pull/7


**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, not the `master` branch
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your `master` branch!
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

## Description
<!-- Please describe your pull request. -->
A rupture change is introduced. Prior to this PR the different services are accessed in the following way by default:

* Access: `localhost:8989`
* Dictionary: `localhost:8990`
* Business Data: `localhost:8991`
* Enrollment: `localhost:8992`

With this PR it is not necessary to use 4 different ports, you can access from a single port using routes for each service, by default it is as follows:

* Access: `localhost:8989/access`
* Dictionary: `localhost:8989/dictionary`
* Business Data: `localhost:8989/businessdata`
* Enrollment: `localhost:8989/enrollment`

### Screenshots
<!-- A picture tells a thousand words -->
 **Before this PR**
At the moment to obtain the session make the request to the route `http://localhost:8989/access.AccessService/GetSession` and to obtain the list of languages make the request on the route `http://localhost:8991/data.BusinessDataService/ListLanguages` both in different ports
![Peek 25-02-2020 11-40](https://user-images.githubusercontent.com/20288327/75263063-d4e15d80-57c3-11ea-877e-b3ffe3fa14ba.gif)

**After this PR**
As you can see the request is made for the session on the route `http://localhost:8989/access/access.AccessService/GetSession` to obtain the list of languages make the request on the route `http://localhost:8989/businessdata/data.BusinessDataService/ListLanguages`. In the same port but with different route prefixes.
![Peek 25-02-2020 11-36](https://user-images.githubusercontent.com/20288327/75263079-dd399880-57c3-11ea-910e-36b6305f5d50.gif)
