### PR TITLE
add the price query window to the rais menu

### DIFF
--- a/src/components/ADempiere/Form/index.vue
+++ b/src/components/ADempiere/Form/index.vue
@@ -22,13 +22,10 @@ export default {
         case 'PriceChecking':
           form = import('@/components/ADempiere/Form/PriceChecking')
           this.$store.dispatch('settings/changeSetting', {
-            key: 'showNavar',
-            value: true
-          })
-          this.$store.dispatch('settings/changeSetting', {
             key: 'showMenu',
             value: false
           })
+          this.$store.dispatch('app/toggleSideBar', false)
           this.$store.dispatch('settings/changeSetting', {
             key: 'tagsView',
             value: false

--- a/src/layout/components/Settings/index.vue
+++ b/src/layout/components/Settings/index.vue
@@ -106,6 +106,7 @@ export default {
         return this.$store.state.settings.showMenu
       },
       set(val) {
+        this.$store.dispatch('app/toggleSideBar')
         this.$store.dispatch('settings/changeSetting', {
           key: 'showMenu',
           value: val

--- a/src/layout/index.vue
+++ b/src/layout/index.vue
@@ -2,7 +2,7 @@
   <div :class="classObj" class="app-wrapper">
     <div v-if="device==='mobile'&&sidebar.opened" class="drawer-bg" @click="handleClickOutside" />
     <sidebar v-show="showMenu" class="sidebar-container" />
-    <div :class="{hasTagsView:needTagsView}" class="main-container">
+    <div :class="{hasTagsView:needTagsView}" class="main-container" :style="showMenu ? '' : 'margin-left:0px'">
       <div :class="{'fixed-header':fixedHeader}">
         <navbar v-show="showNavar" />
         <tags-view v-if="needTagsView" />

--- a/src/router/modules/ADempiere/staticRoutes.js
+++ b/src/router/modules/ADempiere/staticRoutes.js
@@ -68,13 +68,14 @@ const staticRoutes = [
   {
     path: '/PriceChecking',
     component: Layout,
-    hidden: true,
+    hidden: false,
     children: [
       {
         path: '/PriceChecking',
         component: () => import('@/views/ADempiere/Form'),
         name: 'PriceChecking',
         meta: {
+          icon: 'shopping',
           title: 'PriceChecking',
           isIndex: true
         }
@@ -84,7 +85,7 @@ const staticRoutes = [
   {
     path: '/BarcodeReader',
     component: Layout,
-    hidden: false,
+    hidden: true,
     children: [
       {
         path: '/BarcodeReader',


### PR DESCRIPTION
when opening the window you must hide the menu and the tag-views

<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. [xxx]
2. [xxx]
3. [xxxx]

#### Screenshot or Gif


#### Link to minimal reproduction

<!--
Please only use Codepen, JSFiddle, CodeSandbox or a github repo
-->

#### Expected behavior
A clear and concise description of what you expected to happen.

#### Other relevant information
- Your OS:
- Web Browser:
- Node.js version:
- adempiere-vue version:

#### Additional context
Add any other context about the problem here.
