### PR TITLE
fix #410 load data in tab childs after save record

### DIFF
--- a/src/components/ADempiere/Tab/tabChildren.vue
+++ b/src/components/ADempiere/Tab/tabChildren.vue
@@ -64,7 +64,7 @@ export default {
   },
   watch: {
     '$route.query.tabChild'(actionValue) {
-      if (this.isEmptyValue(actionValue) || actionValue === 'create-new') {
+      if (this.isEmptyValue(actionValue)) {
         this.currentTabChild = '0'
         return
       }
@@ -93,6 +93,9 @@ export default {
   },
   mounted() {
     this.setCurrentTabChild()
+    if (this.isReadyFromGetData) {
+      this.getDataTable()
+    }
   },
   methods: {
     setCurrentTabChild() {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, not the `master` branch
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your `master` branch!
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number). fix #410 

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

## Description
In the windows, after creating a new registry, if you unfold the child tabs they will be loading forever.

### Screenshots
<!-- A picture tells a thousand words -->
 **Before this PR**
![no-load-childs](https://user-images.githubusercontent.com/23490674/76792367-4a27c900-6799-11ea-942c-3024cc3157a5.gif)

**After this PR**
![load-childs](https://user-images.githubusercontent.com/23490674/76792376-50b64080-6799-11ea-9e67-2fcfe1afd74e.gif)
