### PR TITLE
Does not sort the field list of the child tabs on every render.

### DIFF
--- a/src/components/ADempiere/DataTable/index.vue
+++ b/src/components/ADempiere/DataTable/index.vue
@@ -165,7 +165,7 @@
               fixed
               min-width="50"
             />
-            <template v-for="(fieldAttributes, key) in fieldList">
+            <template v-for="(fieldAttributes, key) in fieldsList">
               <el-table-column
                 v-if="isDisplayed(fieldAttributes)"
                 :key="key"
@@ -445,12 +445,20 @@ export default {
       }
       return this.getterHeight - 300 - totalRow
     },
-    fieldList() {
+    fieldsList() {
       if (this.getterPanel && this.getterPanel.fieldList) {
-        return this.sortFields(
-          this.getterPanel.fieldList,
-          this.panelType !== 'browser' ? 'seqNoGrid' : 'sequence'
-        )
+        if ((this.panelType === 'window' && this.isParent) || this.panelType === 'browser') {
+          let orderBy = 'seqNoGrid'
+          if (this.panelType === 'browser') {
+            orderBy = 'sequence'
+          }
+
+          return this.sortFields({
+            fieldsList: this.getterPanel.fieldList,
+            orderBy
+          })
+        }
+        return this.getterPanel.fieldList
       }
       return []
     },
@@ -727,7 +735,7 @@ export default {
         this.$store.dispatch('addNewRow', {
           parentUuid: this.parentUuid,
           containerUuid: this.containerUuid,
-          fieldList: this.fieldList,
+          fieldList: this.fieldsList,
           isEdit: true,
           isSendServer: false
         })
@@ -744,7 +752,7 @@ export default {
     },
     async setFocus() {
       return new Promise(resolve => {
-        const fieldFocus = this.fieldList.find(itemField => {
+        const fieldFocus = this.fieldsList.find(itemField => {
           if (this.$refs.hasOwnProperty(itemField.columnName)) {
             if (fieldIsDisplayed(itemField) && !itemField.isReadOnly && itemField.isUpdateable) {
               return true
@@ -939,7 +947,7 @@ export default {
         }).then(response => {
           this.isLoadPanelFromServer = true
         }).catch(error => {
-          console.warn(`FieldList Load Error ${error.code}: ${error.message}.`)
+          console.warn(`Fields List Load Error ${error.code}: ${error.message}.`)
         })
       }
     },
@@ -959,7 +967,7 @@ export default {
           sums[index] = 'Σ'
           return
         }
-        const field = this.fieldList.find(field => field.columnName === columnItem.property)
+        const field = this.fieldsList.find(field => field.columnName === columnItem.property)
         if (!FIELDS_QUANTITY.includes(field.referenceType)) {
           sums[index] = ''
           return

--- a/src/components/ADempiere/DataTable/menu/menuTableMixin.js
+++ b/src/components/ADempiere/DataTable/menu/menuTableMixin.js
@@ -2,7 +2,6 @@ import { supportedTypes, exportFileFromJson, exportFileZip } from '@/utils/ADemp
 import { showNotification } from '@/utils/ADempiere/notification'
 import { recursiveTreeSearch } from '@/utils/ADempiere/valueUtils'
 import { FIELDS_QUANTITY } from '@/components/ADempiere/Field/references'
-import { sortFields } from '@/utils/ADempiere/dictionaryUtils'
 
 export const menuTableMixin = {
   props: {
@@ -79,18 +78,9 @@ export const menuTableMixin = {
     getDataAllRecord() {
       return this.getterDataRecordsAndSelection.record
     },
-    fieldList() {
+    fieldsList() {
       if (this.panelMetadata && this.panelMetadata.fieldList) {
-        let sortAttribute = 'sequence'
-        if (this.panelType === 'browser') {
-          sortAttribute = 'seqNoGrid'
-        }
-        // TODO: Change to destructuring and add isParent attribure to change
-        // orderBy sequence value to seqNoGrid value if isParent is false
-        return this.sortFields(
-          this.panelMetadata.fieldList,
-          sortAttribute
-        )
+        return this.panelMetadata.fieldList
       }
       return []
     },
@@ -167,7 +157,6 @@ export const menuTableMixin = {
   },
   methods: {
     showNotification,
-    sortFields,
     closeMenu() {
       // TODO: Validate to dispatch one action
       this.$store.dispatch('showMenuTable', {
@@ -253,7 +242,7 @@ export const menuTableMixin = {
         this.$store.dispatch('addNewRow', {
           parentUuid: this.parentUuid,
           containerUuid: this.containerUuid,
-          fieldList: this.fieldList,
+          fieldList: this.fieldsList,
           isEdit: true,
           isSendServer: false
         })

--- a/src/store/modules/ADempiere/panel.js
+++ b/src/store/modules/ADempiere/panel.js
@@ -95,7 +95,15 @@ const panel = {
             }
           }
         })
-        params.fieldList = assignedGroup(params.fieldList)
+
+        let orderBy = 'sequence'
+        if ((params.panelType === 'window' && !params.isParent) || params.panelType === 'browser') {
+          orderBy = 'seqNoGrid'
+        }
+        params.fieldList = assignedGroup({
+          fieldsList: params.fieldList,
+          orderBy
+        })
       }
 
       params.keyColumn = keyColumn

--- a/src/utils/ADempiere/dictionaryUtils.js
+++ b/src/utils/ADempiere/dictionaryUtils.js
@@ -467,18 +467,21 @@ export function getFieldTemplate(attributesOverwrite) {
  * @param  {array} fieldList Field of List with
  * @return {array} fieldList
  */
-export function assignedGroup(fieldList, assignedGroup) {
-  if (fieldList === undefined || fieldList.length <= 0) {
-    return fieldList
+export function assignedGroup({ fieldsList, groupToAssigned, orderBy }) {
+  if (fieldsList === undefined || fieldsList.length <= 0) {
+    return fieldsList
   }
 
-  fieldList = sortFields(fieldList, 'sequence', 'asc', fieldList[0].panelType)
+  fieldsList = sortFields({
+    fieldsList,
+    orderBy
+  })
 
   let firstChangeGroup = false
   let currentGroup = ''
   let typeGroup = ''
 
-  fieldList.forEach(fieldElement => {
+  fieldsList.forEach(fieldElement => {
     if (fieldElement.panelType !== 'window') {
       fieldElement.groupAssigned = ''
       fieldElement.typeGroupAssigned = ''
@@ -507,12 +510,12 @@ export function assignedGroup(fieldList, assignedGroup) {
     fieldElement.groupAssigned = currentGroup
     fieldElement.typeGroupAssigned = typeGroup
 
-    if (assignedGroup !== undefined) {
-      fieldElement.groupAssigned = assignedGroup
+    if (groupToAssigned !== undefined) {
+      fieldElement.groupAssigned = groupToAssigned
     }
   })
 
-  return fieldList
+  return fieldsList
 }
 
 /**
@@ -524,18 +527,26 @@ export function assignedGroup(fieldList, assignedGroup) {
  * @param {string} panelType
  * @returns {array}
  */
-export function sortFields(arr, orderBy = 'sequence', type = 'asc', panelType = 'window') {
-  if (panelType === 'browser') {
-    orderBy = 'seqNoGrid'
+export function sortFields({
+  fieldsList,
+  orderBy = 'sequence',
+  type = 'asc'
+}) {
+  if (type.toLowerCase() === 'asc') {
+    fieldsList.sort((itemA, itemB) => {
+      return itemA[orderBy] - itemB[orderBy]
+      // return itemA[orderBy] > itemB[orderBy]
+    })
+  } else {
+    fieldsList.sort((itemA, itemB) => {
+      return itemA[orderBy] + itemB[orderBy]
+      // return itemA[orderBy] > itemB[orderBy]
+    })
   }
-  arr.sort((itemA, itemB) => {
-    return itemA[orderBy] - itemB[orderBy]
-    // return itemA[orderBy] > itemB[orderBy]
-  })
-  if (type.toLowerCase() === 'desc') {
-    return arr.reverse()
-  }
-  return arr
+  // if (type.toLowerCase() === 'desc') {
+  //   return fieldsList.reverse()
+  // }
+  return fieldsList
 }
 
 /**


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Documentation content changes
- [x] Other, please describe: Improve

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, not the `master` branch
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your `master` branch!
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

## Description
<!-- Please describe your pull request. -->
When loading from the server the fields of the default child tabs were sorted and stored in the store with the sequence attribute, however this is only necessary if they are loaded in the main panel. When loading them in the tables for the windows, it requires a sorting with the seqNoGrid attribute, with this change the child tabs now sort and store with this attribute by default and so it is not necessary to sort again the list of fields in each table render.
