### PR TITLE
fix: Field number with out country and currency definition.

### DIFF
--- a/src/components/ADempiere/Field/FieldNumber.vue
+++ b/src/components/ADempiere/Field/FieldNumber.vue
@@ -31,8 +31,7 @@
       v-model="displayedValue"
       :placeholder="metadata.help"
       :disabled="isDisabled"
-      :precision="precision"
-      :class="'display-type-amount ' + metadata.cssClassName"
+      :class="cssClassStyle"
       readonly
       @blur="customFocusLost"
       @focus="customFocusGained"

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -204,10 +204,14 @@ const actions = {
             responseGetInfo.defaultContextMap.get('#C_Country_ID'),
             10
           )
-          // get country and currency
-          dispatch('getCountryFormServer', {
-            countryId
-          })
+          if (isEmptyValue(countryId)) {
+            console.info('context session without Country ID')
+          } else {
+            // get country and currency
+            dispatch('getCountryFormServer', {
+              countryId
+            })
+          }
 
           dispatch('getUserInfoFromSession', sessionUuid)
             .catch(error => {
@@ -448,7 +452,14 @@ const getters = {
     return state.country
   },
   getCurrency: (state) => {
-    return state.country.currency
+    const currency = state.country.currency
+    if (isEmptyValue(currency)) {
+      return {
+        stdPrecision: 2,
+        iSOCode: 'USD'
+      }
+    }
+    return currency
   },
   getCountryLanguage(state) {
     return state.country.language.replace('_', '-')


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce
1. Open any view with number fields.


#### Screenshot or Gif
Before this PR:
![field-number-error](https://user-images.githubusercontent.com/20288327/84820196-3df51700-afe7-11ea-93c0-6f5db6428e04.gif)

After this PR:
![field-number-fix](https://user-images.githubusercontent.com/20288327/84820207-40f00780-afe7-11ea-87fd-28789b8477bf.gif)


#### Expected behavior
The fields are expected to be displayed correctly even if there is no definition of the currency.

#### Additional context
This occurs because the session does not bring the country id to check the definition of the country and therefore the definition of the currency, it should bring the `#C_Country_ID` from the context of the session.
