### PR TITLE
Fixed error with call service for list document statuses when a recor…

### DIFF
--- a/src/components/ADempiere/Panel/index.vue
+++ b/src/components/ADempiere/Panel/index.vue
@@ -639,7 +639,7 @@ export default {
       return groupsList
     },
     setTagsViewTitle(actionValue) {
-      if (this.getterPanel.isDocument && this.getterDataStore.isLoaded) {
+      if (actionValue !== 'create-new' && !this.isEmptyValue(actionValue) && this.getterPanel.isDocument && this.getterDataStore.isLoaded) {
         this.$store.dispatch('listWorkflows', this.metadata.tableName)
         this.$store.dispatch('listDocumentStatus', {
           recordUuid: this.$route.query.action,


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
The problem: the **listDocumentStatuses** service is called always without validation for it
#### Steps to reproduce

1. Open Sales Order window
2. Search a existing record
3. On action menu press new option

Note that is called list document statuses instead validate if is a new record

#### Expected behavior
Validation for new record before request service

#### Other relevant information
- Your OS: Linux
- Node.js version:
- vue-element-admin version:

#### Additional context
This is a little change but improve server request