### PR TITLE
fix: Not set value without fieldList.

### DIFF
--- a/src/components/ADempiere/Field/FieldMixin.js
+++ b/src/components/ADempiere/Field/FieldMixin.js
@@ -140,6 +140,12 @@ export const fieldMixin = {
           value: newValue
         })
       }
+
+      // if is custom field, set custom handle change value
+      if (this.metadata.isCustomField) {
+        return
+      }
+
       if (this.metadata.inTable) {
         this.$store.dispatch('notifyCellTableChange', {
           ...sendParameters,

--- a/src/components/ADempiere/Form/index.vue
+++ b/src/components/ADempiere/Form/index.vue
@@ -22,6 +22,9 @@ export default {
         case 'PriceChecking':
           form = import('@/components/ADempiere/Form/PriceChecking')
           break
+        default:
+          form = import('@/views/ADempiere/Unsupported')
+          break
       }
 
       return () => {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
If a change is made to a field in a form, and that form does not handle a list of fields as the property of the panel, an error is generated when calling the action `notifyFieldChange`, therefore you must finish executing the field before making that call.

#### Screenshot or Gif
![erroredwin](https://user-images.githubusercontent.com/45974454/81103912-b5f7f980-8edf-11ea-8415-6a50f02698dc.gif)

