### PR TITLE
raname variable

### DIFF
--- a/src/views/ADempiere/Browser/index.vue
+++ b/src/views/ADempiere/Browser/index.vue
@@ -10,7 +10,7 @@
       :panel-type="panelType"
     />
     <el-header
-      v-if="ShowInfoContext"
+      v-if="showContextMenu"
     >
       <context-menu
         :menu-parent-uuid="$route.meta.parentUuid"
@@ -105,7 +105,7 @@ export default {
     }
   },
   computed: {
-    ShowInfoContext() {
+    showContextMenu() {
       return this.$store.state.settings.showContextMenu
     },
     getterBrowser() {

--- a/src/views/ADempiere/Browser/index.vue
+++ b/src/views/ADempiere/Browser/index.vue
@@ -106,7 +106,7 @@ export default {
   },
   computed: {
     ShowInfoContext() {
-      return this.$store.state.settings.ShowInfoContext
+      return this.$store.state.settings.showContextMenu
     },
     getterBrowser() {
       return this.$store.getters.getBrowser(this.browserUuid)

--- a/src/views/ADempiere/Form/index.vue
+++ b/src/views/ADempiere/Form/index.vue
@@ -83,7 +83,7 @@ export default {
   },
   computed: {
     ShowInfoContext() {
-      return this.$store.state.settings.ShowInfoContext
+      return this.$store.state.settings.showContextMenu
     },
     formTitle() {
       return this.formMetadata.name || this.$route.meta.title

--- a/src/views/ADempiere/Form/index.vue
+++ b/src/views/ADempiere/Form/index.vue
@@ -6,7 +6,7 @@
     style="height: 84vh;"
   >
     <el-header
-      v-if="ShowInfoContext"
+      v-if="showContextMenu"
       style="height: 39px; background: white;"
     >
       <context-menu
@@ -82,7 +82,7 @@ export default {
     }
   },
   computed: {
-    ShowInfoContext() {
+    showContextMenu() {
       return this.$store.state.settings.showContextMenu
     },
     formTitle() {

--- a/src/views/ADempiere/Process/index.vue
+++ b/src/views/ADempiere/Process/index.vue
@@ -6,7 +6,7 @@
     style="height: 84vh;"
   >
     <el-header
-      v-if="ShowInfoContext"
+      v-if="showContextMenu"
       style="height: 39px;"
     >
       <context-menu
@@ -89,7 +89,7 @@ export default {
     }
   },
   computed: {
-    ShowInfoContext() {
+    showContextMenu() {
       return this.$store.state.settings.showContextMenu
     },
     getterProcess() {

--- a/src/views/ADempiere/Process/index.vue
+++ b/src/views/ADempiere/Process/index.vue
@@ -90,7 +90,7 @@ export default {
   },
   computed: {
     ShowInfoContext() {
-      return this.$store.state.settings.ShowInfoContext
+      return this.$store.state.settings.showContextMenu
     },
     getterProcess() {
       return this.$store.getters.getPanel(this.processUuid)

--- a/src/views/ADempiere/ReportViewer/index.vue
+++ b/src/views/ADempiere/ReportViewer/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="isLoading" key="report-viewer-loaded" style="min-height: inherit;">
     <context-menu
-      v-if="ShowInfoContext"
+      v-if="showContextMenu"
       :container-uuid="reportResult.processUuid"
       :panel-type="panelType"
       :is-report="true"
@@ -113,7 +113,7 @@ export default {
   },
   computed: {
     // TODO: Add get metadata from server to open report view from link
-    ShowInfoContext() {
+    showContextMenu() {
       return this.$store.state.settings.showContextMenu
     },
     getterProcess() {

--- a/src/views/ADempiere/ReportViewer/index.vue
+++ b/src/views/ADempiere/ReportViewer/index.vue
@@ -114,7 +114,7 @@ export default {
   computed: {
     // TODO: Add get metadata from server to open report view from link
     ShowInfoContext() {
-      return this.$store.state.settings.ShowInfoContext
+      return this.$store.state.settings.showContextMenu
     },
     getterProcess() {
       return this.$store.getters.getProcessById(this.$route.params.processId)

--- a/src/views/ADempiere/Window/index.vue
+++ b/src/views/ADempiere/Window/index.vue
@@ -344,7 +344,7 @@ export default {
   },
   computed: {
     ShowInfoContext() {
-      return this.$store.state.settings.ShowInfoContext
+      return this.$store.state.settings.showContextMenu
     },
     defaultPorcentSplitPane() {
       if (this.isShowedRecordPanel) {

--- a/src/views/ADempiere/Window/index.vue
+++ b/src/views/ADempiere/Window/index.vue
@@ -59,7 +59,7 @@
                   <Split v-shortkey="['f8']" direction="vertical" @onDrag="onDrag" @shortkey.native="handleChangeShowedRecordNavigation(!isShowedRecordNavigation)">
                     <SplitArea :size="sizeAreaStyle" :style="splitAreaStyle">
                       <el-header
-                        v-if="ShowInfoContext"
+                        v-if="showContextMenu"
                         :style="isWorkflowBarStatus ? 'height: 45px; background: #F5F7FA' : 'height: 40px'"
                       >
                         <el-container>
@@ -343,7 +343,7 @@ export default {
     next()
   },
   computed: {
-    ShowInfoContext() {
+    showContextMenu() {
       return this.$store.state.settings.showContextMenu
     },
     defaultPorcentSplitPane() {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
Added an option in the quick configuration panel to hide or show the context information
#### Steps to reproduce

1- Open a Process
2- Go to the gear that appears to the right of the api
3- Open quick configuration panel
4- Enable or hide context information
#### Screenshot or Gif

![action](https://user-images.githubusercontent.com/45974454/80639835-8dc85080-8a30-11ea-9852-d1d6c543af73.gif)

#### Other relevant information
- Your OS: Debian 9
- Node.js version: 10
