### PR TITLE
Show sequence options in the table menu

### DIFF
--- a/src/components/ADempiere/DataTable/index.vue
+++ b/src/components/ADempiere/DataTable/index.vue
@@ -326,10 +326,10 @@ export default {
   },
   computed: {
     getterContextMenu() {
-      const process = this.$store.getters.getContextMenu(this.containerUuid).actions
+      const process = this.$store.getters.getContextMenu(this.containerUuid)
       if (process) {
-        return process.filter(menu => {
-          if (menu.type === 'process') {
+        return process.actions.filter(menu => {
+          if (menu.type === 'process' || menu.type === 'application') {
             return menu
           }
         })

--- a/src/components/ADempiere/DataTable/menu/index.vue
+++ b/src/components/ADempiere/DataTable/menu/index.vue
@@ -26,7 +26,7 @@
         v-for="(process, key) in processMenu"
         v-show="isPanelWindow && processMenu"
         :key="key"
-        :disabled="Boolean(getDataSelection.length < 1)"
+        :disabled="process.type === 'application' ? false : Boolean(getDataSelection.length < 1)"
         index="process"
         @click="showModalTable(process)"
       >

--- a/src/components/ADempiere/DataTable/menu/index.vue
+++ b/src/components/ADempiere/DataTable/menu/index.vue
@@ -28,7 +28,7 @@
         :key="key"
         :disabled="process.type === 'application' ? false : Boolean(getDataSelection.length < 1)"
         index="process"
-        @click="showModalTable(process)"
+        @click="process.type === 'application' ? sortTab(process) : showModalTable(process)"
       >
         {{ process.name }}
       </el-menu-item>

--- a/src/components/ADempiere/DataTable/menu/menuTableMixin.js
+++ b/src/components/ADempiere/DataTable/menu/menuTableMixin.js
@@ -157,6 +157,14 @@ export const menuTableMixin = {
   },
   methods: {
     showNotification,
+    sortTab(actionSequence) {
+      // TODO: Refactor and remove redundant dispatchs
+      this.$store.dispatch('setShowDialog', {
+        type: 'window',
+        action: actionSequence,
+        parentRecordUuid: this.$route.query.action
+      })
+    },
     closeMenu() {
       // TODO: Validate to dispatch one action
       this.$store.dispatch('showMenuTable', {

--- a/src/store/modules/ADempiere/window.js
+++ b/src/store/modules/ADempiere/window.js
@@ -197,7 +197,9 @@ const window = {
               parentTabs.push(tab)
               return tab
             }
-            childrenTabs.push(tab)
+            if (!tab.isSortTab) {
+              childrenTabs.push(tab)
+            }
             return tab
           })
 


### PR DESCRIPTION
Hello! The problem of the sequence tabs was solved, removed from view and now appears as options in the table menu
- _**ADempiere-Vue**_
![tabsequencia](https://user-images.githubusercontent.com/45974454/75822676-bb698400-5d76-11ea-8112-9498af1a88f9.gif)
