### PR TITLE
fix: Dashboard route path.

### DIFF
--- a/src/components/ADempiere/Dashboard/calendar/index.vue
+++ b/src/components/ADempiere/Dashboard/calendar/index.vue
@@ -3,7 +3,7 @@
     <!-- Use 2.5 slot syntax. If you use Vue 2.6, please use new slot syntax-->
     <template
       slot="dateCell"
-      slot-scope="{date, data}"
+      slot-scope="{ date, data }"
     >
       <p :class="data.isSelected ? 'is-selected' : ''">
         {{ data.day.split('-').slice(2).join('-') }} {{ data.isSelected ? '✔️' : '' }}

--- a/src/components/ADempiere/Dashboard/docstatus/index.vue
+++ b/src/components/ADempiere/Dashboard/docstatus/index.vue
@@ -59,7 +59,11 @@ export default {
   },
   mounted() {
     this.getPendingDocuments()
-    this.subscribeChanges()
+
+    this.unsubscribe = this.subscribeChanges()
+  },
+  beforeDestroy() {
+    this.unsubscribe()
   },
   methods: {
     showMessage,
@@ -130,7 +134,7 @@ export default {
 
 <style scoped>
   .search_recent {
-    width: 50%!important;
+    width: 50% !important;
     float: right;
   }
   .header {

--- a/src/components/ADempiere/Dashboard/recentItems/index.vue
+++ b/src/components/ADempiere/Dashboard/recentItems/index.vue
@@ -73,7 +73,11 @@ export default {
   },
   mounted() {
     this.getRecentItems({ pageToken: undefined, pageSize: undefined })
-    this.subscribeChanges()
+
+    this.unsubscribe = this.subscribeChanges()
+  },
+  beforeDestroy() {
+    this.unsubscribe()
   },
   methods: {
     showMessage,
@@ -120,11 +124,16 @@ export default {
         if (!this.isEmptyValue(row.uuidRecord)) {
           recordUuid = row.uuidRecord
         }
+        let tabParent
+        if (row.action === 'window') {
+          tabParent = 0
+        }
+
         this.$router.push({
           name: viewSearch.name,
           query: {
             action: recordUuid,
-            tabParent: 0
+            tabParent
           }
         })
       } else {
@@ -157,7 +166,7 @@ export default {
 
 <style scoped>
   .search_recent {
-    width: 50%!important;
+    width: 50% !important;
     float: right;
   }
   .header {

--- a/src/components/ADempiere/Dashboard/userfavorites/index.vue
+++ b/src/components/ADempiere/Dashboard/userfavorites/index.vue
@@ -75,7 +75,11 @@ export default {
   },
   mounted() {
     this.getFavoritesList()
-    this.subscribeChanges()
+
+    this.unsubscribe = this.subscribeChanges()
+  },
+  beforeDestroy() {
+    this.unsubscribe()
   },
   methods: {
     showMessage,
@@ -124,11 +128,16 @@ export default {
         if (!this.isEmptyValue(row.uuidRecord)) {
           recordUuid = row.uuidRecord
         }
+        let tabParent
+        if (row.action === 'window') {
+          tabParent = 0
+        }
+
         this.$router.push({
           name: viewSearch.name,
           query: {
             action: recordUuid,
-            tabParent: 0
+            tabParent
           }
         })
       } else {
@@ -178,7 +187,7 @@ export default {
 
 <style scoped>
   .search_recent {
-    width: 50%!important;
+    width: 50% !important;
     float: right;
   }
   .header {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce
1. Go to the dashboard recent items or favorites.
2. Open a Report/Process, Smart Browser, or Form.

#### Screenshot or Gif
After this PR:
![dashboard-route-path-error](https://user-images.githubusercontent.com/20288327/81089491-707d0180-8eca-11ea-8f97-2da2eda6f58d.gif)

Before this PR:
![dashboard-route-path-fix](https://user-images.githubusercontent.com/20288327/81089622-93a7b100-8eca-11ea-82e6-219e891505a4.gif)

#### Expected behavior
The path 'tabParent' should not exist in the path, since it only belongs to windows.
