### PR TITLE
Hide and show context information

### DIFF
--- a/src/lang/ADempiere/en.js
+++ b/src/lang/ADempiere/en.js
@@ -250,7 +250,7 @@ export default {
     tagsView: 'Open Tags-View',
     fixedHeader: 'Fixed Header',
     sidebarLogo: 'Sidebar Logo',
-    menuContext: 'Enable context information'
+    contextMenu: 'Show Context Information'
   },
   profile: {
     aboutMe: 'About Me',

--- a/src/lang/ADempiere/en.js
+++ b/src/lang/ADempiere/en.js
@@ -250,7 +250,7 @@ export default {
     tagsView: 'Open Tags-View',
     fixedHeader: 'Fixed Header',
     sidebarLogo: 'Sidebar Logo',
-    contextMenu: 'Show Context Information'
+    showContextMenu: 'Show Context Information'
   },
   profile: {
     aboutMe: 'About Me',

--- a/src/lang/ADempiere/en.js
+++ b/src/lang/ADempiere/en.js
@@ -249,7 +249,8 @@ export default {
     theme: 'Theme Color',
     tagsView: 'Open Tags-View',
     fixedHeader: 'Fixed Header',
-    sidebarLogo: 'Sidebar Logo'
+    sidebarLogo: 'Sidebar Logo',
+    menuContext: 'Enable context information'
   },
   profile: {
     aboutMe: 'About Me',

--- a/src/lang/ADempiere/es.js
+++ b/src/lang/ADempiere/es.js
@@ -225,7 +225,7 @@ export default {
     tagsView: 'Habilitar Tags-View',
     fixedHeader: 'Encabezado fijo',
     sidebarLogo: 'Logotipo de la barra lateral',
-    contextMenu: 'Mostrar Menu de Contexto'
+    showContextMenu: 'Mostrar Menu de Contexto'
   },
   profile: {
     aboutMe: 'Sobre Mi',

--- a/src/lang/ADempiere/es.js
+++ b/src/lang/ADempiere/es.js
@@ -224,7 +224,8 @@ export default {
     theme: 'Color del tema',
     tagsView: 'Habilitar Tags-View',
     fixedHeader: 'Encabezado fijo',
-    sidebarLogo: 'Logotipo de la barra lateral'
+    sidebarLogo: 'Logotipo de la barra lateral',
+    menuContext: 'Habilitar información de contexto'
   },
   profile: {
     aboutMe: 'Sobre Mi',

--- a/src/lang/ADempiere/es.js
+++ b/src/lang/ADempiere/es.js
@@ -225,7 +225,7 @@ export default {
     tagsView: 'Habilitar Tags-View',
     fixedHeader: 'Encabezado fijo',
     sidebarLogo: 'Logotipo de la barra lateral',
-    menuContext: 'Habilitar información de contexto'
+    contextMenu: 'Mostrar Menu de Contexto'
   },
   profile: {
     aboutMe: 'Sobre Mi',

--- a/src/layout/components/Settings/index.vue
+++ b/src/layout/components/Settings/index.vue
@@ -14,6 +14,11 @@
       </div>
 
       <div class="drawer-item">
+        <span>{{ $t('settings.menuContext') }}</span>
+        <el-switch v-model="ShowInfoContext" class="drawer-switch" />
+      </div>
+
+      <div class="drawer-item">
         <span>{{ $t('settings.fixedHeader') }}</span>
         <el-switch v-model="fixedHeader" class="drawer-switch" />
       </div>
@@ -54,6 +59,17 @@ export default {
       set(val) {
         this.$store.dispatch('settings/changeSetting', {
           key: 'tagsView',
+          value: val
+        })
+      }
+    },
+    ShowInfoContext: {
+      get() {
+        return this.$store.state.settings.ShowInfoContext
+      },
+      set(val) {
+        this.$store.dispatch('settings/changeSetting', {
+          key: 'ShowInfoContext',
           value: val
         })
       }

--- a/src/layout/components/Settings/index.vue
+++ b/src/layout/components/Settings/index.vue
@@ -14,8 +14,8 @@
       </div>
 
       <div class="drawer-item">
-        <span>{{ $t('settings.menuContext') }}</span>
-        <el-switch v-model="ShowInfoContext" class="drawer-switch" />
+        <span>{{ $t('settings.contextMenu') }}</span>
+        <el-switch v-model="showMenuContext" class="drawer-switch" />
       </div>
 
       <div class="drawer-item">
@@ -63,13 +63,13 @@ export default {
         })
       }
     },
-    ShowInfoContext: {
+    showMenuContext: {
       get() {
-        return this.$store.state.settings.ShowInfoContext
+        return this.$store.state.settings.showMenuContext
       },
       set(val) {
         this.$store.dispatch('settings/changeSetting', {
-          key: 'ShowInfoContext',
+          key: 'showMenuContext',
           value: val
         })
       }

--- a/src/layout/components/Settings/index.vue
+++ b/src/layout/components/Settings/index.vue
@@ -14,8 +14,8 @@
       </div>
 
       <div class="drawer-item">
-        <span>{{ $t('settings.contextMenu') }}</span>
-        <el-switch v-model="showMenuContext" class="drawer-switch" />
+        <span>{{ $t('settings.showContextMenu') }}</span>
+        <el-switch v-model="showContextMenu" class="drawer-switch" />
       </div>
 
       <div class="drawer-item">
@@ -63,13 +63,13 @@ export default {
         })
       }
     },
-    showMenuContext: {
+    showContextMenu: {
       get() {
-        return this.$store.state.settings.showMenuContext
+        return this.$store.state.settings.showContextMenu
       },
       set(val) {
         this.$store.dispatch('settings/changeSetting', {
-          key: 'showMenuContext',
+          key: 'showContextMenu',
           value: val
         })
       }

--- a/src/store/modules/settings.js
+++ b/src/store/modules/settings.js
@@ -8,7 +8,7 @@ const state = {
   showSettings: showSettings,
   tagsView: tagsView,
   fixedHeader: fixedHeader,
-  showMenuContext: true,
+  showContextMenu: true,
   sidebarLogo: sidebarLogo
 }
 

--- a/src/store/modules/settings.js
+++ b/src/store/modules/settings.js
@@ -1,13 +1,14 @@
 import variables from '@/styles/element-variables.scss'
 import defaultSettings from '@/settings'
 
-const { showSettings, tagsView, fixedHeader, sidebarLogo } = defaultSettings
+const { showSettings, tagsView, fixedHeader, sidebarLogo, ShowInfoContext } = defaultSettings
 
 const state = {
   theme: variables.theme,
   showSettings: showSettings,
   tagsView: tagsView,
   fixedHeader: fixedHeader,
+  ShowInfoContext: ShowInfoContext,
   sidebarLogo: sidebarLogo
 }
 
@@ -31,4 +32,3 @@ export default {
   mutations,
   actions
 }
-

--- a/src/store/modules/settings.js
+++ b/src/store/modules/settings.js
@@ -8,7 +8,7 @@ const state = {
   showSettings: showSettings,
   tagsView: tagsView,
   fixedHeader: fixedHeader,
-  ShowInfoContext: true,
+  showMenuContext: true,
   sidebarLogo: sidebarLogo
 }
 

--- a/src/store/modules/settings.js
+++ b/src/store/modules/settings.js
@@ -1,14 +1,14 @@
 import variables from '@/styles/element-variables.scss'
 import defaultSettings from '@/settings'
 
-const { showSettings, tagsView, fixedHeader, sidebarLogo, ShowInfoContext } = defaultSettings
+const { showSettings, tagsView, fixedHeader, sidebarLogo } = defaultSettings
 
 const state = {
   theme: variables.theme,
   showSettings: showSettings,
   tagsView: tagsView,
   fixedHeader: fixedHeader,
-  ShowInfoContext: ShowInfoContext,
+  ShowInfoContext: true,
   sidebarLogo: sidebarLogo
 }
 

--- a/src/views/ADempiere/Browser/index.vue
+++ b/src/views/ADempiere/Browser/index.vue
@@ -9,7 +9,9 @@
       :container-uuid="browserUuid"
       :panel-type="panelType"
     />
-    <el-header>
+    <el-header
+      v-if="ShowInfoContext"
+    >
       <context-menu
         :menu-parent-uuid="$route.meta.parentUuid"
         :container-uuid="browserUuid"
@@ -103,6 +105,9 @@ export default {
     }
   },
   computed: {
+    ShowInfoContext() {
+      return this.$store.state.settings.ShowInfoContext
+    },
     getterBrowser() {
       return this.$store.getters.getBrowser(this.browserUuid)
     },

--- a/src/views/ADempiere/Form/index.vue
+++ b/src/views/ADempiere/Form/index.vue
@@ -5,7 +5,10 @@
     class="view-base"
     style="height: 84vh;"
   >
-    <el-header style="height: 39px;">
+    <el-header
+      v-if="ShowInfoContext"
+      style="height: 39px; background: white;"
+    >
       <context-menu
         :menu-parent-uuid="$route.meta.parentUuid"
         :container-uuid="formUuid"
@@ -79,6 +82,9 @@ export default {
     }
   },
   computed: {
+    ShowInfoContext() {
+      return this.$store.state.settings.ShowInfoContext
+    },
     formTitle() {
       return this.formMetadata.name || this.$route.meta.title
     },

--- a/src/views/ADempiere/Process/index.vue
+++ b/src/views/ADempiere/Process/index.vue
@@ -5,7 +5,10 @@
     class="view-base"
     style="height: 84vh;"
   >
-    <el-header style="height: 39px;">
+    <el-header
+      v-if="ShowInfoContext"
+      style="height: 39px;"
+    >
       <context-menu
         :menu-parent-uuid="$route.meta.parentUuid"
         :container-uuid="processUuid"
@@ -86,6 +89,9 @@ export default {
     }
   },
   computed: {
+    ShowInfoContext() {
+      return this.$store.state.settings.ShowInfoContext
+    },
     getterProcess() {
       return this.$store.getters.getPanel(this.processUuid)
     },

--- a/src/views/ADempiere/ReportViewer/index.vue
+++ b/src/views/ADempiere/ReportViewer/index.vue
@@ -1,6 +1,7 @@
 <template>
   <div v-if="isLoading" key="report-viewer-loaded" style="min-height: inherit;">
     <context-menu
+      v-if="ShowInfoContext"
       :container-uuid="reportResult.processUuid"
       :panel-type="panelType"
       :is-report="true"
@@ -112,6 +113,9 @@ export default {
   },
   computed: {
     // TODO: Add get metadata from server to open report view from link
+    ShowInfoContext() {
+      return this.$store.state.settings.ShowInfoContext
+    },
     getterProcess() {
       return this.$store.getters.getProcessById(this.$route.params.processId)
     },

--- a/src/views/ADempiere/Window/index.vue
+++ b/src/views/ADempiere/Window/index.vue
@@ -58,7 +58,10 @@
                   <resize-observer @notify="handleResize" />
                   <Split v-shortkey="['f8']" direction="vertical" @onDrag="onDrag" @shortkey.native="handleChangeShowedRecordNavigation(!isShowedRecordNavigation)">
                     <SplitArea :size="sizeAreaStyle" :style="splitAreaStyle">
-                      <el-header :style="isWorkflowBarStatus ? 'height: 45px; background: #F5F7FA' : 'height: 40px'">
+                      <el-header
+                        v-if="ShowInfoContext"
+                        :style="isWorkflowBarStatus ? 'height: 45px; background: #F5F7FA' : 'height: 40px'"
+                      >
                         <el-container>
                           <el-aside width="100%" style="width: 78vw;overflow: hidden;">
                             <el-scrollbar>
@@ -340,6 +343,9 @@ export default {
     next()
   },
   computed: {
+    ShowInfoContext() {
+      return this.$store.state.settings.ShowInfoContext
+    },
     defaultPorcentSplitPane() {
       if (this.isShowedRecordPanel) {
         if (this.isShowedRecordNavigation) {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
Added an option in the quick configuration panel to hide or show the context information
#### Steps to reproduce

1- Open a Process
2- Go to the gear that appears to the right of the api
3- Open quick configuration panel
4- Enable or hide context information
#### Screenshot or Gif

![action](https://user-images.githubusercontent.com/45974454/80639835-8dc85080-8a30-11ea-9852-d1d6c543af73.gif)

#### Other relevant information
- Your OS: Debian 9
- Node.js version: 10
