### PR TITLE
Add overwrite definition for factory

### DIFF
--- a/src/utils/ADempiere/lookupFactory.js
+++ b/src/utils/ADempiere/lookupFactory.js
@@ -55,14 +55,15 @@ import FIELDS_DISPLAY_SIZES, { DEFAULT_SIZE } from '@/components/ADempiere/Field
 import store from '@/store'
 
 // Create a Field from UUID based on server meta-data
-export function createFieldDictionary({
+export function createFieldFromDictionary({
   containerUuid,
   fieldUuid,
   columnUuid,
   elementUuid,
   elementColumnName,
   tableName,
-  columnName
+  columnName,
+  overwriteDefinition
 }) {
   let field
   if (fieldUuid) {
@@ -94,7 +95,8 @@ export function createFieldDictionary({
       .then(response => {
         resolve(getFactoryFromField({
           containerUuid,
-          field: response
+          field: response,
+          overwriteDefinition
         }))
       }).catch(error => {
         console.warn(`LookupFactory: Get Field From Server (State) - Error ${error.code}: ${error.message}.`)
@@ -105,60 +107,108 @@ export function createFieldDictionary({
 // Convert field getted from server to factory
 function getFactoryFromField({
   containerUuid,
-  field
+  field,
+  overwriteDefinition
 }) {
-  return createField({
+  const fieldDefinition = {
+    displayType: field.displayType,
+    tableName: field.reference.tableName,
+    directQuery: field.directQuery,
+    query: field.reference.query,
+    keyColumnName: field.reference.keyColumnName,
+    validationCode: field.reference.validationCode,
+    windowsList: field.reference.windowsList,
+    id: field.id,
+    uuid: field.uuid,
+    name: field.name,
+    description: field.description,
+    help: field.help,
+    fieldGroup: field.fieldGroup,
+    isFieldOnly: field.isFieldOnly,
+    isRange: field.isRange,
+    isSameLine: field.isSameLine,
+    sequence: field.sequence,
+    seqNoGrid: field.seqNoGrid,
+    isIdentifier: field.isIdentifier,
+    isKey: field.isKey,
+    isSelectionColumn: field.isSelectionColumn,
+    isUpdateable: field.isUpdateable,
+    formatPattern: field.formatPattern,
+    vFormat: field.vFormat,
+    defaultValue: field.defaultValue,
+    defaultValueTo: field.defaultValueTo,
+    valueMin: field.valueMin,
+    valueMax: field.valueMax,
+    isActive: field.isActive,
+    isMandatory: field.isMandatory,
+    isReadOnly: field.isReadOnly,
+    isDisplayedFromLogic: field.isDisplayedFromLogic,
+    isReadOnlyFromLogic: field.isReadOnlyFromLogic,
+    isMandatoryFromLogic: field.isMandatoryFromLogic,
+    callout: field.callout,
+    isQueryCriteria: field.isQueryCriteria,
+    displayLogic: field.displayLogic,
+    mandatoryLogic: field.mandatoryLogic,
+    readOnlyLogic: field.readOnlyLogic,
+    parentFieldsList: field.parentFieldsList,
+    dependentFieldsList: field.dependentFieldsList,
+    contextInfo: field.contextInfo
+  }
+  // Overwrite definition
+  if (!isEmptyValue(overwriteDefinition)) {
+    if (!isEmptyValue(overwriteDefinition.isQueryCriteria)) {
+      fieldDefinition.isQueryCriteria = overwriteDefinition.isQueryCriteria
+    }
+    if (!isEmptyValue(overwriteDefinition.isMandatory)) {
+      fieldDefinition.isMandatory = overwriteDefinition.isMandatory
+    }
+    if (!isEmptyValue(overwriteDefinition.isReadOnly)) {
+      fieldDefinition.isReadOnly = overwriteDefinition.isReadOnly
+    }
+    if (!isEmptyValue(overwriteDefinition.isSelectionColumn)) {
+      fieldDefinition.isSelectionColumn = overwriteDefinition.isSelectionColumn
+    }
+    if (!isEmptyValue(overwriteDefinition.isUpdateable)) {
+      fieldDefinition.isUpdateable = overwriteDefinition.isUpdateable
+    }
+    if (!isEmptyValue(overwriteDefinition.isFieldOnly)) {
+      fieldDefinition.isFieldOnly = overwriteDefinition.isFieldOnly
+    }
+    if (!isEmptyValue(overwriteDefinition.isRange)) {
+      fieldDefinition.isRange = overwriteDefinition.isRange
+    }
+    if (!isEmptyValue(overwriteDefinition.displayLogic)) {
+      fieldDefinition.displayLogic = overwriteDefinition.displayLogic
+    }
+    if (!isEmptyValue(overwriteDefinition.mandatoryLogic)) {
+      fieldDefinition.mandatoryLogic = overwriteDefinition.mandatoryLogic
+    }
+    if (!isEmptyValue(overwriteDefinition.readOnlyLogic)) {
+      fieldDefinition.readOnlyLogic = overwriteDefinition.readOnlyLogic
+    }
+    if (!isEmptyValue(overwriteDefinition.formatPattern)) {
+      fieldDefinition.formatPattern = overwriteDefinition.formatPattern
+    }
+    if (!isEmptyValue(overwriteDefinition.vFormat)) {
+      fieldDefinition.vFormat = overwriteDefinition.vFormat
+    }
+    if (!isEmptyValue(overwriteDefinition.defaultValue)) {
+      fieldDefinition.defaultValue = overwriteDefinition.defaultValue
+    }
+    if (!isEmptyValue(overwriteDefinition.defaultValueTo)) {
+      fieldDefinition.defaultValueTo = overwriteDefinition.defaultValueTo
+    }
+  }
+  //  Convert it
+  return createFieldFromDefinition({
     containerUuid: containerUuid,
     columnName: field.columnName,
-    definition: {
-      displayType: field.displayType,
-      tableName: field.reference.tableName,
-      directQuery: field.directQuery,
-      query: field.reference.query,
-      keyColumnName: field.reference.keyColumnName,
-      validationCode: field.reference.validationCode,
-      windowsList: field.reference.windowsList,
-      id: field.id,
-      uuid: field.uuid,
-      name: field.name,
-      description: field.description,
-      help: field.help,
-      fieldGroup: field.fieldGroup,
-      isFieldOnly: field.isFieldOnly,
-      isRange: field.isRange,
-      isSameLine: field.isSameLine,
-      sequence: field.sequence,
-      seqNoGrid: field.seqNoGrid,
-      isIdentifier: field.isIdentifier,
-      isKey: field.isKey,
-      isSelectionColumn: field.isSelectionColumn,
-      isUpdateable: field.isUpdateable,
-      formatPattern: field.formatPattern,
-      vFormat: field.vFormat,
-      defaultValue: field.defaultValue,
-      defaultValueTo: field.defaultValueTo,
-      valueMin: field.valueMin,
-      valueMax: field.valueMax,
-      isActive: field.isActive,
-      isMandatory: field.isMandatory,
-      isReadOnly: field.isReadOnly,
-      isDisplayedFromLogic: field.isDisplayedFromLogic,
-      isReadOnlyFromLogic: field.isReadOnlyFromLogic,
-      isMandatoryFromLogic: field.isMandatoryFromLogic,
-      callout: field.callout,
-      isQueryCriteria: field.isQueryCriteria,
-      displayLogic: field.displayLogic,
-      mandatoryLogic: field.mandatoryLogic,
-      readOnlyLogic: field.readOnlyLogic,
-      parentFieldsList: field.parentFieldsList,
-      dependentFieldsList: field.dependentFieldsList,
-      contextInfo: field.contextInfo
-    }
+    definition: fieldDefinition
   })
 }
 
 // Create a field, it assumed that you define all behavior from source code
-export function createField({
+export function createFieldFromDefinition({
   parentUuid,
   containerUuid,
   columnName,
@@ -213,15 +263,6 @@ export function createField({
     }
     definition.reference = reference
   }
-  // if(isLookup()) {
-  //
-  // }
-  // // Special cases
-  // // Please if you need use a special case remember that already exists many implementations
-  // switch (displayType) {
-  //   case TEXT.id:
-  //     break
-  // }
   return getFieldTemplate({
     ...definition,
     isShowedFromUser: true,
@@ -233,10 +274,10 @@ export function createField({
 }
 
 // Default template for injected fields
-export function getFieldTemplate(attributesOverwrite) {
+export function getFieldTemplate(overwriteDefinition) {
   let displayType = 10
-  if (!isEmptyValue(attributesOverwrite.displayType)) {
-    displayType = attributesOverwrite.displayType
+  if (!isEmptyValue(overwriteDefinition.displayType)) {
+    displayType = overwriteDefinition.displayType
   }
 
   const componentReference = evalutateTypeField(displayType)
@@ -244,9 +285,9 @@ export function getFieldTemplate(attributesOverwrite) {
 
   // set size from displayed, max 24
   let size = DEFAULT_SIZE.size
-  if (!isEmptyValue(attributesOverwrite.size)) {
-    size = attributesOverwrite.size
-    delete attributesOverwrite.size
+  if (!isEmptyValue(overwriteDefinition.size)) {
+    size = overwriteDefinition.size
+    delete overwriteDefinition.size
     if (typeof size === 'number') {
       size = {
         xs: size,
@@ -331,7 +372,7 @@ export function getFieldTemplate(attributesOverwrite) {
     isShowedFromUser: false,
     isFixedTableColumn: false,
     sizeFieldFromType,
-    ...attributesOverwrite
+    ...overwriteDefinition
   }
 
   // get parsed parent fields list

--- a/src/views/ADempiere/TestView/index.vue
+++ b/src/views/ADempiere/TestView/index.vue
@@ -28,7 +28,7 @@
 
 <script>
 import Field from '@/components/ADempiere/Field'
-import { createField, createFieldDictionary } from '@/utils/ADempiere/lookupFactory'
+import { createFieldFromDefinition, createFieldFromDictionary } from '@/utils/ADempiere/lookupFactory'
 import { URL, TEXT, NUMBER, INTEGER, TEXT_LONG, TABLE_DIRECT } from '@/utils/ADempiere/references'
 
 export default {
@@ -80,7 +80,7 @@ export default {
 
       let sequence = 10
       // URL
-      fieldsList.push(createField({
+      fieldsList.push(createFieldFromDefinition({
         containerUuid: this.panelUuid,
         columnName: 'URL',
         definition: {
@@ -91,7 +91,7 @@ export default {
         }
       }))
       // From Field UUID
-      createFieldDictionary({
+      createFieldFromDictionary({
         containerUuid: this.panelUuid,
         fieldUuid: '8ceabe8a-fb40-11e8-a479-7a0060f0aa01'
       })
@@ -101,7 +101,7 @@ export default {
           console.warn(`LookupFactory: Get Field From Server (State) - Error ${error.code}: ${error.message}.`)
         })
       // From Column UUID
-      createFieldDictionary({
+      createFieldFromDictionary({
         containerUuid: this.panelUuid,
         columnUuid: '8b4bbb7e-fb40-11e8-a479-7a0060f0aa01'
       })
@@ -111,7 +111,7 @@ export default {
           console.warn(`LookupFactory: Get Field From Server (State) - Error ${error.code}: ${error.message}.`)
         })
       // From Element Column Name
-      createFieldDictionary({
+      createFieldFromDictionary({
         containerUuid: this.panelUuid,
         elementColumnName: 'M_RMA_ID'
       })
@@ -121,10 +121,13 @@ export default {
           console.warn(`LookupFactory: Get Field From Server (State) - Error ${error.code}: ${error.message}.`)
         })
       // From Table and Column Name
-      createFieldDictionary({
+      createFieldFromDictionary({
         containerUuid: this.panelUuid,
         tableName: 'C_BPartner',
-        columnName: 'PaymentRule'
+        columnName: 'PaymentRule',
+        overwriteDefinition: {
+          isMandatory: true
+        }
       })
         .then(metadata => {
           fieldsList.push(metadata)
@@ -134,7 +137,7 @@ export default {
       // Table direct
       // To be define
       sequence = sequence + 10
-      fieldsList.push(createField({
+      fieldsList.push(createFieldFromDefinition({
         containerUuid: this.panelUuid,
         columnName: 'C_Currency_ID',
         definition: {
@@ -150,7 +153,7 @@ export default {
 
       sequence = sequence + 10
       // Text
-      fieldsList.push(createField({
+      fieldsList.push(createFieldFromDefinition({
         containerUuid: this.panelUuid,
         columnName: 'Name',
         definition: {
@@ -164,7 +167,7 @@ export default {
 
       sequence = sequence + 10
       // Amount
-      fieldsList.push(createField({
+      fieldsList.push(createFieldFromDefinition({
         containerUuid: this.panelUuid,
         columnName: 'Amount',
         definition: {
@@ -178,7 +181,7 @@ export default {
 
       sequence = sequence + 10
       // Integer
-      fieldsList.push(createField({
+      fieldsList.push(createFieldFromDefinition({
         containerUuid: this.panelUuid,
         columnName: 'SeqNo',
         definition: {
@@ -192,7 +195,7 @@ export default {
 
       sequence = sequence + 10
       // Text Long
-      fieldsList.push(createField({
+      fieldsList.push(createFieldFromDefinition({
         containerUuid: this.panelUuid,
         columnName: 'Description',
         definition: {


### PR DESCRIPTION
## Bug report / Feature
Currently you can load a field from dictionary and definition, this pull request allows define overwrite attributes for fields.
## Functions added:
```Javascript
createFieldFromDefinition({
  containerUuid,
  columnName,
  definition = {}
})
```
```Javascript
createFieldFromDictionary({
  containerUuid,
  fieldUuid,
  columnUuid,
  elementUuid,
  elementColumnName,
  tableName,
  columnName,
  overwriteDefinition
})
```

## How call it?
### Get meta-data from manual definition
```Javascript
console.log(createFieldFromDefinition({
        containerUuid: this.panelUuid,
        columnName: 'Description',
        definition: {
          name: 'Only Description',
          displayType: TEXT_LONG.id,
          panelType: this.panelType,
          sequence
        }
      }))
```
### Get meta-data from dictionary
```Javascript
createFieldFromDictionary({
        containerUuid: this.panelUuid,
        tableName: 'C_BPartner',
        columnName: 'PaymentRule',
        overwriteDefinition: {
          isMandatory: true
        }
      })
        .then(metadata => {
          console.log(metadata)
        }).catch(error => {
          console.warn(`LookupFactory: Get Field From Server (State) - Error ${error.code}: ${error.message}.`)
        })
```
For example just go to:
src/views/ADempiere/TestView

```Javascript
<template>
  <div class="wrapper">
    <el-form
      v-if="isLoaded"
      key="form-loaded"
      label-position="top"
      label-width="200px"
    >
      <el-row>
        <field
          v-for="(metadata) in metadataList"
          :key="metadata.columnName"
          :metadata-field="metadata"
        />
      </el-row>
    </el-form>
    <div
      v-else
      key="form-loading"
      v-loading="!isLoaded"
      :element-loading-text="$t('notifications.loading')"
      element-loading-spinner="el-icon-loading"
      element-loading-background="rgba(255, 255, 255, 0.8)"
      class="loading-panel"
    />
  </div>
</template>

<script>
import Field from '@/components/ADempiere/Field'
import { createFieldFromDefinition, createFieldFromDictionary } from '@/utils/ADempiere/lookupFactory'
import { URL, TEXT, NUMBER, INTEGER, TEXT_LONG, TABLE_DIRECT } from '@/utils/ADempiere/references'

export default {
  name: 'TestView',
  components: {
    Field
  },
  data() {
    return {
      metadataList: [],
      panelMetadata: {},
      isLoaded: false,
      panelUuid: 'Test-View',
      panelType: 'custom'
    }
  },
  computed: {
    getterPanel() {
      return this.$store.getters.getPanel(this.panelUuid)
    }
  },
  created() {
    this.getPanel()
  },
  methods: {
    getPanel() {
      const panel = this.getterPanel
      if (panel) {
        this.metadataList = panel.fieldList
        this.isLoaded = true
      } else {
        this.setFieldsList()
        this.$store.dispatch('addPanel', {
          name: 'Test View',
          uuid: this.panelUuid,
          panelType: this.panelType,
          fieldList: this.metadataList
        })
          .then(responsePanel => {
            this.metadataList = responsePanel.fieldList
          })
          .finally(() => {
            this.isLoaded = true
          })
      }
    },
    setFieldsList() {
      const fieldsList = []

      let sequence = 10
      // URL
      fieldsList.push(createFieldFromDefinition({
        containerUuid: this.panelUuid,
        columnName: 'URL',
        definition: {
          name: 'Web',
          displayType: URL.id,
          panelType: this.panelType,
          sequence
        }
      }))
      // From Field UUID
      createFieldFromDictionary({
        containerUuid: this.panelUuid,
        fieldUuid: '8ceabe8a-fb40-11e8-a479-7a0060f0aa01'
      })
        .then(metadata => {
          fieldsList.push(metadata)
        }).catch(error => {
          console.warn(`LookupFactory: Get Field From Server (State) - Error ${error.code}: ${error.message}.`)
        })
      // From Column UUID
      createFieldFromDictionary({
        containerUuid: this.panelUuid,
        columnUuid: '8b4bbb7e-fb40-11e8-a479-7a0060f0aa01'
      })
        .then(metadata => {
          fieldsList.push(metadata)
        }).catch(error => {
          console.warn(`LookupFactory: Get Field From Server (State) - Error ${error.code}: ${error.message}.`)
        })
      // From Element Column Name
      createFieldFromDictionary({
        containerUuid: this.panelUuid,
        elementColumnName: 'M_RMA_ID'
      })
        .then(metadata => {
          fieldsList.push(metadata)
        }).catch(error => {
          console.warn(`LookupFactory: Get Field From Server (State) - Error ${error.code}: ${error.message}.`)
        })
      // From Table and Column Name
      createFieldFromDictionary({
        containerUuid: this.panelUuid,
        tableName: 'C_BPartner',
        columnName: 'PaymentRule',
        overwriteDefinition: {
          isMandatory: true
        }
      })
        .then(metadata => {
          fieldsList.push(metadata)
        }).catch(error => {
          console.warn(`LookupFactory: Get Field From Server (State) - Error ${error.code}: ${error.message}.`)
        })
      // Table direct
      // To be define
      sequence = sequence + 10
      fieldsList.push(createFieldFromDefinition({
        containerUuid: this.panelUuid,
        columnName: 'C_Currency_ID',
        definition: {
          name: 'Currency',
          displayType: TABLE_DIRECT.id,
          panelType: this.panelType,
          keyColumn: 'C_Currency.C_Currency_ID',
          directQuery: 'SELECT C_Currency.C_Currency_ID,NULL,C_Currency.ISO_Code,C_Currency.IsActive FROM C_Currency WHERE C_Currency.C_Currency_ID=?',
          query: 'SELECT C_Currency.C_Currency_ID,NULL,C_Currency.ISO_Code,C_Currency.IsActive FROM C_Currency ORDER BY 3',
          sequence
        }
      }))

      sequence = sequence + 10
      // Text
      fieldsList.push(createFieldFromDefinition({
        containerUuid: this.panelUuid,
        columnName: 'Name',
        definition: {
          name: 'Only Name',
          displayType: TEXT.id,
          panelType: this.panelType,
          displayLogic: '@URL@!""',
          sequence
        }
      }))

      sequence = sequence + 10
      // Amount
      fieldsList.push(createFieldFromDefinition({
        containerUuid: this.panelUuid,
        columnName: 'Amount',
        definition: {
          name: 'Amount for it',
          displayType: NUMBER.id,
          panelType: this.panelType,
          readOnlyLogic: '@C_Currency_ID@<>""',
          sequence
        }
      }))

      sequence = sequence + 10
      // Integer
      fieldsList.push(createFieldFromDefinition({
        containerUuid: this.panelUuid,
        columnName: 'SeqNo',
        definition: {
          name: 'Sequence for record',
          displayType: INTEGER.id,
          panelType: this.panelType,
          mandatoryLogic: '@URL@!""',
          sequence
        }
      }))

      sequence = sequence + 10
      // Text Long
      fieldsList.push(createFieldFromDefinition({
        containerUuid: this.panelUuid,
        columnName: 'Description',
        definition: {
          name: 'Only Description',
          displayType: TEXT_LONG.id,
          panelType: this.panelType,
          sequence
        }
      }))

      this.metadataList = fieldsList
    }
  }
}
</script>
```
See:
![Screenshot_20200418_203939](https://user-images.githubusercontent.com/2333092/79676481-bfc9ef00-81b4-11ea-8724-51fac41425c2.png)