### PR TITLE
fix: Lookup item direct query columnName not exist

### DIFF
--- a/src/api/ADempiere/values.js
+++ b/src/api/ADempiere/values.js
@@ -8,13 +8,11 @@ import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 /**
  * Request a Lookup data from Reference
  * The main attributes that function hope are:
- * @param {string} columnName
  * @param {string} tableName
  * @param {string} directQuery
  * @param {string|number} value
  */
 export function requestLookup({
-  columnName,
   tableName,
   directQuery,
   value
@@ -22,7 +20,6 @@ export function requestLookup({
   let filters = []
   if (!isEmptyValue(value)) {
     filters = [{
-      column_name: columnName,
       value
     }]
   }

--- a/src/components/ADempiere/Field/FieldSelect.vue
+++ b/src/components/ADempiere/Field/FieldSelect.vue
@@ -315,7 +315,6 @@ export default {
       this.$store.dispatch('getLookupItemFromServer', {
         parentUuid: this.metadata.parentUuid,
         containerUuid: this.metadata.containerUuid,
-        columnName: this.metadata.columnName,
         tableName: this.metadata.reference.tableName,
         directQuery: this.metadata.reference.directQuery,
         value: this.value

--- a/src/store/modules/ADempiere/lookup.js
+++ b/src/store/modules/ADempiere/lookup.js
@@ -37,7 +37,6 @@ const lookup = {
     getLookupItemFromServer({ commit, rootGetters }, {
       parentUuid,
       containerUuid,
-      columnName,
       tableName,
       directQuery,
       value
@@ -57,7 +56,6 @@ const lookup = {
       }
 
       return requestLookup({
-        columnName,
         tableName,
         directQuery: parsedDirectQuery,
         value

--- a/src/store/modules/ADempiere/panel/actions.js
+++ b/src/store/modules/ADempiere/panel/actions.js
@@ -468,7 +468,6 @@ const actions = {
     //         lookup = await dispatch('getLookupItemFromServer', {
     //           parentUuid,
     //           containerUuid,
-    //           columnName: actionField.columnName,
     //           tableName: actionField.reference.tableName,
     //           directQuery: actionField.reference.parsedDirectQuery,
     //           value: newValues[actionField.columnName]


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open report **Invoice Detail & Margin**.
2. Look at the field **Sales Transcation**.

#### Screenshot or Gif
Before changes:
![lookup-item-error](https://user-images.githubusercontent.com/20288327/101112589-0a697180-35b4-11eb-9a39-55c98d1d73d9.gif)

After changes:
![lookup-item-fix](https://user-images.githubusercontent.com/20288327/101112602-105f5280-35b4-11eb-92a6-3fd07f570785.gif)


#### Expected behavior
The lookup items are expected to load their display value

#### Other relevant information
- Your OS: Linux Mint 19.1 Cinnamon x64.
- Web Browser: Mozilla Firefox 68.0.
- Node.js version: 12.20.0.
- adempiere-vue version: 4.3.1.

#### Additional context
Add any other context about the problem here.
