### PR TITLE
fix: Empty mandatory and read only fields.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@adempiere/grpc-access-client": "^1.2.0",
-    "@adempiere/grpc-data-client": "^2.2.9",
+    "@adempiere/grpc-data-client": "^2.3.2",
     "@adempiere/grpc-dictionary-client": "^1.4.1",
     "@adempiere/grpc-enrollment-client": "^1.1.0",
     "@adempiere/grpc-pos-client": "^1.1.0",
@@ -104,7 +104,7 @@
     "eslint": "^6.8.0",
     "eslint-plugin-vue": "6.2.2",
     "html-webpack-plugin": "4.2.1",
-    "husky": "4.2.5",
+    "husky": "^4.2.5",
     "lint-staged": "10.2.0",
     "mockjs": "1.1.0",
     "node-sass": "^4.14.0",

--- a/src/store/modules/ADempiere/calloutControl.js
+++ b/src/store/modules/ADempiere/calloutControl.js
@@ -16,6 +16,7 @@ const callOutControl = {
      * @param {Object} row, if callout is activate in table
      * @param {Mixed} value
      * @param {Mixed} oldValue
+     * @param {String} valueType
      * @return {Promise} values
      */
     getCallout({ rootGetters, dispatch }, {
@@ -40,11 +41,12 @@ const callOutControl = {
         runCallOutRequest({
           windowUuid: parentUuid,
           tabUuid: containerUuid,
+          callout,
           tableName,
           columnName,
           value,
           oldValue,
-          callout,
+          valueType,
           attributesList,
           windowNo: window.windowIndex
         })

--- a/src/utils/ADempiere/dictionaryUtils.js
+++ b/src/utils/ADempiere/dictionaryUtils.js
@@ -101,43 +101,44 @@ export function generateField({
     }
 
     // VALUE TO
-    if (String(parsedDefaultValueTo).includes('@') &&
-      String(parsedDefaultValueTo).trim() !== '-1') {
-      parsedDefaultValueTo = parseContext({
-        ...moreAttributes,
-        columnName: `${fieldToGenerate.columnName}_To`,
-        value: parsedDefaultValueTo
-      }).value
-    }
+    if (fieldToGenerate.isRange) {
+      if (String(parsedDefaultValueTo).includes('@') &&
+        String(parsedDefaultValueTo).trim() !== '-1') {
+        parsedDefaultValueTo = parseContext({
+          ...moreAttributes,
+          columnName: `${fieldToGenerate.columnName}_To`,
+          value: parsedDefaultValueTo
+        }).value
+      }
 
-    if (isEmptyValue(parsedDefaultValueTo) &&
-      !(fieldToGenerate.isKey || fieldToGenerate.isParent) &&
-      String(parsedDefaultValueTo).trim() !== '-1') {
-      parsedDefaultValueTo = getPreference({
-        parentUuid: fieldToGenerate.parentUuid,
-        containerUuid: fieldToGenerate.containerUuid,
-        columnName: `${fieldToGenerate.columnName}_To`
-      })
-
-      // search value preference with elementName
-      if (!isEmptyValue(fieldToGenerate.elementName) &&
-        isEmptyValue(parsedDefaultValueTo)) {
+      if (isEmptyValue(parsedDefaultValueTo) &&
+        !(fieldToGenerate.isKey || fieldToGenerate.isParent) &&
+        String(parsedDefaultValueTo).trim() !== '-1') {
         parsedDefaultValueTo = getPreference({
           parentUuid: fieldToGenerate.parentUuid,
           containerUuid: fieldToGenerate.containerUuid,
-          columnName: `${fieldToGenerate.elementName}_To`
+          columnName: `${fieldToGenerate.columnName}_To`
         })
+
+        // search value preference with elementName
+        if (!isEmptyValue(fieldToGenerate.elementName) &&
+          isEmptyValue(parsedDefaultValueTo)) {
+          parsedDefaultValueTo = getPreference({
+            parentUuid: fieldToGenerate.parentUuid,
+            containerUuid: fieldToGenerate.containerUuid,
+            columnName: `${fieldToGenerate.elementName}_To`
+          })
+        }
       }
+
+      parsedDefaultValueTo = parsedValueComponent({
+        fieldType: componentReference.componentPath,
+        value: parsedDefaultValueTo,
+        displayType: fieldToGenerate.displayType,
+        isMandatory: fieldToGenerate.isMandatory,
+        isIdentifier: fieldToGenerate.columnName.includes('_ID')
+      })
     }
-
-    parsedDefaultValueTo = parsedValueComponent({
-      fieldType: componentReference.componentPath,
-      value: parsedDefaultValueTo,
-      displayType: fieldToGenerate.displayType,
-      isMandatory: fieldToGenerate.isMandatory,
-      isIdentifier: fieldToGenerate.columnName.includes('_ID')
-    })
-
     parentFieldsList = getParentFields(fieldToGenerate)
 
     // evaluate logics

--- a/src/utils/ADempiere/references.js
+++ b/src/utils/ADempiere/references.js
@@ -28,7 +28,7 @@ export const NUMBER = {
   id: 12,
   isSupported: true,
   valueType: 'DECIMAL',
-  componentPath: 'FieldText',
+  componentPath: 'FieldNumber',
   size: {
     xs: 24,
     sm: 12,
@@ -104,7 +104,7 @@ export const COLOR = {
   id: 27,
   isSupported: false,
   valueType: 'INTEGER',
-  componentPath: 'FieldText',
+  componentPath: 'FieldColor',
   size: {
     xs: 24,
     sm: 12,

--- a/src/utils/ADempiere/valueUtils.js
+++ b/src/utils/ADempiere/valueUtils.js
@@ -169,6 +169,7 @@ export function convertFieldListToShareLink(fieldList) {
 
   return attributesListLink.slice(0, -1)
 }
+
 /**
  * Find element in an array recursively
  * @param {object|array} treeData
@@ -256,7 +257,8 @@ export function parsedValueComponent({
   isMandatory = false,
   isIdentifier = false
 }) {
-  if ((value === undefined || value === null) && !isMandatory) {
+  const isEmpty = isEmptyValue(value)
+  if (isEmpty && !isMandatory) {
     if (fieldType === 'FieldYesNo') {
       return Boolean(value)
     }
@@ -267,7 +269,7 @@ export function parsedValueComponent({
   switch (fieldType) {
     // data type Number
     case 'FieldNumber':
-      if (String(value).trim() === '' || value === undefined || value === null) {
+      if (isEmpty) {
         returnValue = undefined
         if (isMandatory) {
           returnValue = 0
@@ -305,7 +307,7 @@ export function parsedValueComponent({
     // data type Date
     case 'FieldDate':
     case 'FieldTime ':
-      if (String(value).trim() === '') {
+      if (isEmpty) {
         value = undefined
       }
       if (!isNaN(value)) {
@@ -321,7 +323,7 @@ export function parsedValueComponent({
       break
 
     case 'FieldSelect':
-      if (String(value).trim() === '') {
+      if (isEmpty) {
         value = undefined
       }
       if (typeof value === 'boolean') {
@@ -329,7 +331,7 @@ export function parsedValueComponent({
       }
       // Table (18) or Table Direct (19)
       if (displayType === TABLE.id || (displayType === TABLE_DIRECT.id && isIdentifier)) {
-        if (value !== '' && value !== null && value !== undefined) {
+        if (!isEmptyValue(value)) {
           value = Number(value)
         }
       } // Search or List
@@ -342,6 +344,7 @@ export function parsedValueComponent({
   }
   return returnValue
 }
+
 /**
  * add a tab depending on the status of the document
  * @param {string} tag, document status key


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce
1. Open the 'Sales Orders' window.
2. Select the 'create new' option.
3. See the 'Grand Total' and 'Total Lines' fields.

#### Screenshot or Gif
Before this PR:
![empty-mandatory-read-only-fields-error](https://user-images.githubusercontent.com/20288327/81188249-18560600-8f83-11ea-926c-6f64f09903be.gif)

After this PR:
![empty-mandatory-read-only-fields-fix](https://user-images.githubusercontent.com/20288327/81188260-1b50f680-8f83-11ea-9999-145740139dd7.gif)

#### Expected behavior
If the field is numeric, and must show the value by default by 0, even more if it is only read since you cannot set a value manually from the field, since this prevents a new record from being created.

#### Additional context
This PR depends on a change in the grpc data client https://github.com/erpcya/gRPC-Data-Client/pull/60