### PR TITLE
feat: Update and replace runjs with taskfile.

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -1,19 +1,15 @@
-const { run } = require('runjs')
-const chalk = require('chalk')
-const config = require('../vue.config.js')
+const { sh } = require('tasksfile')
 const rawArgv = process.argv.slice(2)
 const args = rawArgv.join(' ')
 
+sh(`vue-cli-service build ${args}`)
+
 if (process.env.npm_config_preview || rawArgv.includes('--preview')) {
-  const report = rawArgv.includes('--report')
-
-  run(`vue-cli-service build ${args}`)
-
-  const port = 9526
+  const config = require('../vue.config.js')
   const publicPath = config.publicPath
 
-  var connect = require('connect')
-  var serveStatic = require('serve-static')
+  const connect = require('connect')
+  const serveStatic = require('serve-static')
   const app = connect()
 
   app.use(
@@ -23,13 +19,13 @@ if (process.env.npm_config_preview || rawArgv.includes('--preview')) {
     })
   )
 
-  app.listen(port, function () {
+  const port = 9526
+  app.listen(port, function() {
+    const chalk = require('chalk')
     console.log(chalk.green(`> Preview at  http://localhost:${port}${publicPath}`))
-    if (report) {
+
+    if (rawArgv.includes('--report')) {
       console.log(chalk.green(`> Report at  http://localhost:${port}${publicPath}report.html`))
     }
-
   })
-} else {
-  run(`vue-cli-service build ${args}`)
 }

--- a/package.json
+++ b/package.json
@@ -86,13 +86,13 @@
     "lint-staged": "10.2.11",
     "mockjs": "1.1.0",
     "plop": "2.7.3",
-    "runjs": "4.4.2",
     "sass": "1.26.10",
     "sass-loader": "8.0.2",
     "script-ext-html-webpack-plugin": "2.1.4",
     "serve-static": "1.14.1",
     "svg-sprite-loader": "5.0.0",
     "svgo": "1.3.2",
+    "tasksfile": "5.1.1",
     "vue-template-compiler": "2.6.11"
   },
   "browserslist": [


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
When installing the dependencies the message is displayed in the terminal that the `runjs` package is depreciated and will be replaced by the `taskfile` package.

#### Steps to reproduce
1. Delete all packages `rm -R node_modules`.
2. Delete package-lock.json file `rm package-lock.json`.
3. Clean npm cache `npm cache clean -f`.
4. Install packages `npm i`

#### Screenshot or Gif
![runjs-error](https://user-images.githubusercontent.com/20288327/99161804-2cb25280-26cc-11eb-935f-d2b5837a556e.png)

#### Expected behavior
You should not have deprecated packages installed if there is a current alternative whose functionality is compatible

#### Other relevant information
- Your OS: Linux Mint 19.1.
- Node.js version: 12.19.0.
- adempiere-vue version: 1.1

#### Additional context
Author message: `This project has been renamed to 'tasksfile'. Install using 'npm install tasksfile' instead.`

https://www.npmjs.com/package/runjs


