### PR TITLE
feat: Add autofocus and showControl attributes.

### DIFF
--- a/src/components/ADempiere/Field/FieldMixin.js
+++ b/src/components/ADempiere/Field/FieldMixin.js
@@ -38,7 +38,9 @@ export const fieldMixin = {
   },
   methods: {
     activeFocus() {
-      this.$refs[this.metadata.columnName].focus()
+      if (this.$refs[this.metadata.columnName]) {
+        this.$refs[this.metadata.columnName].focus()
+      }
     },
     /**
      * Overwrite component method if necessary
@@ -49,6 +51,14 @@ export const fieldMixin = {
       this.handleChange(value)
     },
     focusGained(value) {
+      if (this.metadata.isAutoSelection) {
+        // select all the content inside the text box
+        if (!this.isEmptyValue(value.target.selectionStart) &&
+          !this.isEmptyValue(value.target.selectionStart)) {
+          value.target.selectionStart = 0
+          value.target.selectionEnd = value.target.value.length
+        }
+      }
       if (this.metadata.handleFocusGained) {
         this.$store.dispatch('notifyFocusGained', {
           containerUuid: this.metadata.containerUuid,

--- a/src/components/ADempiere/Field/FieldNumber.vue
+++ b/src/components/ADempiere/Field/FieldNumber.vue
@@ -9,7 +9,8 @@
       :placeholder="metadata.help"
       :disabled="isDisabled"
       :precision="precision"
-      controls-position="right"
+      :controls="isShowControls"
+      :controls-position="controlsPosition"
       :class="'display-type-amount ' + metadata.cssClassName"
       @change="preHandleChange"
       @blur="focusLost"
@@ -62,6 +63,24 @@ export default {
         return 2
       }
       return undefined
+    },
+    isShowControls() {
+      if (!this.isEmptyValue(this.metadata.showControl)) {
+        if (this.metadata.showControl === 0) {
+          return false
+        }
+      }
+      return true
+    },
+    controlsPosition() {
+      if (!this.isEmptyValue(this.metadata.showControl)) {
+        // show side controls
+        if (this.metadata.showControl === 1) {
+          return undefined
+        }
+      }
+      // show right controls
+      return 'right'
     }
   },
   watch: {

--- a/src/components/ADempiere/Field/FieldYesNo.vue
+++ b/src/components/ADempiere/Field/FieldYesNo.vue
@@ -89,6 +89,6 @@ export default {
 
 <style>
   .custom-field-yes-no {
-    min-height: 34px;
+    max-height: 34px;
   }
 </style>

--- a/src/views/ADempiere/TestView/fieldsList.js
+++ b/src/views/ADempiere/TestView/fieldsList.js
@@ -6,6 +6,7 @@ export default [
     columnName: 'URL',
     definition: {
       name: 'Web',
+      isAutoSelection: true,
       displayType: URL.id
     }
   },
@@ -69,7 +70,8 @@ export default [
     definition: {
       name: 'Sequence for record',
       displayType: INTEGER.id,
-      mandatoryLogic: '@URL@!""'
+      mandatoryLogic: '@URL@!""',
+      showControl: 1
     }
   },
   // Text Long


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

Select all the content inside the text box
```javascript
  {
    columnName: 'URL',
    definition: {
      name: 'Web',
      isAutoSelection: true, // set autofocus
      displayType: URL.id
    }
  }
```
To configure control display 0 = controls disabled, 1 = side controls, any other value controls to the right
```javascript
  {
    columnName: 'SeqNo',
    definition: {
      name: 'Sequence for record',
      displayType: INTEGER.id,
      mandatoryLogic: '@URL@!""',
      showControl: 1
    }
  }
```

![isAutoFous](https://user-images.githubusercontent.com/20288327/80841137-cac94a00-8bcc-11ea-8ed4-f93da20241cd.gif)


#### Additional context
The selection of content is valid only for components that contain text boxes.
The control display is available only for number components.
