### PR TITLE
fix: Run print format without operator's.

### DIFF
--- a/src/store/modules/ADempiere/panel.js
+++ b/src/store/modules/ADempiere/panel.js
@@ -1389,12 +1389,21 @@ const panel = {
             value = undefined
           }
 
-          // only to fields type Time, Datea and DateTime
+          let operator
+          // set default operator of field
+          if (isAdvancedQuery || ['process', 'report'].includes(parameterItem.panelType)) {
+            operator = parameterItem.operator
+          }
+          // only to fields type Time, Date and DateTime, and is range, with values
+          // manage as Array = [value, valueTo]
           if (parameterItem.isRange && parameterItem.componentPath !== 'FieldNumber') {
+            operator = 'LESS_EQUAL' // operand to value is second position of array
             parametersRange.push({
               columnName: `${parameterItem.columnName}_To`,
+              operator,
               value: valueTo
             })
+            operator = 'GREATER_EQUAL' // rewrite to assign first position of array
           }
 
           return {
@@ -1402,7 +1411,7 @@ const panel = {
             value,
             isRange: parameterItem.isRange,
             values,
-            operator: isAdvancedQuery ? parameterItem.operator : undefined
+            operator
           }
         })
 

--- a/src/store/modules/ADempiere/reportControl.js
+++ b/src/store/modules/ADempiere/reportControl.js
@@ -143,12 +143,11 @@ const reportControl = {
       instanceUuid,
       option
     }) {
-      if (isEmptyValue(printFormatUuid)) {
-        printFormatUuid = getters.getDefaultPrintFormat(processUuid).printFormatUuid
-      }
-
-      const parametersList = rootGetters.getParametersToServer({ containerUuid: processUuid })
       return new Promise(resolve => {
+        if (isEmptyValue(printFormatUuid)) {
+          printFormatUuid = getters.getDefaultPrintFormat(processUuid).printFormatUuid
+        }
+        const parametersList = rootGetters.getParametersToServer({ containerUuid: processUuid })
         getReportOutput({
           parametersList,
           printFormatUuid,
@@ -166,7 +165,7 @@ const reportControl = {
               isError: false,
               instanceUuid,
               isReport: true,
-              option: option
+              option
             }
             commit('setNewReportOutput', reportOutput)
 

--- a/src/utils/ADempiere/dictionaryUtils.js
+++ b/src/utils/ADempiere/dictionaryUtils.js
@@ -197,13 +197,17 @@ export function generateField({
   }
 
   // Overwrite some values
-  if (typeRange) {
-    field.uuid = `${field.uuid}_To`
-    field.columnName = `${field.columnName}_To`
-    field.name = `${field.name} To`
-    field.value = parsedDefaultValueTo
-    field.defaultValue = field.defaultValueTo
-    field.parsedDefaultValue = field.parsedDefaultValueTo
+  if (field.isRange) {
+    field.operator = 'GREATER_EQUAL'
+    if (typeRange) {
+      field.uuid = `${field.uuid}_To`
+      field.columnName = `${field.columnName}_To`
+      field.name = `${field.name} To`
+      field.value = parsedDefaultValueTo
+      field.defaultValue = field.defaultValueTo
+      field.parsedDefaultValue = field.parsedDefaultValueTo
+      field.operator = 'LESS_EQUAL'
+    }
   }
 
   // hidden field type button


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `develop` branch, not the `master` branch
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your `master` branch!
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

## Description
<!-- Please describe your pull request. -->
Fixed error that launches the empty report, after the first execution when changing the print format.

### Screenshots
<!-- A picture tells a thousand words -->
 **Before this PR**
![run-print-format-operator-error](https://user-images.githubusercontent.com/20288327/77567353-69131300-6e9d-11ea-8666-c9ed5baa22e9.gif)

**After this PR**
![run-print-format-operator-fixed](https://user-images.githubusercontent.com/20288327/77571388-ada1ad00-6ea3-11ea-989c-18114b9d6af7.gif)



