### PR TITLE
reolve the activate focus primary field

### DIFF
--- a/src/components/ADempiere/DataTable/index.vue
+++ b/src/components/ADempiere/DataTable/index.vue
@@ -333,7 +333,7 @@ export default {
           }
         })
       }
-      return false
+      return []
     },
     getShowContextMenuTable() {
       return this.$store.getters.getShowContextMenuTable

--- a/src/components/ADempiere/Field/index.vue
+++ b/src/components/ADempiere/Field/index.vue
@@ -329,7 +329,7 @@ export default {
   methods: {
     showMessage,
     focusField() {
-      if (this.isDisplayed && this.isMandatory && !this.isReadOnly) {
+      if (this.isDisplayed && !this.isReadOnly) {
         this.$refs[this.field.columnName].activeFocus()
       }
     }

--- a/src/components/ADempiere/Panel/index.vue
+++ b/src/components/ADempiere/Panel/index.vue
@@ -680,7 +680,7 @@ export default {
       return new Promise(resolve => {
         const fieldFocus = this.getterFieldList.find(itemField => {
           if (this.$refs.hasOwnProperty(itemField.columnName)) {
-            if (fieldIsDisplayed(itemField) && !itemField.isReadOnly && itemField.isUpdateable) {
+            if (fieldIsDisplayed(itemField) && !itemField.isReadOnly && itemField.isUpdateable && itemField.componentPath !== 'FieldSelect') {
               return true
             }
           }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

Hello, the error of the focus in the select type fields has been corrected. Also an error in the table menu

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, not the `master` branch
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your `master` branch!
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

## Description
<!-- Please describe your pull request. -->
Now the focus is positioned on the first field that is mandatory, updateable and that is not a select or a checbook

### Screenshots
<!-- A picture tells a thousand words -->
 **Before this PR**
![focus](https://user-images.githubusercontent.com/45974454/77372088-41a43500-6d3b-11ea-96bf-8c9eaaf555cc.gif)
