### PR TITLE
fix: Default search SmartBrowser without mandatory query criteria fields

### DIFF
--- a/src/views/ADempiere/Browser/index.vue
+++ b/src/views/ADempiere/Browser/index.vue
@@ -109,8 +109,8 @@ export default {
     browserTitle() {
       return this.browserMetadata.name || this.$route.meta.title
     },
-    getDataRecords() {
-      return this.$store.getters.getDataRecordsList(this.browserUuid)
+    isLoadedRecords() {
+      return this.$store.getters.getDataRecordAndSelection(this.browserUuid).isLoaded
     },
     getContainerIsReadyForSubmit() {
       return !this.$store.getters.isNotReadyForSubmit(this.browserUuid) && !this.browserMetadata.awaitForValuesToQuery
@@ -189,17 +189,17 @@ export default {
         this.activeSearch = ['opened-criteria']
       }
 
-      if (this.getDataRecords.length <= 0) {
+      if (!this.isLoadedRecords) {
         if (this.getContainerIsReadyForSubmit) {
           this.$store.dispatch('getBrowserSearch', {
             containerUuid: this.browserUuid
           })
-        } else {
-          this.$store.dispatch('setRecordSelection', {
-            containerUuid: this.browserUuid,
-            panelType: this.panelType
-          })
         }
+      } else {
+        this.$store.dispatch('setRecordSelection', {
+          containerUuid: this.browserUuid,
+          panelType: this.panelType
+        })
       }
     }
   }


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce
1. Open Smart Browser 'Project Task Browser'.
2. Switch to another view.
3. Return to the SmartBrowser.

#### Screenshot or Gif
Before this PR:
![sb-default-search-error](https://user-images.githubusercontent.com/20288327/80210360-a59f6f00-8601-11ea-988f-89fa8112dfcc.gif)

After this PR:
![sb-default-search-fix](https://user-images.githubusercontent.com/20288327/80217698-1f3d5a00-860e-11ea-930d-244934d617c9.gif)


#### Expected behavior
It is expected that if the search has already been carried out, although with empty results, it will not perform another search just by switching between views.

#### Additional context
This behavior is only visible with Smart Browser which the result is empty and whose mandatory fields are full or if it does not have mandatory fields
