### PR TITLE
fix: Create/update entity send log columns.

### DIFF
--- a/src/components/ADempiere/Field/index.vue
+++ b/src/components/ADempiere/Field/index.vue
@@ -80,6 +80,7 @@ import translated from '@/components/ADempiere/Field/popover/translated'
 import calculator from '@/components/ADempiere/Field/popover/calculator'
 import { DEFAULT_SIZE } from '@/utils/ADempiere/references'
 import { evalutateTypeField, fieldIsDisplayed } from '@/utils/ADempiere/dictionaryUtils'
+import { LOG_COLUMNS_NAME_LIST } from '@/utils/ADempiere/dataUtils.js'
 
 /**
  * This is the base component for linking the components according to the
@@ -206,6 +207,10 @@ export default {
       }
       return this.field.isMandatory || this.field.isMandatoryFromLogic
     },
+    /**
+     * Idicate if field is read only
+     * TODO: Create common method to evaluate isReadOnly
+     */
     isReadOnly() {
       if (this.isAdvancedQuery) {
         if (['NULL', 'NOT_NULL'].includes(this.field.operator)) {
@@ -218,9 +223,16 @@ export default {
         return true
       }
 
+      // records in columns manage by backend
+      const isLogColumns = LOG_COLUMNS_NAME_LIST.includes(this.field.columnName)
+
       const isUpdateableAllFields = this.field.isReadOnly || this.field.isReadOnlyFromLogic
 
       if (this.field.panelType === 'window') {
+        if (isLogColumns) {
+          return true
+        }
+
         if (this.field.isAlwaysUpdateable) {
           return false
         }
@@ -240,7 +252,7 @@ export default {
       } else if (this.field.panelType === 'browser') {
         if (this.inTable) {
           // browser result
-          return this.field.isReadOnly
+          return this.field.isReadOnly || isLogColumns
         }
         // query criteria
         return this.field.isReadOnlyFromLogic

--- a/src/components/ADempiere/Panel/mainPanelMixin.js
+++ b/src/components/ADempiere/Panel/mainPanelMixin.js
@@ -3,6 +3,7 @@ import FilterFields from '@/components/ADempiere/Panel/filterFields'
 import { fieldIsDisplayed } from '@/utils/ADempiere/dictionaryUtils.js'
 import { parsedValueComponent } from '@/utils/ADempiere/valueUtils.js'
 import { convertObjectToKeyValue } from '@/utils/ADempiere/valueFormat.js'
+import { LOG_COLUMNS_NAME_LIST } from '@/utils/ADempiere/dataUtils.js'
 
 export default {
   name: 'MainPanelMixin',
@@ -536,7 +537,9 @@ export default {
           }
           if (Object.prototype.hasOwnProperty.call(this.$refs, itemField.columnName)) {
             if (fieldIsDisplayed(itemField) &&
-              !itemField.isReadOnly &&
+              !(itemField.isReadOnly ||
+              // records in columns manage by backend
+              LOG_COLUMNS_NAME_LIST.includes(itemField.columnName)) &&
               itemField.isUpdateable &&
               itemField.componentPath !== 'FieldSelect') {
               return true

--- a/src/store/modules/ADempiere/persistence.js
+++ b/src/store/modules/ADempiere/persistence.js
@@ -4,6 +4,8 @@ import {
 } from '@/api/ADempiere/persistence.js'
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 import { LOG_COLUMNS_NAME_LIST } from '@/utils/ADempiere/dataUtils.js'
+import language from '@/lang'
+import { showMessage } from '@/utils/ADempiere/notification.js'
 
 const persistence = {
   state: {
@@ -70,7 +72,14 @@ const persistence = {
               tableName,
               attributesList
             })
-              .then(response => resolve(response))
+              .then(response => {
+                showMessage({
+                  message: language.t('data.createRecordSuccessful'),
+                  type: 'success'
+                })
+
+                resolve(response)
+              })
               .catch(error => reject(error))
           }
         }

--- a/src/store/modules/ADempiere/windowControl/actions.js
+++ b/src/store/modules/ADempiere/windowControl/actions.js
@@ -12,6 +12,7 @@ import { showMessage } from '@/utils/ADempiere/notification'
 import language from '@/lang'
 import router from '@/router'
 import { convertObjectToKeyValue } from '@/utils/ADempiere/valueFormat.js'
+import { LOG_COLUMNS_NAME_LIST } from '@/utils/ADempiere/dataUtils.js'
 
 /**
  * Window Control Vuex Module
@@ -126,8 +127,14 @@ export default {
           value
         })
         const emptyFields = getters.getFieldsListEmptyMandatory({
-          containerUuid: field.containerUuid
+          containerUuid: field.containerUuid,
+          formatReturn: false
+        }).filter(itemField => {
+          return !LOG_COLUMNS_NAME_LIST.includes(itemField.columnName)
+        }).map(itemField => {
+          return itemField.name
         })
+
         if (!isEmptyValue(emptyFields)) {
           showMessage({
             message: language.t('notifications.mandatoryFieldMissing') + emptyFields,

--- a/src/utils/ADempiere/dataUtils.js
+++ b/src/utils/ADempiere/dataUtils.js
@@ -192,3 +192,42 @@ export const FIELD_OPERATORS_LIST = [
   OPERATORS_FIELD_TIME,
   OPERATORS_FIELD_YES_NO
 ]
+
+/**
+ * Log columns list into table
+ * Manages with user session
+ */
+export const LOG_COLUMNS_NAME_LIST = [
+  'Created',
+  'CreatedBy',
+  'Updated',
+  'UpdatedBy'
+]
+
+/**
+ * Columns list into standard table
+ */
+export const STANDARD_COLUMNS_NAME_LIST = [
+  ...LOG_COLUMNS_NAME_LIST,
+  // Table Name '_ID'
+  'AD_Client_ID',
+  'AD_Org_ID',
+  'IsActive',
+  'UUID'
+]
+
+/**
+ * Columns list into document table
+ */
+export const DOCUMENT_COLUMNS_NAME_LIST = [
+  ...STANDARD_COLUMNS_NAME_LIST,
+  'C_DocType_ID',
+  'DateDoc',
+  'Description',
+  'DocAction',
+  'DocStatus',
+  'DocumentNo',
+  'IsApproved',
+  'Processed',
+  'Processing'
+]


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report

Currently the columns, used for the log record, are being sent to the server from the client, these columns should be omitted as they should be handled by the server only.

#### Steps to reproduce

Currently the columns, used for the log record, are being sent to the server from the client, these columns should be omitted as they should be handled by the server only.

1. Expand the `System Admin` menu.
2. Open `Issue Report` window.
3. Run action `New Record` and fill fields.


#### Screenshot or Gif
After this PR:
![issue-report-error](https://user-images.githubusercontent.com/20288327/109395907-5010ae80-7905-11eb-919b-4e6ed80c54e5.gif)

Before this PR:
![issue-report-fix](https://user-images.githubusercontent.com/20288327/109395649-e512a800-7903-11eb-8a0d-f4c769e4e661.gif)


#### Expected behavior
These columns should always remain read-only for both log entry and editing, as they are in the smart browser results and window. 
As for the smart browser and query criteria reports/processes and forms, they can be editable (if defined in the application dictionary) since they do not modify record data from the client but are used for queries.

#### Other relevant information
- Your OS: Linux Mint 19.1 Cinnamon x64.
- Web Browser: Mozilla Firefox 85.0.
- Node.js version: 12.20.0.
- adempiere-vue version: 4.3.1.

#### Additional context
the evaluation of obligatory nature is omitted and the t fields are placed as read-only are placed where applicable.
