### PR TITLE
Activate the calculator enter action using a native JavaScript method

### DIFF
--- a/src/components/ADempiere/Field/FieldNumber.vue
+++ b/src/components/ADempiere/Field/FieldNumber.vue
@@ -3,7 +3,6 @@
     <el-input-number
       :ref="metadata.columnName"
       v-model="value"
-      v-shortkey="['enter']"
       type="number"
       :min="minValue"
       :max="maxValue"
@@ -13,9 +12,9 @@
       controls-position="right"
       :class="'display-type-' + cssClass"
       @change="preHandleChange"
-      @shortkey.native="changeValue"
       @blur="changeValue"
       @keydown.native="calculateValue"
+      @keyup.enter.native="changeValue"
     />
   </el-tooltip>
 </template>

--- a/src/components/ADempiere/Field/popover/calculator.vue
+++ b/src/components/ADempiere/Field/popover/calculator.vue
@@ -7,10 +7,9 @@
       <el-input
         ref="calculatorInput"
         v-model="calcValue"
-        v-shortkey="['enter']"
         class="calc-input"
         @keydown.native="calculateValue"
-        @shortkey.native="changeValue"
+        @keyup.enter.native="changeValue"
       >
         <template slot="append">{{ valueToDisplay }}</template>
       </el-input>


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
The enter error is corrected
#### Steps to reproduce

1. Display the calculator
2. Execute any mathematical operation
3. Press enter to change value

#### Screenshot or Gif

![enter](https://user-images.githubusercontent.com/45974454/79092283-6bd78a00-7d1e-11ea-93b7-6ab7eba5f075.gif)



#### Other relevant information
- Your OS: Debian 9
- Node.js version: 8.9

#### Description
Hi there!. In this pull request it was solved to change the value in the calculator using the enter using a native Java function
