### PR TITLE
fix: Default values that are @SQL= on the first load

### DIFF
--- a/src/api/ADempiere/data.js
+++ b/src/api/ADempiere/data.js
@@ -13,15 +13,6 @@ function Instance() {
 }
 
 /**
- * Converted the gRPC value to the value needed
- * @param {object} grpcValue Value get of gRPC
- * @returns {mixed}
- */
-export function convertValueFromGRPC(grpcValue) {
-  return Instance.call(this).convertValueFromGRPC(grpcValue)
-}
-
-/**
  * Create entity
  * @param {string}  parameters.tableName
  * @param {array}   parameters.attributesList
@@ -213,13 +204,13 @@ export function runProcess({ uuid, reportType, tableName, recordId, parameters: 
  * @param {string} whereClause
  * @param {string} orderByClause
  * @param {string} nextPageToken
- * @param {array}  parameters, This allows follow structure:
+ * @param {array}  parametersList, This allows follow structure:
  * [{
  *     columnName,
  *     value
  * }]
  */
-export function getBrowserSearch({ uuid, parameters: parametersList = [], query, whereClause, orderByClause, nextPageToken: pageToken, pageSize }) {
+export function getBrowserSearch({ uuid, parametersList = [], query, whereClause, orderByClause, nextPageToken: pageToken, pageSize }) {
   //  Run browser
   return Instance.call(this).requestListBrowserSearch({
     uuid,

--- a/src/components/ADempiere/Field/FieldMixin.js
+++ b/src/components/ADempiere/Field/FieldMixin.js
@@ -7,7 +7,7 @@ export const fieldMixin = {
     },
     // value received from data result
     valueModel: {
-      type: [String, Number, Boolean, Date, Array],
+      type: [String, Number, Boolean, Date, Array, Object],
       default: null
     }
   },
@@ -37,6 +37,16 @@ export const fieldMixin = {
     */
     isDisabled() {
       return Boolean(this.metadata.readonly || this.metadata.disabled)
+    }
+  },
+  async created() {
+    if (this.metadata.isSQLValue && (this.isEmptyValue(this.metadata.value) || this.metadata.value.isSQL || isNaN(this.metadata.value))) {
+      const value = await this.$store.dispatch('getValueBySQL', {
+        parentUuid: this.metadata.parentUuid,
+        containerUuid: this.metadata.containerUuid,
+        query: this.metadata.defaultValue
+      })
+      this.preHandleChange(value)
     }
   },
   methods: {

--- a/src/store/modules/ADempiere/browser.js
+++ b/src/store/modules/ADempiere/browser.js
@@ -16,8 +16,12 @@ const browser = {
     dictionaryResetCacheBrowser(state) {
       state.browser = []
     },
-    changeBrowser(state, payload) {
-      payload.browser = payload.newBrowser
+    changeBrowserAttribute(state, payload) {
+      let value = payload.attributeValue
+      if (payload.attributeNameControl) {
+        value = payload.browser[payload.attributeNameControl]
+      }
+      payload.browser[payload.attributeName] = value
     }
   },
   actions: {
@@ -41,7 +45,8 @@ const browser = {
 
             //  Convert from gRPC
             const fieldsRangeList = []
-            let isMandatoryParams = false
+            let isShowedCriteria = false
+            let awaitForValues = 0
             let fieldsList = browserResponse.fieldsList.map((fieldItem, index) => {
               const someAttributes = {
                 ...additionalAttributes,
@@ -65,24 +70,29 @@ const browser = {
                 fieldsRangeList.push(fieldRange)
               }
 
-              if ((query.includes(`@${field.columnName}@`) ||
-                query.includes(`@${field.columnName}_To@`) ||
-                whereClause.includes(`@${field.columnName}@`) ||
-                whereClause.includes(`@${field.columnName}_To@`)) &&
-                field.isQueryCriteria) {
-                field.isMandatory = true
-                field.isMandatoryFromLogic = true
-                field.isShowedFromUser = true
-              }
-
               // Only isQueryCriteria fields with values, displayed in main panel
               if (field.isQueryCriteria) {
+                if (field.isSQLValue) {
+                  isShowedCriteria = true
+                  field.isShowedFromUser = true
+                  awaitForValues++
+                }
+                if (query.includes(`@${field.columnName}@`) ||
+                  query.includes(`@${field.columnName}_To@`) ||
+                  whereClause.includes(`@${field.columnName}@`) ||
+                  whereClause.includes(`@${field.columnName}_To@`)) {
+                  field.isMandatory = true
+                  field.isMandatoryFromLogic = true
+                  field.isShowedFromUser = true
+                }
+
                 if (isEmptyValue(field.value)) {
                   // isMandatory params to showed search criteria
                   if (field.isMandatory || field.isMandatoryFromLogic) {
-                    isMandatoryParams = true
+                    isShowedCriteria = true
                   }
                 } else {
+                  // with value
                   field.isShowedFromUser = true
                 }
               }
@@ -91,7 +101,7 @@ const browser = {
             })
             fieldsList = fieldsList.concat(fieldsRangeList)
 
-            //  Get dependent fields
+            // Get dependent fields
             fieldsList
               .filter(field => field.parentFieldsList && field.isActive)
               .forEach((field, index, list) => {
@@ -105,7 +115,7 @@ const browser = {
                 })
               })
 
-            //  Convert from gRPC process list
+            // Convert from gRPC process list
             const actions = []
             if (process) {
               actions.push({
@@ -126,7 +136,7 @@ const browser = {
               //   containerUuidAssociated: containerUuid
               // })
             }
-            //  Add process menu
+            // Add process menu
             dispatch('setContextMenu', {
               containerUuid,
               relations: [],
@@ -134,14 +144,16 @@ const browser = {
               references: []
             })
 
-            //  Panel for save on store
+            // Panel for save on store
             const newBrowser = {
               ...browserResponse,
               containerUuid,
               fieldList: fieldsList,
               panelType,
               // app attributes
-              isShowedCriteria: Boolean(fieldsList.length && isMandatoryParams),
+              awaitForValues, // control to values
+              awaitForValuesToQuery: awaitForValues, // get values from request search
+              isShowedCriteria,
               isShowedTotals: true
             }
 
@@ -165,16 +177,17 @@ const browser = {
       containerUuid,
       browser,
       attributeName,
+      attributeNameControl,
       attributeValue
     }) {
       if (isEmptyValue(browser)) {
         browser = getters.getBrowser(containerUuid)
       }
-      const newBrowser = browser
-      newBrowser[attributeName] = attributeValue
-      commit('changeBrowser', {
+      commit('changeBrowserAttribute', {
         browser,
-        newBrowser
+        attributeName,
+        attributeValue,
+        attributeNameControl
       })
     }
   },

--- a/src/store/modules/ADempiere/browserControl.js
+++ b/src/store/modules/ADempiere/browserControl.js
@@ -28,7 +28,7 @@ const browserControl = {
 
       const browser = rootGetters.getBrowser(containerUuid)
       // parameters isQueryCriteria
-      const finalParameters = rootGetters.getParametersToServer({
+      const parametersList = rootGetters.getParametersToServer({
         containerUuid,
         fieldList: browser.fieldList
       })
@@ -62,7 +62,7 @@ const browserControl = {
         query: parsedQuery,
         whereClause: parsedWhereClause,
         orderByClause: browser.orderByClause,
-        parameters: finalParameters,
+        parametersList,
         nextPageToken: nextPageToken
       })
         .then(browserSearchResponse => {

--- a/src/utils/ADempiere/contextUtils.js
+++ b/src/utils/ADempiere/contextUtils.js
@@ -63,7 +63,9 @@ export function getParentFields({ displayLogic, mandatoryLogic, readOnlyLogic, d
  * @param {string} parentUuid: (REQUIRED from Window) UUID Window
  * @param {string} containerUuid: (REQUIRED) UUID Tab, Process, SmartBrowser, Report and Form
  * @param {string} columnName: (Optional if exists in value) Column name to search in context
- * @param {boolean} isBooleanToString, convert boolean values to string
+ * @param {boolean} isBooleanToString, convert boolean values to string ('Y' or 'N')
+ * @param {boolean} isSQL
+ * @param {boolean} isSOTrxMenu
  */
 export function parseContext({
   parentUuid,
@@ -98,6 +100,12 @@ export function parseContext({
   var outString = ''
 
   let firstIndexTag = inString.indexOf('@')
+  const convertBooleanToString = (booleanValue) => {
+    if (booleanValue) {
+      return 'Y'
+    }
+    return 'N'
+  }
 
   while (firstIndexTag !== -1) {
     outString = outString + inString.substring(0, firstIndexTag) // up to @
@@ -122,12 +130,8 @@ export function parseContext({
       containerUuid,
       columnName
     }) // get context
-    if (isBooleanToString && typeof contextInfo === 'boolean') {
-      if (contextInfo) {
-        contextInfo = 'Y'
-      } else {
-        contextInfo = 'N'
-      }
+    if ((isBooleanToString || isSQL) && typeof contextInfo === 'boolean') {
+      contextInfo = convertBooleanToString(contextInfo)
     }
 
     if (isEmptyValue(contextInfo) &&
@@ -139,6 +143,9 @@ export function parseContext({
     // menu attribute isEmptyValue isSOTrx
     if (!isEmptyValue(isSOTrxMenu) && token === 'IsSOTrx' && isEmptyValue(contextInfo)) {
       contextInfo = isSOTrxMenu
+      if (isBooleanToString || isSQL) {
+        contextInfo = convertBooleanToString(contextInfo)
+      }
     }
     if (contextInfo === undefined || contextInfo.length === 0) {
       console.info(`No Context for: ${token}`)
@@ -160,16 +167,18 @@ export function parseContext({
   }
   if (isSQL) {
     return {
+      errorsList,
+      isError,
+      isSQL,
       query: outString,
-      value: contextInfo,
-      isSQL
+      value: contextInfo
     }
   }
   return {
-    value: outString,
-    isError,
     errorsList,
-    isSQL
+    isError,
+    isSQL,
+    value: outString
   }
 } // parseContext
 

--- a/src/utils/ADempiere/dictionaryUtils.js
+++ b/src/utils/ADempiere/dictionaryUtils.js
@@ -18,6 +18,7 @@ export function generateField({
   isSOTrxMenu
 }) {
   let isShowedFromUser = false
+  let isSQLValue = false
   // verify if it no overwrite value with ...moreAttributes
   if (moreAttributes.isShowedFromUser) {
     isShowedFromUser = moreAttributes.isShowedFromUser
@@ -75,6 +76,11 @@ export function generateField({
       isMandatory: fieldToGenerate.isMandatory
     })
 
+    if (String(fieldToGenerate.defaultValue).includes('@SQL=')) {
+      isShowedFromUser = true
+      isSQLValue = true
+    }
+
     // VALUE TO
     // if (String(parsedDefaultValueTo).includes('@SQL=')) {
     //   parsedDefaultValueTo.replace('@SQL=', '')
@@ -119,6 +125,7 @@ export function generateField({
   const field = {
     ...fieldToGenerate,
     ...moreAttributes,
+    isSOTrxMenu,
     // displayed attributes
     componentPath: componentReference.type,
     isSupport: componentReference.support,
@@ -142,6 +149,7 @@ export function generateField({
     isShowedFromUser,
     isShowedTableFromUser: fieldToGenerate.isDisplayed,
     isFixedTableColumn: false,
+    isSQLValue,
     // Advanced query
     operator, // current operator
     oldOperator: undefined, // old operator

--- a/src/utils/ADempiere/valueUtils.js
+++ b/src/utils/ADempiere/valueUtils.js
@@ -1,5 +1,3 @@
-import { convertValueFromGRPC } from '@/api/ADempiere/data'
-
 /**
  * Checks if value is empty. Deep-checks arrays and objects
  * Note: isEmpty([]) == true, isEmpty({}) == true,
@@ -10,7 +8,7 @@ import { convertValueFromGRPC } from '@/api/ADempiere/data'
 export function isEmptyValue(value) {
   if (value === undefined || value == null) {
     return true
-  } else if (value === -1 || String(value).trim() === '-1') {
+  } else if (String(value).trim() === '-1') {
     return true
   } else if (typeof value === 'string') {
     return Boolean(!value.trim().length)
@@ -134,41 +132,6 @@ export function convertArrayPairsToObject({
     result[element[nameKey]] = element[nameValue]
   })
 
-  return result
-}
-
-export function convertValuesMapToObject(map) {
-  var objectConverted = {}
-  map.forEach((value, key) => {
-    var valueResult = map.get(key)
-    var tempValue
-    if (valueResult) {
-      tempValue = convertValueFromGRPC(value)
-    }
-    objectConverted[key] = tempValue
-  })
-  return objectConverted
-}
-
-export function convertMapToArrayPairs({
-  toConvert,
-  nameKey = 'columnName',
-  nameValue = 'value',
-  isGRPC = true
-}) {
-  const result = []
-  if (toConvert) {
-    toConvert.forEach((value, key) => {
-      const element = {}
-      element[nameKey] = key
-      element[nameValue] = value
-      if (isGRPC) {
-        element[nameValue] = convertValueFromGRPC(value)
-      }
-
-      result.push(element)
-    })
-  }
   return result
 }
 

--- a/src/views/ADempiere/Browser/index.vue
+++ b/src/views/ADempiere/Browser/index.vue
@@ -112,7 +112,7 @@ export default {
       return this.$store.getters.getDataRecordsList(this.browserUuid)
     },
     getContainerIsReadyForSubmit() {
-      return !this.$store.getters.isNotReadyForSubmit(this.browserUuid)
+      return !this.$store.getters.isNotReadyForSubmit(this.browserUuid) && !this.browserMetadata.awaitForValuesToQuery
     },
     isMobile() {
       return this.$store.state.app.device === 'mobile'
@@ -128,6 +128,21 @@ export default {
         return 'content-help-mobile'
       }
       return 'content-help'
+    },
+    isShowedCriteria() {
+      if (this.getterBrowser) {
+        return this.getterBrowser.isShowedCriteria
+      }
+      return false
+    }
+  },
+  watch: {
+    isShowedCriteria(value) {
+      const activeSearch = []
+      if (value) {
+        activeSearch.push('opened-criteria')
+      }
+      this.activeSearch = activeSearch
     }
   },
   created() {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, not the `master` branch
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your `master` branch!
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

## Description
<!-- Please describe your pull request. -->
When the panel with the query criteria is first loaded in a SmartBrowser and there is a field that has a default value @SQL= it does not set the value, on the contrary an error was generated because the set value was an object

### Screenshots
<!-- A picture tells a thousand words -->
 **Before this PR**
![Peek 05-03-2020 18-32](https://user-images.githubusercontent.com/20288327/76032448-4e89f180-5f10-11ea-97d1-60429f335a80.gif)


**After this PR**
![Peek 05-03-2020 18-21](https://user-images.githubusercontent.com/20288327/76032437-49c53d80-5f10-11ea-954e-99bfb336c632.gif)

Note: This PR https://github.com/erpcya/gRPC-Data-Client/pull/57/ is needed for conversion of the double values.