### PR TITLE
Fixed error with value for list

### DIFF
--- a/src/components/ADempiere/Field/FieldSelect.vue
+++ b/src/components/ADempiere/Field/FieldSelect.vue
@@ -142,7 +142,6 @@ export default {
         }
         if (!this.findLabel(value) &&
           this.metadata.displayed &&
-          this.metadata.optionCRUD !== 'create-new' &&
           this.isEmptyValue(this.metadata.displayColumn)) {
           value = undefined
         }


### PR DESCRIPTION
## Bug report / Feature
Lookup value is showed as 0 value instead blank for new records
#### Steps to reproduce

1. Open Purchase Order
2. On actions press Create New Record
3. Note that business partner is showed with display value **0**

#### Gif before change
![Lookup_Error_Before](https://user-images.githubusercontent.com/2333092/78712878-58c05680-78e7-11ea-8a39-2da374842769.gif)

#### Gif after change
![Lookup_Error_After](https://user-images.githubusercontent.com/2333092/78718423-439bf580-78f0-11ea-9065-d69592b25e70.gif)

#### Link to minimal reproduction

<!--
Please only use Codepen, JSFiddle, CodeSandbox or a github repo
-->

#### Expected behavior
A clear and concise description of what you expected to happen.

#### Other relevant information
- Your OS:
- Node.js version:
- vue-element-admin version:

#### Additional context
Add any other context about the problem here.
