### PR TITLE
add tax to order

### DIFF
--- a/src/components/ADempiere/Form/VPOS/Order/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Order/index.vue
@@ -37,10 +37,9 @@
                 v-if="!isEmptyValue(getOrder.documentStatus.value)"
                 :type="tagStatus(getOrder.documentStatus.value)"
               >
-                <span v-if="isEmptyValue(getOrder.documentStatus.value)">
-                  Borrador
+                <span v-if="!isEmptyValue(getOrder.documentStatus.value)">
+                  {{ getOrder.documentStatus.name }}
                 </span>
-                {{ getOrder.documentStatus.name }}
               </el-tag>
             </el-col>
           </el-row>

--- a/src/components/ADempiere/Form/VPOS/posMixin.js
+++ b/src/components/ADempiere/Form/VPOS/posMixin.js
@@ -357,10 +357,10 @@ export default {
       // this.order = orderToPush
     },
     getOrderTax(currency) {
-      if (this.isEmptyValue(this.order)) {
-        return undefined
+      if (this.isEmptyValue(this.getOrder) && (this.getOrder.grandTotal <= 0)) {
+        return this.formatPrice(this.getOrder.grandTotal, currency)
       }
-      return this.formatPrice(this.order.grandTotal - this.order.totalLines, currency)
+      return this.formatPrice(this.getOrder.grandTotal - this.getOrder.totalLines, currency)
     },
     subscribeChanges() {
       return this.$store.subscribe((mutation, state) => {

--- a/src/components/ADempiere/Form/VPOS/posMixin.js
+++ b/src/components/ADempiere/Form/VPOS/posMixin.js
@@ -357,9 +357,6 @@ export default {
       // this.order = orderToPush
     },
     getOrderTax(currency) {
-      if (this.isEmptyValue(this.getOrder) && (this.getOrder.grandTotal <= 0)) {
-        return this.formatPrice(this.getOrder.grandTotal, currency)
-      }
       return this.formatPrice(this.getOrder.grandTotal - this.getOrder.totalLines, currency)
     },
     subscribeChanges() {


### PR DESCRIPTION

## Bug report / Feature
Tax is not displayed
#### Steps to reproduce

1. Login to the Point of Sale 
2. Create Order
3. View Totals and Tax

#### Before Screenshot or Gif

![image](https://user-images.githubusercontent.com/45974454/109510021-e95fd200-7a77-11eb-92cb-499ca9a52abd.png)

#### After Screenshot

![image](https://user-images.githubusercontent.com/45974454/109510343-43f92e00-7a78-11eb-9105-348507ed7dcb.png)

#### Expected behavior
Tell me the tax amount of the order

#### Other relevant information
- Your operating system: Debian 9
- Web browser: Chrome
- Node.js version: 10.9