### PR TITLE
Fixed error with document action list component population

### DIFF
--- a/src/components/ADempiere/Field/popover/documentStatus.vue
+++ b/src/components/ADempiere/Field/popover/documentStatus.vue
@@ -101,6 +101,7 @@ export default {
         if (!this.withoutRecord && this.$route.query.action !== this.documentActions.recordUuid) {
           this.$store.dispatch('listDocumentActionStatus', {
             recordUuid: this.$route.query.action,
+            tableName: this.$route.params.tableName,
             recordId: this.$route.params.recordId
           })
         }

--- a/src/components/ADempiere/WorkflowStatusBar/index.vue
+++ b/src/components/ADempiere/WorkflowStatusBar/index.vue
@@ -170,6 +170,7 @@ export default {
         if (!this.withoutRecord && this.$route.query.action !== this.documentActions.recordUuid) {
           this.$store.dispatch('listDocumentActionStatus', {
             recordUuid: this.$route.query.action,
+            tableName: this.$route.params.tableName,
             recordId: this.$route.params.recordId
           })
         }


### PR DESCRIPTION
## Bug report / Feature
Error loading document action list
#### Steps to reproduce

- Open Order Window
- Press New Action
- Fill all fields
- Go to Change Document Action

See error

```Java
contextMenu.js:104 Error getting document action list. Code 13: @AD_Table_ID@ @NotFound@%0A@AD_Table_ID@ @NotFound@.
```