### PR TITLE
fix: Search menu into navbar.

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "echarts": "4.7.0",
     "element-ui": "2.13.1",
     "file-saver": "2.0.2",
-    "fuse.js": "5.2.3",
+    "fuse.js": "3.4.4",
     "js-cookie": "2.2.1",
     "jsonlint": "1.6.3",
     "jszip": "3.4.0",
@@ -66,7 +66,7 @@
     "moment": "^2.24.0",
     "normalize.css": "8.0.1",
     "nprogress": "0.2.0",
-    "path-to-regexp": "6.1.0",
+    "path-to-regexp": "2.4.0",
     "screenfull": "5.0.2",
     "script-loader": "0.7.2",
     "showdown": "1.9.1",
@@ -87,7 +87,7 @@
     "xlsx": "0.15.6"
   },
   "devDependencies": {
-    "@adempiere/grpc-core-client": "^1.0.3",
+    "@adempiere/grpc-core-client": "^1.0.4",
     "@babel/core": "7.9.0",
     "@babel/register": "7.9.0",
     "@vue/cli-plugin-babel": "4.3.1",


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

### Description
When a search is made in the navbar for the main menu items, an error is generated in the console.

After this PR:
![search-menu-error](https://user-images.githubusercontent.com/20288327/82090735-1cd99780-96c4-11ea-9c63-c10b578ff3d3.gif)

Before this PR:
![search-menu-fixed](https://user-images.githubusercontent.com/20288327/82090512-b8b6d380-96c3-11ea-8111-08382b53ccbd.gif)

### Additional context:
This error is generated since there is still no compatibility with the new versions of the `fuse.js` and `path-to-regexp` libraries.
