### PR TITLE
Fixed error with parameter name for workflow process used for documen…

### DIFF
--- a/src/components/ADempiere/WorkflowStatusBar/index.vue
+++ b/src/components/ADempiere/WorkflowStatusBar/index.vue
@@ -195,7 +195,7 @@ export default {
             recordId: this.$route.params.recordId,
             recordUuid: this.$route.query.action,
             parametersList: [{
-              columnName: 'DocStatus',
+              columnName: 'DocAction',
               value: this.valueActionDocument
             }],
             isActionDocument: true,


### PR DESCRIPTION
…t action for documents

## Bug report / Feature
When a document action process is called from client the server espect a document action like parameter for process a document, the problem here is that is used like parameter name **DocStatus** instead **DocAction**
#### Steps to reproduce

1. Open Sales Order window
2. Go to a record on draft status
3. Process it for **Prepare** or **Complete** action

#### Expected behavior
a service request for process document with a new action instead status

#### Other relevant information
- Your OS:
- Node.js version:
- vue-element-admin version:

#### Additional context
I should be change also on server