### PR TITLE
fix: Error run process, output is undefined.

### DIFF
--- a/src/store/modules/ADempiere/processControl.js
+++ b/src/store/modules/ADempiere/processControl.js
@@ -399,7 +399,9 @@ const processControl = {
                     logs: logList,
                     output
                   })
-                  dispatch('setReportTypeToShareLink', processResult.output.reportType)
+                  if (!isEmptyValue(processResult.output)) {
+                    dispatch('setReportTypeToShareLink', processResult.output.reportType)
+                  }
                   commit('addNotificationProcess', processResult)
                   resolve(processResult)
                 })
@@ -579,7 +581,9 @@ const processControl = {
                 output
               })
               resolve(processResult)
-              dispatch('setReportTypeToShareLink', processResult.output.reportType)
+              if (!isEmptyValue(processResult.output)) {
+                dispatch('setReportTypeToShareLink', processResult.output.reportType)
+              }
             })
             .catch(error => {
               Object.assign(processResult, {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open any process (`Cache Reset` in this case)
2. Run process.

#### Screenshot or Gif
**Before this PR:**
![run-process-error](https://user-images.githubusercontent.com/20288327/83294457-5a0d5180-a1bb-11ea-8180-c0777924de00.gif)

**After this PR:**
![run-process-fix](https://user-images.githubusercontent.com/20288327/83294539-7610f300-a1bb-11ea-83af-b5da12afc63e.gif)


#### Expected behavior
It is expected that if the process was executed correctly on the server side, it will not generate an error when obtaining the response from it. Like the following error generated in the web browser console:
```bash
Error running the process processResult.output is undefined. Code: undefined.
```

#### Additional context
This error is generated after the change in the library: https://github.com/erpcya/gRPC-Core-Client/pull/6
