### PR TITLE
feat: Add icon in header search component.

### DIFF
--- a/src/components/HeaderSearch/index.vue
+++ b/src/components/HeaderSearch/index.vue
@@ -17,7 +17,10 @@
         :key="element.item.path"
         :value="element.item"
         :label="element.item.title.join(' > ')"
-      />
+      >
+        {{ element.item.title.join(' > ') }}
+        <svg-icon :icon-class="element.item.meta.icon" />
+      </el-option>
     </el-select>
   </div>
 </template>


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Login with any role
2. Perform a search for any type of view in the header search.

Note that the icons appear in allusion to the type of view, just as it appears in the main menu

#### Screenshot or Gif
![header-search-icon](https://user-images.githubusercontent.com/20288327/103602172-b539bc00-4ee1-11eb-8d1f-5f7d0f5c7cdf.gif)



#### Other relevant information
- Your OS: Linux Mint 19.1 Cinnamon x64.
- Web Browser: Mozilla Firefox 68.0.
- Node.js version: 12.20.0.
- adempiere-vue version: 4.3.1.
