### PR TITLE
fix: Navigation duplicated.

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "vue-i18n": "8.17.4",
     "vue-multipane": "^0.9.5",
     "vue-resize": "^0.5.0",
-    "vue-router": "3.1.6",
+    "vue-router": "3.2.0",
     "vue-shortkey": "^3.1.7",
     "vue-split-panel": "^1.0.4",
     "vue-splitpane": "1.0.6",

--- a/src/components/ADempiere/DataTable/index.vue
+++ b/src/components/ADempiere/DataTable/index.vue
@@ -858,15 +858,20 @@ export default {
           // disabled rollback when change route
           this.$store.dispatch('setDataLog', {})
         }
+        const tableName = this.getterPanel.tableName
         this.$router.push({
+          name: this.$route.name,
           query: {
             ...this.$route.query,
             action: row.UUID
           },
           params: {
-            tableName: this.getterPanel.tableName,
-            recordId: row[`${this.getterPanel.tableName}_ID`]
+            ...this.$router.params,
+            tableName,
+            recordId: row[`${tableName}_ID`]
           }
+        }).catch(error => {
+          console.info(`DataTable Component: ${error.name}, ${error.message}`)
         })
       } else {
         if (!row.isEdit) {

--- a/src/components/ADempiere/Panel/index.vue
+++ b/src/components/ADempiere/Panel/index.vue
@@ -446,7 +446,11 @@ export default {
         if (!Object.prototype.hasOwnProperty.call(route.params, 'isReadParameters') || route.params.isReadParameters) {
           this.getData(parameters)
         }
-        this.setTagsViewTitle(route.query.action)
+        let viewTitle = ''
+        if (route.query && !this.isEmptyValue(route.query.action)) {
+          viewTitle = route.query.action
+        }
+        this.setTagsViewTitle(viewTitle)
       } else {
         if (this.panelType === 'table' && route.query.action === 'advancedQuery') {
           // TODO: use action notifyPanelChange with isShowedField in true
@@ -513,6 +517,8 @@ export default {
           .then(response => {
             if (response.length && !parameters.isNewRecord) {
               this.dataRecords = response[0]
+              const recordId = this.dataRecords[`${this.metadata.tableName}_ID`]
+
               if (this.$route.query.action === 'criteria') {
                 this.$router.push({
                   name: this.$route.name,
@@ -523,9 +529,12 @@ export default {
                   params: {
                     ...this.$route.params,
                     tableName: this.metadata.tableName,
-                    recordId: this.dataRecords[`${this.metadata.tableName}_ID`]
+                    recordId
                   }
+                }).catch(error => {
+                  console.info(`Panel Component: ${error.name}, ${error.message}`)
                 })
+
                 this.$store.dispatch('notifyPanelChange', {
                   parentUuid: this.parentUuid,
                   containerUuid: this.containerUuid,
@@ -542,10 +551,14 @@ export default {
                     ...this.$route.query
                   },
                   params: {
+                    ...this.$route.params,
                     tableName: this.metadata.tableName,
-                    recordId: this.dataRecords[`${this.metadata.tableName}_ID`]
+                    recordId
                   }
+                }).catch(error => {
+                  console.info(`Panel Component: ${error.name}, ${error.message}`)
                 })
+
                 this.$store.dispatch('notifyPanelChange', {
                   parentUuid: this.parentUuid,
                   containerUuid: this.containerUuid,
@@ -560,10 +573,16 @@ export default {
                   query: {
                     ...this.$route.query,
                     action: this.dataRecords.UUID
+                  },
+                  params: {
+                    ...this.$route.params,
+                    tableName: this.metadata.tableName,
+                    recordId
                   }
+                }).catch(error => {
+                  console.info(`Panel Component: ${error.name}, ${error.message}`)
                 })
-                this.$route.params['tableName'] = this.metadata.tableName
-                this.$route.params['recordId'] = this.dataRecords[`${this.metadata.tableName}_ID`]
+
                 this.$store.dispatch('notifyPanelChange', {
                   parentUuid: this.parentUuid,
                   containerUuid: this.containerUuid,
@@ -574,7 +593,11 @@ export default {
                   panelType: this.panelType
                 })
               }
-              this.setTagsViewTitle(this.$route.query.action)
+              let viewTitle = ''
+              if (this.$route.query && !this.isEmptyValue(this.$route.query.action)) {
+                viewTitle = this.$route.query.action
+              }
+              this.setTagsViewTitle(viewTitle)
               this.isLoadRecord = true
             } else {
               this.$router.push({
@@ -582,6 +605,8 @@ export default {
                   ...this.$route.query,
                   action: 'create-new'
                 }
+              }).catch(error => {
+                console.info(`Panel Component: ${error.name}, ${error.message}`)
               })
             }
           })
@@ -703,7 +728,7 @@ export default {
         }
       }
       this.setTagsViewTitle(uuidRecord)
-      if (this.$route.query.action === 'create-new') {
+      if (this.$route.query && this.$route.query.action === 'create-new') {
         this.setFocus()
       }
       const currentRecord = this.getterDataStore.record.find(record => record.UUID === uuidRecord)


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce
1. Go to any window
2. Select a record from the navigation table.
3. When the uuid is established in the route, select the same record


#### Screenshot or Gif
**Before this PR:**
Show error in Google Chrome:
![router-navigation-error-chrome](https://user-images.githubusercontent.com/20288327/82831947-cf111c00-9e87-11ea-875c-7585d49417cf.gif)
Show error in Mozilla Firefox:
![router-navigation-error-firefox](https://user-images.githubusercontent.com/20288327/82831956-d46e6680-9e87-11ea-9d61-cf01eaf9d220.gif)

**After this PR:**
![router-navigation-fix](https://user-images.githubusercontent.com/20288327/82831964-d7695700-9e87-11ea-93bf-0f772ea24a7c.gif)


#### Expected behavior
It is expected that no errors will be generated in the web browser console when the same record is selected multiple times.

