### PR TITLE
Fixed error with set context from tables and browsers, it is a proble…

### DIFF
--- a/src/store/modules/ADempiere/data.js
+++ b/src/store/modules/ADempiere/data.js
@@ -701,6 +701,12 @@ const data = {
       displayColumn,
       withOutColumnNames = []
     }) {
+      dispatch('setContext', {
+        parentUuid,
+        containerUuid,
+        columnName,
+        value: newValue
+      })
       const recordSelection = state.recordSelection.find(recordItem => {
         return recordItem.containerUuid === containerUuid
       })
@@ -712,7 +718,6 @@ const data = {
       if (row[columnName] === newValue) {
         return
       }
-
       const rowSelection = recordSelection.selection.find(itemRecord => {
         return itemRecord[keyColumn] === rowKey
       })

--- a/src/store/modules/ADempiere/panel.js
+++ b/src/store/modules/ADempiere/panel.js
@@ -77,36 +77,33 @@ const panel = {
               componentPath: itemField.componentPath
             })
           }
-
           if (panelType === 'table' || params.isAdvancedQuery) {
             itemField.isShowedFromUser = false
             if (count < 2 && itemField.isSelectionColumn && itemField.sequence >= 10) {
               itemField.isShowedFromUser = true
               count++
             }
-          } else {
-            if (['browser', 'process', 'report', 'form'].includes(panelType) ||
-              panelType === 'window' && params.isParentTab) {
-              dispatch('setContext', {
-                parentUuid: params.parentUuid,
-                containerUuid: params.uuid,
-                columnName: itemField.columnName,
-                value: itemField.value
+          }
+          //  For all
+          if (['browser', 'process', 'report', 'form', 'table'].includes(panelType) || (panelType === 'window' && params.isParentTab)) {
+            dispatch('setContext', {
+              parentUuid: params.parentUuid,
+              containerUuid: params.uuid,
+              columnName: itemField.columnName,
+              value: itemField.value
+            })
+          }
+          //  Get dependent fields
+          if (!isEmptyValue(itemField.parentFieldsList) && itemField.isActive) {
+            itemField.parentFieldsList.forEach(parentColumnName => {
+              const parentField = listFields.find(parentFieldItem => {
+                return parentFieldItem.columnName === parentColumnName &&
+                  parentColumnName !== itemField.columnName
               })
-            }
-
-            //  Get dependent fields
-            if (!isEmptyValue(itemField.parentFieldsList) && itemField.isActive) {
-              itemField.parentFieldsList.forEach(parentColumnName => {
-                const parentField = listFields.find(parentFieldItem => {
-                  return parentFieldItem.columnName === parentColumnName &&
-                    parentColumnName !== itemField.columnName
-                })
-                if (parentField) {
-                  parentField.dependentFieldsList.push(itemField.columnName)
-                }
-              })
-            }
+              if (parentField) {
+                parentField.dependentFieldsList.push(itemField.columnName)
+              }
+            })
           }
         })
 
@@ -592,7 +589,6 @@ const panel = {
             columnName,
             value: newValue
           })
-
           // request context info field
           if ((!isEmptyValue(field.value) || !isEmptyValue(newValue)) && !isEmptyValue(field.contextInfo) && !isEmptyValue(field.contextInfo.sqlStatement)) {
             let isSQL = false

--- a/src/utils/ADempiere/contextUtils.js
+++ b/src/utils/ADempiere/contextUtils.js
@@ -22,11 +22,18 @@ export const getContext = ({
  * @param {string} displayLogic
  * @param {string} mandatoryLogic
  * @param {string} readOnlyLogic
+ * @param {object} reference
  * @param {string} defaultValue
  * @returns {array} List column name of parent fields
  */
-export function getParentFields({ displayLogic, mandatoryLogic, readOnlyLogic, defaultValue }) {
-  return Array.from(new Set([
+export function getParentFields({
+  displayLogic,
+  mandatoryLogic,
+  readOnlyLogic,
+  reference,
+  defaultValue
+}) {
+  const parentFields = Array.from(new Set([
     //  For Display logic
     ...evaluator.parseDepends(displayLogic),
     //  For Mandatory Logic
@@ -36,6 +43,11 @@ export function getParentFields({ displayLogic, mandatoryLogic, readOnlyLogic, d
     //  For Default Value
     ...evaluator.parseDepends(defaultValue)
   ]))
+  //  Validate reference
+  if (!isEmptyValue(reference)) {
+    parentFields.push(...evaluator.parseDepends(reference.validationCode))
+  }
+  return parentFields
 }
 
 /**
@@ -60,7 +72,6 @@ export function parseContext({
   let isError = false
   const errorsList = []
   value = String(value)
-
   if (isEmptyValue(value)) {
     return {
       value: undefined,


### PR DESCRIPTION
## Bug report / Feature
Fixed error with set context from tables and browsers, it is a problem when exist one field depending, example:
@C_BPartner_Location_ID@ depending of @C_BPartner_ID@
#### Steps to reproduce

1. Go to Requisition-to-Invoice
2. Open window RFQ Topic
3. Create a new header
4. After save go to new line
5. Fill Business Partner
6. Try to fill Business Partner Location

A path for it: http://0.0.0.0:9527/#/203/window/452
#### Expected behavior
Fill Location based on Business Partner selected
