### PR TITLE
fix: Error with `this.unsubscribe is not a function`

### DIFF
--- a/src/components/ADempiere/Dashboard/docstatus/index.vue
+++ b/src/components/ADempiere/Dashboard/docstatus/index.vue
@@ -40,6 +40,7 @@ export default {
   data() {
     return {
       documents: [],
+      unsubscribe: () => {},
       search: ''
     }
   },
@@ -89,7 +90,7 @@ export default {
       })
     },
     subscribeChanges() {
-      this.$store.subscribe((mutation, state) => {
+      return this.$store.subscribe((mutation, state) => {
         if (mutation.type === 'notifyDashboardRefresh') {
           this.getPendingDocuments()
         }

--- a/src/components/ADempiere/Dashboard/recentItems/index.vue
+++ b/src/components/ADempiere/Dashboard/recentItems/index.vue
@@ -49,6 +49,7 @@ export default {
   data() {
     return {
       recentItems: [],
+      unsubscribe: () => {},
       isLoaded: true,
       search: '',
       accentRegexp: /[\u0300-\u036f]/g
@@ -144,7 +145,7 @@ export default {
       }
     },
     subscribeChanges() {
-      this.$store.subscribe((mutation, state) => {
+      return this.$store.subscribe((mutation, state) => {
         if (mutation.type === 'notifyDashboardRefresh') {
           this.getRecentItems()
         }

--- a/src/components/ADempiere/Dashboard/userfavorites/index.vue
+++ b/src/components/ADempiere/Dashboard/userfavorites/index.vue
@@ -54,6 +54,7 @@ export default {
   data() {
     return {
       favorites: [],
+      unsubscribe: () => {},
       isLoaded: true,
       search: '',
       accentRegexp: /[\u0300-\u036f]/g
@@ -108,7 +109,7 @@ export default {
       })
     },
     subscribeChanges() {
-      this.$store.subscribe((mutation, state) => {
+      return this.$store.subscribe((mutation, state) => {
         if (mutation.type === 'notifyDashboardRefresh') {
           this.getFavoritesList()
         }

--- a/src/components/ADempiere/Form/PriceChecking/index.vue
+++ b/src/components/ADempiere/Form/PriceChecking/index.vue
@@ -37,7 +37,8 @@ export default {
   mixins: [formMixin],
   data() {
     return {
-      fieldsList
+      fieldsList,
+      unsubscribe: () => {}
     }
   },
   created() {

--- a/src/views/ADempiere/Test/index.vue
+++ b/src/views/ADempiere/Test/index.vue
@@ -96,7 +96,8 @@ export default {
   },
   data() {
     return {
-      fieldsList
+      fieldsList,
+      unsubscribe: () => {}
     }
   },
   computed: {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce
1. Log in with any role that has associated dashboards.
2. Change the role to one without associated dashboards.

#### Screenshot or Gif
**Before this PR:**
![unsubscribe-error](https://user-images.githubusercontent.com/20288327/82232714-f8b4cb00-98fc-11ea-95a4-56f8fb461ab2.gif)

**After this PR:**
![unsubscribe-fixed](https://user-images.githubusercontent.com/20288327/82232507-bab7a700-98fc-11ea-8bb7-6e2fd072ab3c.gif)


#### Expected behavior
Dismounting the component should not generate an unsubscription error.

#### Additional context
Any component that handles subscriptions must delete the subscription in the beforeDestroy hook to avoid making multiple subscriptions for the same component and increasing the subscriptions every time that component is created.
