### PR TITLE
fix: Without records refreshing on different child tab than the first.

### DIFF
--- a/src/components/ADempiere/Tab/index.vue
+++ b/src/components/ADempiere/Tab/index.vue
@@ -34,6 +34,11 @@ export default {
     MainPanel
   },
   mixins: [tabMixin],
+  data() {
+    return {
+      currentTab: this.$route.query.tabParent
+    }
+  },
   computed: {
     tabParentStyle() {
       // if tabs children is showed or closed
@@ -70,6 +75,19 @@ export default {
         })
         this.$route.meta.tabUuid = this.tabUuid
       }
+    },
+    tabUuid(value) {
+      this.setCurrentTab()
+    }
+  },
+  methods: {
+    setCurrentTab() {
+      this.$store.dispatch('setCurrentTab', {
+        parentUuid: this.windowUuid,
+        containerUuid: this.tabUuid,
+        window: this.windowMetadata
+      })
+      this.$route.meta.tabUuid = this.tabUuid
     }
   }
 }

--- a/src/components/ADempiere/Tab/tabChildren.vue
+++ b/src/components/ADempiere/Tab/tabChildren.vue
@@ -52,14 +52,9 @@ export default {
     getterDataParentTab() {
       return this.$store.getters.getDataRecordAndSelection(this.firstTabUuid)
     },
-    getterIsLoadRecordParent() {
-      return this.getterDataParentTab.isLoaded
-    },
-    getterIsLoadContextParent() {
-      return this.getterDataParentTab.isLoadedContext
-    },
     isReadyFromGetData() {
-      return !this.getDataSelection.isLoaded && this.getterIsLoadContextParent && this.getterIsLoadRecordParent
+      const { isLoaded, isLoadedContext } = this.getterDataParentTab
+      return !this.getDataSelection.isLoaded && isLoaded && isLoadedContext
     }
   },
   watch: {
@@ -91,8 +86,12 @@ export default {
       }
     }
   },
-  mounted() {
+  created() {
     this.setCurrentTabChild()
+    const currentIndex = parseInt(this.currentTabChild, 10)
+    this.tabUuid = this.tabsList[currentIndex].uuid
+  },
+  mounted() {
     if (this.isReadyFromGetData) {
       this.getDataTable()
     }

--- a/src/components/ADempiere/Tab/tabMixin.js
+++ b/src/components/ADempiere/Tab/tabMixin.js
@@ -17,10 +17,8 @@ export const tabMixin = {
   },
   data() {
     return {
-      currentTab: this.$route.query.tabParent,
       tabUuid: '',
-      panelType: 'window',
-      firstTableName: this.tabsList[0].tableName
+      panelType: 'window'
     }
   },
   computed: {
@@ -32,21 +30,11 @@ export const tabMixin = {
     this.tabUuid = this.tabsList[0].uuid
   },
   methods: {
-    parseContext,
-    //
     getDataTable() {
       this.$store.dispatch('getDataListTab', {
         parentUuid: this.windowUuid,
         containerUuid: this.tabUuid
       })
-    },
-    setCurrentTab() {
-      this.$store.dispatch('setCurrentTab', {
-        parentUuid: this.windowUuid,
-        containerUuid: this.tabUuid,
-        window: this.windowMetadata
-      })
-      this.$route.meta.tabUuid = this.tabUuid
     },
     /**
      * @param {object} tabHTML DOM HTML the tab clicked
@@ -54,7 +42,6 @@ export const tabMixin = {
     handleClick(tabHTML) {
       if (this.tabUuid !== tabHTML.$attrs.tabuuid) {
         this.tabUuid = tabHTML.$attrs.tabuuid
-        this.setCurrentTab()
       }
     },
     handleBeforeLeave(activeName) {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
Records are not loaded in child tabs other than first if web browser refreshes

#### Steps to reproduce
1. Open a window with child tabs, for this example the 'Smart Browser' window was used.
2. Select the second child tab, in this case 'Browse Field'.
3. Refresh the web browser.


#### Screenshot or Gif
Before this PR
![tab-child-not-data-refresh-in-first-error](https://user-images.githubusercontent.com/20288327/78386591-dca6d580-75ab-11ea-838f-e948fef5533b.gif)

After this PR:
![tab-child-not-data-refresh-in-first-fix](https://user-images.githubusercontent.com/20288327/78388861-c00c9c80-75af-11ea-85b4-6199b9765e57.gif)


#### Expected behavior
You must load the records of the focused tab ('Browse Field'), however load the records of the first tab ('Access') without this tab being selected, as observed when selecting it, load the metadata and the data logs had been loaded

#### Other relevant information
- Your OS: Debian 9.5 x64
- Web Browser: Firefox 74.0
- Node.js version: 10.19.0
- vue-element-admin version: 4.1.0

