### PR TITLE
Fixed error with instance for dictionary based on new implementation …

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
   },
   "dependencies": {
     "@adempiere/grpc-access-client": "^1.2.1",
-    "@adempiere/grpc-data-client": "^2.3.4",
-    "@adempiere/grpc-dictionary-client": "^1.4.1",
+    "@adempiere/grpc-data-client": "^2.3.6",
+    "@adempiere/grpc-dictionary-client": "^1.4.2",
     "@adempiere/grpc-enrollment-client": "^1.1.0",
     "@adempiere/grpc-pos-client": "^1.2.0",
     "axios": "0.19.2",

--- a/src/api/ADempiere/instances.js
+++ b/src/api/ADempiere/instances.js
@@ -34,11 +34,11 @@ export const DictionaryInstance = () => {
   const { getLanguage } = require('@/lang/index')
   const { getToken } = require('@/utils/auth')
 
-  return new Dictionary(
-    DICTIONARY_ADDRESS,
-    getToken(),
-    getLanguage() || 'en_US'
-  )
+  return new Dictionary({
+    host: DICTIONARY_ADDRESS,
+    sessionUuid: getToken(),
+    language: getLanguage() || 'en_US'
+  })
 }
 
 // Instance for connection Enrollment


### PR DESCRIPTION
This pull request resolve a problem with dictionary instance based on new implementation of gRCP.

The step for reproduce is simple:
- Login on ADempiere
- Open any window

see:
```Shell
POST http://0.0.0.0:9527/undefined/dictionary.Dictionary/GetWindowAndTabs 404 (Not Found)
windowDefinition.js?b832:241 Dictionary Window (State Window) - Error 5: Http response at 400 or 500 level.
```