### PR TITLE
feat: Add support to package gRPC-Dictionary-Client v1.4.3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@adempiere/grpc-access-client": "^1.2.1",
     "@adempiere/grpc-core-client": "^1.1.4",
     "@adempiere/grpc-data-client": "^2.4.4",
-    "@adempiere/grpc-dictionary-client": "^1.4.2",
+    "@adempiere/grpc-dictionary-client": "^1.4.3",
     "@adempiere/grpc-enrollment-client": "^1.1.0",
     "@adempiere/grpc-pos-client": "^1.3.2",
     "axios": "0.19.2",

--- a/src/api/ADempiere/dictionary.js
+++ b/src/api/ADempiere/dictionary.js
@@ -1,36 +1,34 @@
 // Get Instance for connection
 import { DictionaryInstance as Instance } from '@/api/ADempiere/instances.js'
 
-export function getWindow(uuid, isWithTabs = true) {
+export function getWindow({ uuid, id, isWithTabs = true }) {
   return Instance.call(this).requestWindow({
     uuid,
-    isWithTabs,
-    isConvertedMetadata: true
+    id,
+    isWithTabs
   })
 }
 
-export function getProcess(uuid, isConvertedMetadata = true) {
+export function getProcess({ uuid, id }) {
   return Instance.call(this).requestProcess({
-    uuid: uuid,
-    isConvertedMetadata,
-    isConvertedFields: true
+    uuid,
+    id,
+    isWithFields: true
   })
 }
 
-export function getBrowser(uuid, isConvertedMetadata = true) {
+export function getBrowser({ uuid, id }) {
   return Instance.call(this).requestBrowser({
     uuid,
-    isConvertedMetadata,
-    isConvertedFields: true
+    id
   })
 }
 
-export function getTab(uuid, isWithFields = true, isConvertedMetadata = true) {
+export function getTab({ uuid, id, isWithFields = true }) {
   return Instance.call(this).requestTab({
     uuid,
-    isWithFields,
-    isConvertedMetadata,
-    isConvertedFields: true
+    id,
+    isWithFields
   })
 }
 

--- a/src/store/modules/ADempiere/browser.js
+++ b/src/store/modules/ADempiere/browser.js
@@ -27,10 +27,14 @@ const browser = {
   actions: {
     getBrowserFromServer({ commit, dispatch }, {
       containerUuid,
+      browserId,
       routeToDelete
     }) {
       return new Promise(resolve => {
-        getBrowserMetadata(containerUuid)
+        getBrowserMetadata({
+          uuid: containerUuid,
+          id: browserId
+        })
           .then(browserResponse => {
             const panelType = 'browser'
             const additionalAttributes = {

--- a/src/store/modules/ADempiere/process.js
+++ b/src/store/modules/ADempiere/process.js
@@ -18,16 +18,21 @@ const process = {
   },
   actions: {
     /**
-     * Get process metadata from server
+     * Get process/report metadata from server
      * @param {string} containerUuid
+     * @param {number} processId
      * @param {object} routeToDelete, route to close in tagView when fail
      */
     getProcessFromServer({ commit, dispatch }, {
       containerUuid,
+      processId,
       routeToDelete
     }) {
       return new Promise(resolve => {
-        getProcessMetadata(containerUuid)
+        getProcessMetadata({
+          uuid: containerUuid,
+          id: processId
+        })
           .then(async responseProcess => {
             let printFormatsAvailable = []
             if (responseProcess.isReport) {

--- a/src/store/modules/ADempiere/window.js
+++ b/src/store/modules/ADempiere/window.js
@@ -46,9 +46,13 @@ const window = {
   actions: {
     getWindowFromServer({ commit, state, dispatch }, {
       windowUuid,
+      windowId,
       routeToDelete
     }) {
-      return getWindowMetadata(windowUuid)
+      return getWindowMetadata({
+        uuid: windowUuid,
+        id: windowId
+      })
         .then(responseWindow => {
           const firstTabTableName = responseWindow.tabsList[0].tableName
           const firstTabUuid = responseWindow.tabsList[0].uuid
@@ -244,12 +248,16 @@ const window = {
     getTabAndFieldFromServer({ dispatch, getters }, {
       parentUuid,
       containerUuid,
+      tabId,
       panelType = 'window',
       panelMetadata,
       isAdvancedQuery = false
     }) {
       return new Promise(resolve => {
-        getTabMetadata(containerUuid)
+        getTabMetadata({
+          uuid: containerUuid,
+          id: tabId
+        })
           .then(tabResponse => {
             const additionalAttributes = {
               parentUuid,

--- a/src/utils/ADempiere/dictionaryUtils.js
+++ b/src/utils/ADempiere/dictionaryUtils.js
@@ -323,7 +323,7 @@ export function generateProcess({ processToGenerate, containerUuidAssociated = u
     isDirectPrint: processToGenerate.isDirectPrint
   }
 
-  processToGenerate.reportExportTypeList.forEach(actionValue => {
+  processToGenerate.reportExportTypesList.forEach(actionValue => {
     //  Push values
     summaryAction.childs.push({
       name: `${language.t('components.ExportTo')} (${actionValue.name})`,


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
* The `reportExportTypeList` attribute is corrected for `reportExportTypesList` (adds a missing 'S' in the attribute name, between Type and List).
* Added the ID parameter (in addition to the existing UUID parameter) to get the metadata.
* The parameters are defined as shredded objects instead of arguments that must follow a specific sequence.
* Support for versiond 1.4.3 of the `adempiere/grpc-dictionary-client` package

### Additional Context:
This PR depends on the changes https://github.com/erpcya/gRPC-Dictionary-Client/pull/13