### PR TITLE
Feature/support pos

### DIFF
--- a/src/components/ADempiere/Form/VPOS/Collection/convertAmount/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Collection/convertAmount/index.vue
@@ -73,8 +73,20 @@ export default {
   computed: {
     displayCurrency() {
       return this.$store.getters.getValueOfField({
-        containerUuid: this.containerUuid,
+        containerUuid: 'Collection-Convert-Amount',
         columnName: 'DisplayColumn_C_Currency_ID'
+      })
+    },
+    typeCurrency() {
+      return this.$store.getters.getValueOfField({
+        containerUuid: 'Collection-Convert-Amount',
+        columnName: 'C_Currency_ID'
+      })
+    },
+    currencyUuid() {
+      return this.$store.getters.getValueOfField({
+        containerUuid: 'Collection-Convert-Amount',
+        columnName: 'C_Currency_ID_UUID'
       })
     }
   },

--- a/src/components/ADempiere/Form/VPOS/Collection/fieldsListCollection.js
+++ b/src/components/ADempiere/Form/VPOS/Collection/fieldsListCollection.js
@@ -34,7 +34,6 @@ export default [
   // Bank
   {
     tableName,
-    elementColumnName: 'C_Bank_ID',
     columnName: 'C_Bank_ID',
     isFromDictionary: true,
     overwriteDefinition: {

--- a/src/components/ADempiere/Form/VPOS/Collection/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Collection/index.vue
@@ -233,14 +233,17 @@ export default {
   },
   computed: {
     validateCompleteCollection() {
-      if (this.order.grandTotal === this.pay) {
-        return false
-      } else if (this.isCashAmt >= this.change) {
-        return false
-      } else if (this.pay >= this.order.grandTotal && this.checked) {
-        return false
+      let collection
+      if (this.pay === this.order.grandTotal) {
+        collection = false
+      } else {
+        if (this.pay >= this.order.grandTotal && (this.isCashAmt >= this.change) || this.checked) {
+          collection = false
+        } else {
+          collection = true
+        }
       }
-      return true
+      return collection
     },
     fullCopper() {
       if ((this.change > this.isCashAmt) && this.pay > this.order.grandTotal) {
@@ -406,7 +409,7 @@ export default {
     },
     currencyUuid() {
       return this.$store.getters.getValueOfField({
-        containerUuid: this.containerUuid,
+        containerUuid: 'Collection',
         columnName: 'C_Currency_ID_UUID'
       })
     },
@@ -419,9 +422,12 @@ export default {
     multiplyRate() {
       return this.$store.getters.getMultiplyRate
     },
+    multiplyRateCollection() {
+      return this.$store.getters.getMultiplyRateCollection
+    },
     converCurrency() {
       return this.$store.getters.getValueOfField({
-        containerUuid: 'Collection-Convert-Amount',
+        containerUuid: 'Collection',
         columnName: 'C_Currency_ID_UUID'
       })
     },
@@ -442,7 +448,7 @@ export default {
       return true
     },
     fieldpending() {
-      return this.pending * this.multiplyRate
+      return this.pending * this.multiplyRateCollection
     }
   },
   watch: {
@@ -470,12 +476,13 @@ export default {
       }
       if (!this.isEmptyValue(value)) {
         this.$store.dispatch('conversionMultiplyRate', {
+          containerUuid: 'Collection',
           conversionTypeUuid: this.$store.getters.getCurrentPOS.conversionTypeUuid,
           currencyFromUuid: this.currencyPoint.uuid,
           currencyToUuid: value
         })
       } else {
-        this.$store.commit('currencyMultiplyRate', 1)
+        this.$store.commit('currencyMultiplyRateCollection', 1)
       }
     },
     convertAllPayment(value) {
@@ -487,6 +494,7 @@ export default {
     converCurrency(value) {
       if (!this.isEmptyValue(value)) {
         this.$store.dispatch('conversionMultiplyRate', {
+          containerUuid: 'Collection',
           conversionTypeUuid: this.$store.getters.getCurrentPOS.conversionTypeUuid,
           currencyFromUuid: this.currencyPoint.uuid,
           currencyToUuid: value

--- a/src/components/ADempiere/Form/VPOS/Collection/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Collection/index.vue
@@ -73,7 +73,7 @@
                 </b>
               </el-link>
             </el-checkbox>
-            <el-button type="danger" icon="el-icon-close" @click="cancel" />
+            <el-button type="danger" icon="el-icon-close" @click="exit" />
             <el-button type="primary" :disabled="validPay || addPay" icon="el-icon-plus" @click="addCollectToList(paymentBox)" />
             <el-button type="success" :disabled="validateCompleteCollection" icon="el-icon-shopping-cart-full" />
           </samp>
@@ -631,6 +631,9 @@ export default {
       this.defaultValueCurrency()
       this.$store.dispatch('conversionDivideRate', 1)
       this.$store.commit('currencyMultiplyRate', 1)
+    },
+    exit() {
+      this.$store.commit('setShowPOSCollection', false)
     },
     getPriceApplyingDiscount(price, discount) {
       if (this.isEmptyValue(price)) {

--- a/src/components/ADempiere/Form/VPOS/Order/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Order/index.vue
@@ -410,7 +410,7 @@ export default {
     },
     currencyUuid() {
       return this.$store.getters.getValueOfField({
-        containerUuid: this.containerUuid,
+        containerUuid: 'Collection-Convert-Amount',
         columnName: 'C_Currency_ID_UUID'
       })
     },
@@ -434,6 +434,7 @@ export default {
     converCurrency(value) {
       if (!this.isEmptyValue(value)) {
         this.$store.dispatch('conversionMultiplyRate', {
+          containerUuid: 'Order',
           conversionTypeUuid: this.$store.getters.getCurrentPOS.conversionTypeUuid,
           currencyFromUuid: this.currencyPoint.uuid,
           currencyToUuid: value

--- a/src/components/ADempiere/Form/VPOS/Order/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Order/index.vue
@@ -449,7 +449,7 @@ export default {
       this.newOrder()
     },
     openCollectionPanel() {
-      this.$store.commit('setShowPOSCollection', !this.$store.getters.getShowCollectionPos)
+      this.$store.commit('setShowPOSCollection', true)
       this.isShowedPOSKeyLayout = true
       this.$store.commit('setShowPOSOptions', false)
     },

--- a/src/components/ADempiere/Form/VPOS/OrderList/index.vue
+++ b/src/components/ADempiere/Form/VPOS/OrderList/index.vue
@@ -224,10 +224,12 @@ export default {
         containerUuid: this.metadata.containerUuid
       })
       values = this.convertValuesToSend(values)
-
-      this.$store.dispatch('listOrdersFromServer', {
-        ...values
-      })
+      const point = this.$store.getters.getPointOfSalesUuid
+      if (!this.isEmptyValue(point)) {
+        this.$store.dispatch('listOrdersFromServer', {
+          ...values
+        })
+      }
     },
     handleChangePage(newPage) {
       this.$store.dispatch('setOrdersListPageNumber', newPage)

--- a/src/store/modules/ADempiere/pointOfSales/collection.js
+++ b/src/store/modules/ADempiere/pointOfSales/collection.js
@@ -7,7 +7,9 @@ const collection = {
   state: {
     paymentBox: [],
     multiplyRate: 1,
-    divideRate: 1
+    divideRate: 1,
+    multiplyRateCollection: 1,
+    divideRateCollection: 1
   },
   mutations: {
     addPaymentBox(state, paymentBox) {
@@ -18,6 +20,12 @@ const collection = {
     },
     currencyDivideRate(state, divideRate) {
       state.divideRate = divideRate
+    },
+    currencyMultiplyRateCollection(state, multiplyRateCollection) {
+      state.multiplyRateCollection = multiplyRateCollection
+    },
+    currencyDivideRateCollection(state, divideRateCollection) {
+      state.divideRateCollection = divideRateCollection
     }
   },
   actions: {
@@ -25,12 +33,16 @@ const collection = {
      * creating boxes with the payment list
      */
     setPaymentBox({ state, commit, getters }, params) {
-      const payments = undefined
+      const payments = getters.getPaymentBox.find(element => {
+        if (params.tenderType === 'X' && element.currency.id === params.currency.id) {
+          return element
+        }
+      })
       if (isEmptyValue(payments)) {
         commit('addPaymentBox', params)
       } else {
         const addPayment = getters.getPaymentBox.map(item => {
-          if (item.tenderType === params.tenderType && item.currency.id === params.currency.id) {
+          if ((item.tenderType === params.tenderType) && item.currency.id === params.currency.id) {
             return {
               ...item,
               payAmt: item.payAmt + params.payAmt,
@@ -58,7 +70,11 @@ const collection = {
       })
         .then(response => {
           const divideRate = isEmptyValue(response.divideRate) ? 1 : response.divideRate
-          commit('currencyDivideRate', divideRate)
+          if (params.containerUuid === 'Collection') {
+            commit('currencyDivideRateCollection', divideRate)
+          } else {
+            commit('currencyDivideRate', divideRate)
+          }
         })
         .catch(error => {
           console.warn(`conversionDivideRate: ${error.message}. Code: ${error.code}.`)
@@ -70,6 +86,7 @@ const collection = {
         })
     },
     conversionMultiplyRate({ commit }, {
+      containerUuid,
       conversionTypeUuid,
       currencyFromUuid,
       currencyToUuid
@@ -82,9 +99,12 @@ const collection = {
         // conversionDate
       })
         .then(response => {
-          const multiplyRate = isEmptyValue(response.multiplyRate) ? 1 : response.multiplyRate
-
-          commit('currencyMultiplyRate', multiplyRate)
+          const multiplyRate = isEmptyValue(response.multiplyRate) ? 0 : response.multiplyRate
+          if (containerUuid === 'Collection') {
+            commit('currencyMultiplyRateCollection', multiplyRate)
+          } else {
+            commit('currencyMultiplyRate', multiplyRate)
+          }
         })
         .catch(error => {
           console.warn(`conversionMultiplyRate: ${error.message}. Code: ${error.code}.`)
@@ -111,6 +131,12 @@ const collection = {
     },
     getDivideRate: (state) => {
       return state.divideRate
+    },
+    getMultiplyRateCollection: (state) => {
+      return state.multiplyRateCollection
+    },
+    getDivideRateCollection: (state) => {
+      return state.divideRateCollection
     }
   }
 }


### PR DESCRIPTION
- [x] Process payment button must be enabled when the balance is zero.
- [x] when there is no conversion rate it should show the amount to be cashed in zero
- [x] when you have more than one cash collection you must sum (by currency) into one.
- [x] when you hit cancel it should exit the cashout window.
- [x] The lookups do not show well
![Peek 29-01-2021 16-19](https://user-images.githubusercontent.com/45974454/106323639-1e48f100-624e-11eb-8406-4a8bcf66cb3e.gif)
