### PR TITLE
fix: Request document statuses only window is document

### DIFF
--- a/src/components/ADempiere/Panel/index.vue
+++ b/src/components/ADempiere/Panel/index.vue
@@ -615,7 +615,7 @@ export default {
       return groupsList
     },
     setTagsViewTitle(actionValue) {
-      if (!this.isEmptyValue(this.$route.params.recordId)) {
+      if (!this.isEmptyValue(this.$route.params.recordId) && this.getterPanel.isDocument) {
         this.$store.dispatch('listDocumentStatus', {
           recordUuid: this.$route.query.action,
           recordId: this.$route.params.recordId

--- a/src/store/modules/ADempiere/contextMenu.js
+++ b/src/store/modules/ADempiere/contextMenu.js
@@ -60,29 +60,31 @@ const contextMenu = {
       documentAction,
       documentStatus
     }) {
-      requestListDocumentActions({
-        tableName,
-        recordId,
-        recordUuid,
-        documentAction,
-        documentStatus,
-        pageSize: 0,
-        pageToken: ''
-      })
-        .then(responseDocumentActios => {
-          const documentAction = {
-            defaultDocumentAction: responseDocumentActios.defaultDocumentAction,
-            documentActionsList: responseDocumentActios.documentActionsList,
-            recordId,
-            recordUuid
-          }
+      return new Promise(resolve => {
+        requestListDocumentActions({
+          tableName,
+          recordId,
+          recordUuid,
+          documentAction,
+          documentStatus,
+          pageSize: 0,
+          pageToken: ''
+        })
+          .then(responseDocumentActios => {
+            const documentAction = {
+              defaultDocumentAction: responseDocumentActios.defaultDocumentAction,
+              documentActionsList: responseDocumentActios.documentActionsList,
+              recordId,
+              recordUuid
+            }
 
-          commit('listDocumentAction', documentAction)
-          return documentAction
-        })
-        .catch(error => {
-          console.warn(error)
-        })
+            commit('listDocumentAction', documentAction)
+            resolve(documentAction)
+          })
+          .catch(error => {
+            console.warn(`Error getting document action list. Code ${error.code}: ${error.message}.`)
+          })
+      })
     },
     listDocumentStatus({ commit }, {
       tableName = 'C_Order',
@@ -91,27 +93,29 @@ const contextMenu = {
       documentAction,
       documentStatus
     }) {
-      requestListDocumentStatuses({
-        tableName,
-        recordId,
-        recordUuid,
-        documentAction,
-        documentStatus,
-        pageSize: 0,
-        pageToken: ''
+      return new Promise(resolve => {
+        requestListDocumentStatuses({
+          tableName,
+          recordId,
+          recordUuid,
+          documentAction,
+          documentStatus,
+          pageSize: 0,
+          pageToken: ''
+        })
+          .then(responseDocumentStatus => {
+            const documentStatus = {
+              documentActionsList: responseDocumentStatus.documentStatusesList,
+              recordId,
+              recordUuid
+            }
+            commit('addlistDocumentStatus', documentStatus)
+            resolve(documentStatus)
+          })
+          .catch(error => {
+            console.warn(`Error getting document statuses list. Code ${error.code}: ${error.message}.`)
+          })
       })
-        .then(responseDocumentStatus => {
-          const documentStatus = {
-            documentActionsList: responseDocumentStatus.documentStatusesList,
-            recordId,
-            recordUuid
-          }
-          commit('addlistDocumentStatus', documentStatus)
-          return documentStatus
-        })
-        .catch(error => {
-          console.warn(error)
-        })
     }
   },
   getters: {
@@ -131,10 +135,10 @@ const contextMenu = {
       const menu = state.contextMenu.find(
         item => item.containerUuid === containerUuid
       )
-      if (menu === undefined) {
-        return menu
+      if (menu) {
+        return menu.actions
       }
-      return menu.actions
+      return menu
     },
     getListDocumentActions: (state) => {
       return state.listDocumentAction


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, not the `master` branch
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your `master` branch!
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

## Description
<!-- Please describe your pull request. -->
Unnecessary requests for List Document Statuses are made

This request should only be made when the panel has the isDocument attribute set to true, however it makes the request in all windows, generating an error in those in which the isDocument attribute is false

### Screenshots
<!-- A picture tells a thousand words -->
 **Before this PR**
![Peek 28-02-2020 17-15](https://user-images.githubusercontent.com/20288327/75588298-bba01180-5a4e-11ea-9ca2-5506077ef2e7.gif)

**After this PR**
![Peek 28-02-2020 17-17](https://user-images.githubusercontent.com/20288327/75588306-be9b0200-5a4e-11ea-86ed-c0a4ffa52034.gif)
