### PR TITLE
fix: Run process notification without session

### DIFF
--- a/src/api/ADempiere/data.js
+++ b/src/api/ADempiere/data.js
@@ -176,15 +176,15 @@ export function getLookupList({
  * @param {number}  reportType
  * @param {number}  tableName, table name of tab, used only window
  * @param {number}  recordId, record identifier, used only window
- * @param {array}   parameters, parameters from process [{ columnName, value }]
- * @param {array}   selection, selection records, used only browser
+ * @param {array}   parametersList, parameters from process [{ columnName, value }]
+ * @param {array}   selectionsList, selection records, used only browser
       [{
           selectionId,
           selectionValues: [{ columnName, value }]
       }]
  * @param {string}  printFormatUuid
  */
-export function runProcess({ uuid, reportType, tableName, recordId, parameters: parametersList = [], selection: selectionsList = [], printFormatUuid }) {
+export function runProcess({ uuid, reportType, tableName, recordId, parametersList = [], selectionsList = [], printFormatUuid }) {
   //  Run Process
   return Instance.call(this).requestRunProcess({
     uuid,

--- a/src/components/ADempiere/ContextMenu/contextMenuMixin.js
+++ b/src/components/ADempiere/ContextMenu/contextMenuMixin.js
@@ -525,10 +525,7 @@ export const contextMixin = {
               }
               response.url = link.href
             }
-            this.$store.dispatch('finishProcess', {
-              processOutput: response,
-              routeToDelete: this.$route
-            })
+            this.$store.dispatch('finishProcess', response)
           })
       }
     },

--- a/src/components/ADempiere/ContextMenu/contextMenuMixin.js
+++ b/src/components/ADempiere/ContextMenu/contextMenuMixin.js
@@ -487,7 +487,7 @@ export const contextMixin = {
             })
         }
       } else if (action.type === 'updateReport') {
-        var updateReportParams = {
+        const updateReportParams = {
           instanceUuid: action.instanceUuid,
           processUuid: action.processUuid,
           tableName: action.tableName,
@@ -525,7 +525,9 @@ export const contextMixin = {
               }
               response.url = link.href
             }
-            this.$store.dispatch('finishProcess', response)
+            this.$store.dispatch('finishProcess', {
+              processOutput: response
+            })
           })
       }
     },

--- a/src/store/modules/ADempiere/processControl.js
+++ b/src/store/modules/ADempiere/processControl.js
@@ -6,6 +6,7 @@ import { showNotification } from '@/utils/ADempiere/notification'
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
 import language from '@/lang'
 import router from '@/router'
+import { getToken } from '@/utils/auth'
 
 const initStateProcessControl = {
   inExecution: [], // process not response from server
@@ -68,7 +69,7 @@ const processControl = {
     setReportValues(state, payload) {
       state.reportObject = payload
       if (state.reportList.some(report => report.instanceUuid === payload.instanceUuid)) {
-        var reportIndex = state.reportList.findIndex(report => report.instanceUuid === payload.instanceUuid)
+        const reportIndex = state.reportList.findIndex(report => report.instanceUuid === payload.instanceUuid)
         state.reportList.splice(reportIndex, 1, payload)
       } else {
         state.reportList.push(payload)
@@ -101,12 +102,25 @@ const processControl = {
   },
   actions: {
     // Supported Actions for it
-    startProcess({ commit, state, dispatch, getters, rootGetters }, params) {
+    startProcess({ commit, state, dispatch, getters, rootGetters }, {
+      parentUuid,
+      containerUuid,
+      panelType,
+      action,
+      parametersList,
+      reportFormat,
+      isProcessTableSelection,
+      isActionDocument,
+      tableNameUuidSelection,
+      recordUuidSelection,
+      menuParentUuid,
+      routeToDelete
+    }) {
       return new Promise((resolve, reject) => {
-        // TODO: Add support to evaluate params to send
-        // const samePocessInExecution = getters.getInExecution(params.containerUuid)
+        // TODO: Add support to evaluate parameters list to send
+        // const samePocessInExecution = getters.getInExecution(containerUuid)
         // exists some call to executed process with container uuid
-        // if (samePocessInExecution && !params.isProcessTableSelection) {
+        // if (samePocessInExecution && !isProcessTableSelection) {
         //   return reject({
         //     error: 0,
         //     message: `In this process (${samePocessInExecution.name}) there is already an execution in progress.`
@@ -117,11 +131,11 @@ const processControl = {
         let selection = []
         let allData = {}
         let tab, tableName, recordId
-        if (params.panelType) {
-          if (params.panelType === 'browser') {
-            allData = getters.getDataRecordAndSelection(params.containerUuid)
+        if (panelType) {
+          if (panelType === 'browser') {
+            allData = getters.getDataRecordAndSelection(containerUuid)
             selection = rootGetters.getSelectionToServer({
-              containerUuid: params.containerUuid,
+              containerUuid,
               selection: allData.selection
             })
             if (selection.length < 1) {
@@ -131,26 +145,24 @@ const processControl = {
               })
               return reject({
                 error: 0,
-                message: `Required selection data record to run this process (${params.action.name})`
+                message: `Required selection data record to run this process (${action.name})`
               })
             }
           }
-          if (params.panelType === 'window') {
+          if (panelType === 'window') {
             const contextMenu = getters.getRecordUuidMenu
-            if (params.isProcessTableSelection) {
-              tab = rootGetters.getTab(params.parentUuid, params.containerUuid)
-              tableName = params.tableNameUuidSelection
-              recordId = params.recordUuidSelection
+            tab = rootGetters.getTab(parentUuid, containerUuid)
+            if (isProcessTableSelection) {
+              tableName = tableNameUuidSelection
+              recordId = recordUuidSelection
             } else {
               if (contextMenu.processTable) {
-                tab = rootGetters.getTab(params.parentUuid, params.containerUuid)
                 tableName = contextMenu.tableName
                 recordId = contextMenu.valueRecord
               } else {
-                tab = rootGetters.getTab(params.parentUuid, params.containerUuid)
                 tableName = tab.tableName
                 const field = rootGetters.getFieldFromColumnName({
-                  containerUuid: params.containerUuid,
+                  containerUuid,
                   columnName: `${tableName}_ID`
                 })
                 recordId = field.value
@@ -159,29 +171,33 @@ const processControl = {
           }
         }
         // get info metadata process
-        const processDefinition = !isEmptyValue(params.isActionDocument) ? params.action : rootGetters.getProcess(params.action.uuid)
-        let reportType = params.reportFormat
+        const processDefinition = !isEmptyValue(isActionDocument) ? action : rootGetters.getProcess(action.uuid)
+        let reportType = reportFormat
         const finalParameters = rootGetters.getParametersToServer({ containerUuid: processDefinition.uuid })
 
-        showNotification({
-          title: language.t('notifications.processing'),
-          message: processDefinition.name,
-          summary: processDefinition.description,
-          type: 'info'
-        })
+        const isSession = !isEmptyValue(getToken())
+        if (isSession) {
+          showNotification({
+            title: language.t('notifications.processing'),
+            message: processDefinition.name,
+            summary: processDefinition.description,
+            type: 'info'
+          })
+        }
         const timeInitialized = (new Date()).getTime()
         let processResult
-        if (!isEmptyValue(params.isActionDocument)) {
+        if (!isEmptyValue(isActionDocument)) {
           processResult = {
             // panel attributes from where it was executed
-            parentUuid: params.parentUuid,
-            containerUuid: params.containerUuid,
-            panelType: params.panelType,
+            parentUuid,
+            containerUuid,
+            panelType,
             lastRun: timeInitialized,
-            processUuid: params.action.uuid,
-            processId: params.action.id,
+            processUuid: action.uuid,
+            processId: action.id,
             processName: 'Procesar Orden',
-            parameters: params.parametersList,
+            parameters: parametersList,
+            parametersList,
             isError: false,
             isProcessing: true,
             summary: '',
@@ -203,12 +219,12 @@ const processControl = {
           // uuid of process
           processResult = {
           // panel attributes from where it was executed
-            parentUuid: params.parentUuid,
-            containerUuid: params.containerUuid,
-            panelType: params.panelType,
-            menuParentUuid: params.menuParentUuid,
-            processIdPath: params.routeToDelete.path,
-            printFormatUuid: params.action.printFormatUuid,
+            parentUuid,
+            containerUuid,
+            panelType,
+            menuParentUuid,
+            processIdPath: routeToDelete.path,
+            printFormatUuid: action.printFormatUuid,
             // process attributes
             lastRun: timeInitialized,
             action: processDefinition.name,
@@ -237,25 +253,25 @@ const processControl = {
           }
         }
         commit('addInExecution', processResult)
-        if (params.panelType === 'window') {
+        if (panelType === 'window') {
           reportType = 'pdf'
-        } else if (params.panelType === 'browser') {
+        } else if (panelType === 'browser') {
           if (allData.record.length <= 100) {
             // close view if is browser.
             router.push({ path: '/dashboard' })
-            dispatch('tagsView/delView', params.routeToDelete)
+            dispatch('tagsView/delView', routeToDelete)
             // delete data associate to browser
             dispatch('deleteRecordContainer', {
-              viewUuid: params.containerUuid
+              viewUuid: containerUuid
             })
           }
         } else {
           // close view if is process, report.
           router.push({ path: '/dashboard' })
-          dispatch('tagsView/delView', params.routeToDelete)
+          dispatch('tagsView/delView', routeToDelete)
         }
-        if (params.isProcessTableSelection) {
-          var windowSelectionProcess = getters.getProcessSelect
+        if (isProcessTableSelection) {
+          const windowSelectionProcess = getters.getProcessSelect
           windowSelectionProcess.selection.forEach(selection => {
             Object.assign(processResult, {
               selection: selection.UUID,
@@ -267,9 +283,9 @@ const processControl = {
               runProcess({
                 uuid: processDefinition.uuid,
                 id: processDefinition.id,
-                reportType: reportType,
-                parameters: isEmptyValue(finalParameters) ? params.parametersList : finalParameters,
-                selection: selection,
+                reportType,
+                parametersList: isEmptyValue(finalParameters) ? parametersList : finalParameters,
+                selectionsList: selection,
                 tableName: windowSelectionProcess.tableName,
                 recordId: selection[windowSelectionProcess.tableName]
               })
@@ -414,17 +430,14 @@ const processControl = {
                   const countResponse = state.totalResponse + 1
                   commit('setTotalResponse', countResponse)
                   if (state.totalResponse === state.totalRequest) {
-                    // showNotification({
-                    //   title: language.t('notifications.succesful'),
-                    //   message: language.t('notifications.totalProcess') + countResponse + language.t('notifications.error') + state.errorSelection + language.t('notifications.succesful') + state.successSelection + language.t('notifications.processExecuted'),
-                    //   type: 'success'
-                    // })
-                    const processMessage = {
-                      title: language.t('notifications.succesful'),
-                      message: language.t('notifications.totalProcess') + countResponse + language.t('notifications.error') + state.errorSelection + language.t('notifications.succesful') + state.successSelection + language.t('notifications.processExecuted'),
-                      type: 'success'
+                    if (isSession) {
+                      showNotification({
+                        title: language.t('notifications.succesful'),
+                        message: language.t('notifications.totalProcess') + countResponse + language.t('notifications.error') + state.errorSelection + language.t('notifications.succesful') + state.successSelection + language.t('notifications.processExecuted'),
+                        type: 'success'
+                      })
                     }
-                    showNotification(processMessage)
+
                     commit('setTotalRequest', 0)
                     commit('setTotalResponse', 0)
                     commit('setSuccessSelection', 0)
@@ -438,7 +451,7 @@ const processControl = {
                   commit('addNotificationProcess', processResult)
                   commit('addStartedProcess', processResult)
                   commit('deleteInExecution', {
-                    containerUuid: params.containerUuid
+                    containerUuid
                   })
                 })
             }
@@ -448,8 +461,8 @@ const processControl = {
             uuid: processDefinition.uuid,
             id: processDefinition.id,
             reportType,
-            parameters: isEmptyValue(finalParameters) ? params.parametersList : finalParameters,
-            selection,
+            parametersList: isEmptyValue(finalParameters) ? parametersList : finalParameters,
+            selectionsList: selection,
             tableName,
             recordId
           })
@@ -529,7 +542,7 @@ const processControl = {
                       }
                     })
                 } else {
-                  var index = contextMenuMetadata.actions.findIndex(action => action.option === 'printFormat')
+                  const index = contextMenuMetadata.actions.findIndex(action => action.option === 'printFormat')
                   if (index !== -1) {
                     contextMenuMetadata.actions[index] = printFormatList
                   }
@@ -586,30 +599,27 @@ const processControl = {
             })
             .finally(() => {
               if (!processResult.isError) {
-                if (params.panelType === 'window') {
+                if (panelType === 'window') {
                   // TODO: Add conditional to indicate when update record
                   dispatch('updateRecordAfterRunProcess', {
-                    parentUuid: params.parentUuid,
-                    containerUuid: params.containerUuid,
-                    tab: tab
+                    parentUuid,
+                    containerUuid,
+                    tab
                   })
-                } else if (params.panelType === 'browser') {
+                } else if (panelType === 'browser') {
                   if (allData.record.length >= 100) {
                     dispatch('getBrowserSearch', {
-                      containerUuid: params.containerUuid
+                      containerUuid
                     })
                   }
                 }
               }
 
               commit('addNotificationProcess', processResult)
-              dispatch('finishProcess', {
-                processOutput: processResult,
-                routeToDelete: params.routeToDelete
-              })
+              dispatch('finishProcess', processResult)
 
               commit('deleteInExecution', {
-                containerUuid: params.containerUuid
+                containerUuid
               })
 
               dispatch('setProcessTable', {
@@ -625,30 +635,40 @@ const processControl = {
       })
     },
     // Supported to process selection
-    selectionProcess({ commit, state, dispatch, getters, rootGetters }, params) {
+    selectionProcess({ commit, state, dispatch, getters, rootGetters }, {
+      parentUuid,
+      containerUuid,
+      panelType,
+      action,
+      isProcessTableSelection,
+      menuParentUuid,
+      routeToDelete
+    }) {
       // get info metadata process
-      const processDefinition = rootGetters.getProcess(params.action.uuid)
-      var reportType = 'pdf'
+      const processDefinition = rootGetters.getProcess(action.uuid)
+      const reportType = 'pdf'
       const finalParameters = rootGetters.getParametersToServer({ containerUuid: processDefinition.uuid })
-
-      showNotification({
-        title: language.t('notifications.processing'),
-        message: processDefinition.name,
-        summary: processDefinition.description,
-        type: 'info'
-      })
+      const isSession = !isEmptyValue(getToken())
+      if (isSession) {
+        showNotification({
+          title: language.t('notifications.processing'),
+          message: processDefinition.name,
+          summary: processDefinition.description,
+          type: 'info'
+        })
+      }
       const timeInitialized = (new Date()).getTime()
       // Run process on server and wait for it for notify
-      if (params.isProcessTableSelection) {
-        var windowSelectionProcess = getters.getProcessSelect
+      if (isProcessTableSelection) {
+        const windowSelectionProcess = getters.getProcessSelect
         windowSelectionProcess.selection.forEach(selection => {
-          var processResult = {
+          const processResult = {
             // panel attributes from where it was executed
-            parentUuid: params.parentUuid,
-            containerUuid: params.containerUuid,
-            panelType: params.panelType,
-            menuParentUuid: params.menuParentUuid,
-            processIdPath: params.routeToDelete.path,
+            parentUuid,
+            containerUuid,
+            panelType,
+            menuParentUuid,
+            processIdPath: routeToDelete.path,
             // process attributes
             lastRun: timeInitialized,
             action: processDefinition.name,
@@ -684,14 +704,14 @@ const processControl = {
             return runProcess({
               uuid: processDefinition.uuid,
               id: processDefinition.id,
-              reportType: reportType,
-              parameters: finalParameters,
-              selection: selection,
+              reportType,
+              parametersList: finalParameters,
+              selectionsList: selection,
               tableName: windowSelectionProcess.tableName,
               recordId: selection[windowSelectionProcess.tableName]
             })
               .then(response => {
-                var output = {
+                let output = {
                   uuid: '',
                   name: '',
                   description: '',
@@ -714,7 +734,7 @@ const processControl = {
                     reportType: responseOutput.reporttype
                   }
                 }
-                var logList = []
+                let logList = []
                 if (response.getLogsList) {
                   logList = response.getLogsList.map(itemLog => {
                     return {
@@ -733,7 +753,7 @@ const processControl = {
                   ResultTableName: response.resulttablename,
                   lastRun: response.lastRun,
                   logs: logList,
-                  output: output
+                  output
                 })
                 dispatch('setReportTypeToShareLink', processResult.output.reportType)
                 if (processResult.isError) {
@@ -746,12 +766,13 @@ const processControl = {
                 const countResponse = state.totalResponse + 1
                 commit('setTotalResponse', countResponse)
                 if (state.totalResponse === state.totalRequest) {
-                  var processMessage = {
-                    title: language.t('notifications.succesful'),
-                    message: language.t('notifications.totalProcess') + countResponse + language.t('notifications.error') + state.errorSelection + language.t('notifications.succesful') + state.successSelection + language.t('notifications.processExecuted'),
-                    type: 'success'
+                  if (isSession) {
+                    showNotification({
+                      title: language.t('notifications.succesful'),
+                      message: language.t('notifications.totalProcess') + countResponse + language.t('notifications.error') + state.errorSelection + language.t('notifications.succesful') + state.successSelection + language.t('notifications.processExecuted'),
+                      type: 'success'
+                    })
                   }
-                  showNotification(processMessage)
                   commit('setTotalRequest', 0)
                   commit('setTotalResponse', 0)
                   commit('setSuccessSelection', 0)
@@ -765,7 +786,7 @@ const processControl = {
                 commit('addNotificationProcess', processResult)
                 commit('addStartedProcess', processResult)
                 commit('deleteInExecution', {
-                  containerUuid: params.containerUuid
+                  containerUuid
                 })
               })
               .catch(error => {
@@ -774,7 +795,7 @@ const processControl = {
                   message: error.message,
                   isProcessing: false
                 })
-                console.warn(`Error running the process ${error}.`)
+                console.warn(`Error running the process. Code ${error.code}: ${error.message}.`)
               })
           }
         })
@@ -828,21 +849,24 @@ const processControl = {
      * Show modal dialog with process/report, tab (sequence) metadata
      * @param {object} params
      */
-    setShowDialog({ state, commit, dispatch, rootGetters }, params) {
+    setShowDialog({ state, commit, dispatch, rootGetters }, {
+      type,
+      action
+    }) {
       const panels = ['process', 'report', 'window']
-      if (params.action && (panels.includes(params.type) || panels.includes(params.action.panelType))) {
+      if (action && (panels.includes(type) || panels.includes(action.panelType))) {
         // show some process loaded in store
         if (state.metadata && !isEmptyValue(state.metadata.containerUuid) &&
-        state.metadata.containerUuid === params.action.containerUuid) {
+        state.metadata.containerUuid === action.containerUuid) {
           commit('setShowDialog', true)
           return
         }
-        const panel = rootGetters.getPanel(params.action.containerUuid)
+        const panel = rootGetters.getPanel(action.containerUuid)
         if (panel === undefined) {
           dispatch('getPanelAndFields', {
-            parentUuid: params.action.parentUuid,
-            containerUuid: isEmptyValue(params.action.uuid) ? params.action.containerUuid : params.action.uuid,
-            panelType: params.action.panelType
+            parentUuid: action.parentUuid,
+            containerUuid: isEmptyValue(action.uuid) ? action.containerUuid : action.uuid,
+            panelType: action.panelType
           })
             .then(response => {
               commit('setMetadata', response)
@@ -856,53 +880,55 @@ const processControl = {
       }
       commit('setShowDialog', false)
     },
-    finishProcess({ commit }, parameters) {
-      var processMessage = {
-        name: parameters.processOutput.processName,
+    finishProcess({ commit }, processOutput) {
+      const processMessage = {
+        name: processOutput.processName,
         title: language.t('notifications.succesful'),
         message: language.t('notifications.processExecuted'),
         type: 'success',
-        logs: parameters.processOutput.logs,
-        summary: parameters.processOutput.summary
+        logs: processOutput.logs,
+        summary: processOutput.summary
       }
-      var errorMessage = !isEmptyValue(parameters.processOutput.message) ? parameters.processOutput.message : language.t('notifications.error')
+      const errorMessage = !isEmptyValue(processOutput.message) ? processOutput.message : language.t('notifications.error')
       // TODO: Add isReport to type always 'success'
-      if (parameters.processOutput.isError || isEmptyValue(parameters.processOutput.processId) || isEmptyValue(parameters.processOutput.instanceUuid)) {
+      if (processOutput.isError || isEmptyValue(processOutput.processId) || isEmptyValue(processOutput.instanceUuid)) {
         processMessage.title = language.t('notifications.error')
         processMessage.message = errorMessage
         processMessage.type = 'error'
-        parameters.processOutput.isError = true
+        processOutput.isError = true
       }
-      if (parameters.processOutput.isReport && !parameters.processOutput.isError) {
+      if (processOutput.isReport && !processOutput.isError) {
         // open report viewer with report response
-        if (isEmptyValue(parameters.processOutput.menuParentUuid)) {
-          parameters.processOutput.menuParentUuid = parameters.processOutput.processUuid
+        if (isEmptyValue(processOutput.menuParentUuid)) {
+          processOutput.menuParentUuid = processOutput.processUuid
         }
 
         let tableName
-        if (parameters.processOutput.option && !isEmptyValue(parameters.processOutput.option)) {
-          if (parameters.processOutput.option === 'drillTable') {
-            tableName = parameters.processOutput.tableName
+        if (processOutput.option && !isEmptyValue(processOutput.option)) {
+          if (processOutput.option === 'drillTable') {
+            tableName = processOutput.tableName
           }
         }
         router.push({
           name: 'Report Viewer',
           params: {
-            processId: parameters.processOutput.processId,
-            instanceUuid: parameters.processOutput.instanceUuid,
-            fileName: isEmptyValue(parameters.processOutput.output.fileName) ? parameters.processOutput.fileName : parameters.processOutput.output.fileName,
-            menuParentUuid: parameters.processOutput.menuParentUuid,
-            tableName: tableName
+            processId: processOutput.processId,
+            instanceUuid: processOutput.instanceUuid,
+            fileName: isEmptyValue(processOutput.output.fileName) ? processOutput.fileName : processOutput.output.fileName,
+            menuParentUuid: processOutput.menuParentUuid,
+            tableName
           }
         })
       }
-
-      showNotification(processMessage)
-      commit('addStartedProcess', parameters.processOutput)
-      commit('setReportValues', parameters.processOutput)
+      const isSession = !isEmptyValue(getToken())
+      if (isSession) {
+        showNotification(processMessage)
+      }
+      commit('addStartedProcess', processOutput)
+      commit('setReportValues', processOutput)
     },
     changeFormatReport({ commit }, reportFormat) {
-      if (reportFormat !== undefined) {
+      if (!isEmptyValue(reportFormat)) {
         commit('changeFormatReport', reportFormat)
       }
     }

--- a/src/utils/ADempiere/notification.js
+++ b/src/utils/ADempiere/notification.js
@@ -6,7 +6,6 @@ export function hasTranslation(text) {
   const hasKey = language.te('notifications.' + text)
   if (hasKey) {
     const translatedText = language.t('notifications.' + text)
-
     return translatedText
   }
   return text
@@ -14,61 +13,70 @@ export function hasTranslation(text) {
 
 /**
  *
- * @param {object} parameters
- * @param {object} parameters.type, required
- * @param {object} parameters.title, required
- * @param {object} parameters.message, required
- * @param {object} parameters.summary, required
- * @param {object} parameters.name, required
+ * @param {string} type, required
+ * @param {string} title, required
+ * @param {object} message
+ * @param {string} summary
+ * @param {string} name
+ * @param {array} logs
  */
-export function showNotification(parameters) {
-  var title = hasTranslation(parameters.title)
-  var message = ''
-  if (parameters.message) {
-    message = hasTranslation(parameters.message)
+export function showNotification({ type, title, message, summary, name, logs = [] }) {
+  title = hasTranslation(title)
+  if (message) {
+    message = hasTranslation(message)
   }
-  //  For summary
-  if (parameters.summary) {
+  // For summary
+  if (summary) {
     if (message) {
-      message = message + '<br>' + parameters.summary
+      message = `${message} <br> ${summary}`
     } else {
-      message = parameters.summary
+      message = summary
     }
   }
-  //  For logs
-  if (parameters.logs) {
-    parameters.logs.forEach(logResult => {
+  // For logs
+  if (logs && logs.length) {
+    logs.forEach(logResult => {
       if (logResult) {
-        message = message + '<br>' + logResult.log
+        message = `${message} <br> ${logResult.log}`
       }
     })
   }
-  if (parameters.name) {
-    message = parameters.name + message
+  if (name) {
+    message = name + message
   }
-  Notification({
-    title: title,
-    message: `<div style="max-height: 100px; overflow-y: auto;">` + message + `</div>`,
-    type: parameters.type,
+
+  return Notification({
+    title,
+    message: `<div style="max-height: 100px; overflow-y: auto;">${message}</div>`,
+    type,
     position: 'bottom-right',
     dangerouslyUseHTMLString: true,
     onClick() {
-      router.push({ name: 'ProcessActivity' })
+      router.push({
+        name: 'ProcessActivity'
+      })
     }
   })
 }
 
-export function showMessage(parameters) {
-  var delay = 3000
-  if (parameters.type === 'info') {
+/**
+ *
+ * @param {string} type
+ * @param {string} message
+ * @param {number} duration
+ */
+export function showMessage({ type, message, duration = 0 }) {
+  let delay = 3000
+  if (type === 'info') {
     delay = 2000
   }
-  if (parameters.duration) {
-    delay = parameters.duration
+  if (duration) {
+    delay = duration
   }
-  Message({
-    message: parameters.message,
-    type: parameters.type,
+
+  return Message({
+    message,
+    type,
     showClose: true,
     duration: delay
   })


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, not the `master` branch
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your `master` branch!
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

## Description
<!-- Please describe your pull request. -->
When a process is executed, the success/error notification is displayed when it ends even if the session is already closed.

### Screenshots
<!-- A picture tells a thousand words -->
 **Before this PR**
![run-process-error](https://user-images.githubusercontent.com/20288327/77238113-07545f80-6ba4-11ea-967d-5bee10fa721d.gif)

**After this PR**
![run-process-fix](https://user-images.githubusercontent.com/20288327/77238118-0d4a4080-6ba4-11ea-89a5-d3af7e48e4c9.gif)

