### PR TITLE
Fixed error wuth login is too long when a session is expired

### DIFF
--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -79,7 +79,7 @@ const actions = {
     if (isEmptyValue(sessionUuid)) {
       sessionUuid = getToken()
     }
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       getSessionInfo(sessionUuid)
         .then(responseGetInfo => {
           const { role } = responseGetInfo
@@ -118,10 +118,12 @@ const actions = {
           dispatch('getUserInfoFromSession', sessionUuid)
             .catch(error => {
               console.warn(`Error ${error.code} getting user info value: ${error.message}.`)
+              reject(error)
             })
         })
         .catch(error => {
           console.warn(`Error ${error.code} getting context session: ${error.message}.`)
+          reject(error)
         })
     })
   },


### PR DESCRIPTION
## Bug report / Feature
This pull request resolve a problem when a user have a session token but it was expired
#### Steps to reproduce

1. Login on ADempiere
2. Close browser
3. Stop Access service
4. Start Access service
5. Open browser
6. Open adempiere login

#### Expected behavior
A login panel for write user and pass