### PR TITLE
feat: Add handle focus to field.

### DIFF
--- a/src/components/ADempiere/Field/FieldMixin.js
+++ b/src/components/ADempiere/Field/FieldMixin.js
@@ -37,7 +37,7 @@ export const fieldMixin = {
     }
   },
   mounted() {
-    if (this.metadata.isAutoFocus || this.metadata.handleFocus) {
+    if (this.metadata.handleFocus) {
       this.requestFocus()
     }
   },
@@ -59,7 +59,7 @@ export const fieldMixin = {
       this.handleChange(value)
     },
     focusGained(value) {
-      if (this.metadata.isAutoSelection) {
+      if (this.metadata.handleSelection) {
         // select all the content inside the text box
         if (!this.isEmptyValue(value.target.selectionStart) &&
           !this.isEmptyValue(value.target.selectionStart)) {

--- a/src/components/ADempiere/Field/FieldMixin.js
+++ b/src/components/ADempiere/Field/FieldMixin.js
@@ -36,6 +36,11 @@ export const fieldMixin = {
       this.preHandleChange(value)
     }
   },
+  mounted() {
+    if (this.metadata.isAutoFocus || this.metadata.handleFocus) {
+      this.requestFocus()
+    }
+  },
   methods: {
     /**
      * Set focus if handle focus attribute is true

--- a/src/components/ADempiere/Field/FieldMixin.js
+++ b/src/components/ADempiere/Field/FieldMixin.js
@@ -18,7 +18,7 @@ export const fieldMixin = {
       value = this.valueModel
     }
     return {
-      value: value
+      value
     }
   },
   computed: {
@@ -37,7 +37,10 @@ export const fieldMixin = {
     }
   },
   methods: {
-    activeFocus() {
+    /**
+     * Set focus if handle focus attribute is true
+     */
+    requestFocus() {
       if (this.$refs[this.metadata.columnName]) {
         this.$refs[this.metadata.columnName].focus()
       }

--- a/src/components/ADempiere/Field/FieldMixin.js
+++ b/src/components/ADempiere/Field/FieldMixin.js
@@ -37,7 +37,7 @@ export const fieldMixin = {
     }
   },
   mounted() {
-    if (this.metadata.handleFocus) {
+    if (this.metadata.handleRequestFocus) {
       this.requestFocus()
     }
   },
@@ -59,7 +59,7 @@ export const fieldMixin = {
       this.handleChange(value)
     },
     focusGained(value) {
-      if (this.metadata.handleSelection) {
+      if (this.metadata.handleContentSelection) {
         // select all the content inside the text box
         if (!this.isEmptyValue(value.target.selectionStart) &&
           !this.isEmptyValue(value.target.selectionStart)) {

--- a/src/components/ADempiere/Field/index.vue
+++ b/src/components/ADempiere/Field/index.vue
@@ -371,7 +371,7 @@ export default {
   },
   methods: {
     focusField() {
-      if (this.metadata.handleFocus || (this.field.displayed && !this.field.readonly)) {
+      if (this.field.handleFocus || this.field.isAutoFocus || (this.field.displayed && !this.field.readonly)) {
         this.$refs[this.field.columnName].requestFocus()
       }
     }

--- a/src/components/ADempiere/Field/index.vue
+++ b/src/components/ADempiere/Field/index.vue
@@ -371,8 +371,8 @@ export default {
   },
   methods: {
     focusField() {
-      if (this.isDisplayed && !this.isReadOnly) {
-        this.$refs[this.field.columnName].activeFocus()
+      if (this.metadata.handleFocus || (this.field.displayed && !this.field.readonly)) {
+        this.$refs[this.field.columnName].requestFocus()
       }
     }
   }

--- a/src/components/ADempiere/Field/index.vue
+++ b/src/components/ADempiere/Field/index.vue
@@ -371,7 +371,7 @@ export default {
   },
   methods: {
     focusField() {
-      if (this.field.handleFocus || (this.field.displayed && !this.field.readonly)) {
+      if (this.field.handleRequestFocus || (this.field.displayed && !this.field.readonly)) {
         this.$refs[this.field.columnName].requestFocus()
       }
     }

--- a/src/components/ADempiere/Field/index.vue
+++ b/src/components/ADempiere/Field/index.vue
@@ -371,7 +371,7 @@ export default {
   },
   methods: {
     focusField() {
-      if (this.field.handleFocus || this.field.isAutoFocus || (this.field.displayed && !this.field.readonly)) {
+      if (this.field.handleFocus || (this.field.displayed && !this.field.readonly)) {
         this.$refs[this.field.columnName].requestFocus()
       }
     }

--- a/src/components/ADempiere/Panel/index.vue
+++ b/src/components/ADempiere/Panel/index.vue
@@ -709,7 +709,7 @@ export default {
     async setFocus() {
       return new Promise(resolve => {
         const fieldFocus = this.getterFieldList.find(itemField => {
-          if (itemField.handleFocus) {
+          if (itemField.handleRequestFocus) {
             return true
           }
           if (Object.prototype.hasOwnProperty.call(this.$refs, itemField.columnName)) {

--- a/src/components/ADempiere/Panel/index.vue
+++ b/src/components/ADempiere/Panel/index.vue
@@ -700,13 +700,18 @@ export default {
         }
       }
       this.setTagsViewTitle(uuidRecord)
-      this.setFocus()
+      if (this.$route.query.action === 'create-new') {
+        this.setFocus()
+      }
       const currentRecord = this.getterDataStore.record.find(record => record.UUID === uuidRecord)
       this.$store.dispatch('currentRecord', currentRecord)
     },
     async setFocus() {
       return new Promise(resolve => {
         const fieldFocus = this.getterFieldList.find(itemField => {
+          if (itemField.isAutoFocus || itemField.handleFocus) {
+            return true
+          }
           if (Object.prototype.hasOwnProperty.call(this.$refs, itemField.columnName)) {
             if (fieldIsDisplayed(itemField) && !itemField.isReadOnly && itemField.isUpdateable && itemField.componentPath !== 'FieldSelect') {
               return true

--- a/src/components/ADempiere/Panel/index.vue
+++ b/src/components/ADempiere/Panel/index.vue
@@ -709,7 +709,7 @@ export default {
     async setFocus() {
       return new Promise(resolve => {
         const fieldFocus = this.getterFieldList.find(itemField => {
-          if (itemField.isAutoFocus || itemField.handleFocus) {
+          if (itemField.handleFocus) {
             return true
           }
           if (Object.prototype.hasOwnProperty.call(this.$refs, itemField.columnName)) {

--- a/src/views/ADempiere/Test/fieldsList.js
+++ b/src/views/ADempiere/Test/fieldsList.js
@@ -6,8 +6,8 @@ export default [
     columnName: 'URL',
     definition: {
       name: 'Web',
-      isAutoFocus: true, // or handleFocus
-      isAutoSelection: true,
+      handleFocus: true,
+      handleSelection: true,
       displayType: URL.id
     }
   },

--- a/src/views/ADempiere/Test/fieldsList.js
+++ b/src/views/ADempiere/Test/fieldsList.js
@@ -6,6 +6,7 @@ export default [
     columnName: 'URL',
     definition: {
       name: 'Web',
+      isAutoFocus: true, // or handleFocus
       isAutoSelection: true,
       displayType: URL.id
     }

--- a/src/views/ADempiere/Test/fieldsList.js
+++ b/src/views/ADempiere/Test/fieldsList.js
@@ -6,8 +6,8 @@ export default [
     columnName: 'URL',
     definition: {
       name: 'Web',
-      handleFocus: true,
-      handleSelection: true,
+      handleRequestFocus: true,
+      handleContentSelection: true,
       displayType: URL.id
     }
   },


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Description
Set focus to the indicated field, if said handles `handleRequestFocus` attribute to `true`.

![is-atofocus](https://user-images.githubusercontent.com/20288327/81426176-d4036b00-9126-11ea-8c6a-b69c3e536c91.gif)


#### Additional context
To set the attribute in the lookup factory by definition into definition:
```javascript
  {
    columnName: 'URL',
    definition: {
      name: 'Web',
      handleRequestFocus: true,
      displayType: URL.id
    }
  }
```

To set the attribute in the factoty lookup by dictionary, into overwriteDefinition:
 ```javascript
  {
    tableName: 'C_BPartner',
    columnName: 'PaymentRule',
    isFromDictionary: true,
    overwriteDefinition: {
      isMandatory: true,
      handleRequestFocus: true
    }
  }
```