### PR TITLE
feat: Add support to environment variables.

### DIFF
--- a/src/api/ADempiere/constants.js
+++ b/src/api/ADempiere/constants.js
@@ -1,11 +1,13 @@
 
-export const ADDRESS_HOST = 'http://localhost'
-export const PROXY_PORT = '8989'
+const proxyAddress = process.env.VUE_APP_PROXY_ADDRESS || 'localhost'
+const proxyPort = process.env.VUE_APP_PROXY_PORT || '8989'
 
-export const DICTIONARY_ADDRESS = `${ADDRESS_HOST}:${PROXY_PORT}/dictionary`
+export const API_ADDRESS = `http://${proxyAddress}:${proxyPort}`
 
-export const BUSINESS_DATA_ADDRESS = `${ADDRESS_HOST}:${PROXY_PORT}/businessdata`
+export const ACCESS_ADDRESS = `${API_ADDRESS}/access`
 
-export const ACCESS_ADDRESS = `${ADDRESS_HOST}:${PROXY_PORT}/access`
+export const DICTIONARY_ADDRESS = `${API_ADDRESS}/dictionary`
 
-export const ENROLLMENT_ADDRESS = `${ADDRESS_HOST}:${PROXY_PORT}/enrollment`
+export const BUSINESS_DATA_ADDRESS = `${API_ADDRESS}/businessdata`
+
+export const ENROLLMENT_ADDRESS = `${API_ADDRESS}/enrollment`


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, not the `master` branch
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your `master` branch!
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

## Description
<!-- Please describe your pull request. -->
Add support for environment variables

This is useful for deploying docker containers without having to edit the connection files to the gRPC API, but their values are easily replaced when the following environment variables are present:

`VUE_APP_PROXY_ADDRESS` = sets the address or domain of the proxy, it must not contain the web protocols `http://` or `https://`, default value `localhost`.
`VUE_APP_PROXY_PORT` = Sets the number of the port from which you access the proxy, default value `8989`.


Note: The VUE_APP_ prefix is required in the names of the environment variables so that they can be integrated via webpack, and their value can be obtained.