### PR TITLE
fix: Unnecesarily loop in the static menu.

### DIFF
--- a/src/router/modules/ADempiere/menu.js
+++ b/src/router/modules/ADempiere/menu.js
@@ -161,7 +161,9 @@ function getRouteFromMenuItem({ menu, roleUuid, organizationUuid }) {
  * @returns {object} routes with hidden/show
  */
 function hidenStactiRoutes({ staticRoutes, permiseRole }) {
-  if (!permiseRole.isAllowInfoProduct) {
+  const { isAllowInfoProduct } = permiseRole
+  if (!isAllowInfoProduct) {
+    // does not change the hidden visibility of ProductInfo
     return staticRoutes
   }
 
@@ -169,8 +171,8 @@ function hidenStactiRoutes({ staticRoutes, permiseRole }) {
     if (route.path === '/ProductInfo') {
       return {
         ...route,
-        // is hidden by default
-        hidden: false
+        // is hidden by default, change to be visible
+        hidden: !isAllowInfoProduct
       }
     }
     return {

--- a/src/router/modules/ADempiere/menu.js
+++ b/src/router/modules/ADempiere/menu.js
@@ -155,15 +155,22 @@ function getRouteFromMenuItem({ menu, roleUuid, organizationUuid }) {
 /**
  * Grant visibility to static routes based on current role permissions
  * @author elsiosanchez <elsiosanches@gmail.com>
+ * @author Edwin Betancourt <EdwinBetanc0urt@outlook.com>
  * @param {object} staticRoutes static routes
  * @param {object} permiseRole role permissions
+ * @returns {object} routes with hidden/show
  */
 function hidenStactiRoutes({ staticRoutes, permiseRole }) {
+  if (!permiseRole.isAllowInfoProduct) {
+    return staticRoutes
+  }
+
   return staticRoutes.map(route => {
     if (route.path === '/ProductInfo') {
       return {
         ...route,
-        hidden: !permiseRole.isAllowInfoProduct
+        // is hidden by default
+        hidden: false
       }
     }
     return {

--- a/src/router/modules/ADempiere/menu.js
+++ b/src/router/modules/ADempiere/menu.js
@@ -155,7 +155,6 @@ function getRouteFromMenuItem({ menu, roleUuid, organizationUuid }) {
 /**
  * Grant visibility to static routes based on current role permissions
  * @author elsiosanchez <elsiosanches@gmail.com>
- * @author Edwin Betancourt <EdwinBetanc0urt@outlook.com>
  * @param {object} staticRoutes static routes
  * @param {object} permiseRole role permissions
  * @returns {object} routes with hidden/show


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
The static menu item is traversed to modify the visibility of the `ProductInfo` item, only if the `isAllowInfoProduct` role attribute is set to true.
fixes https://github.com/adempiere/adempiere-vue/issues/659

#### Other relevant information
- Your OS: Linux Mint 19.1 Cinnamon x64.
- Web Browser: Mozilla Firefox 85.0.
- Node.js version: 12.20.0.
- adempiere-vue version: 4.3.1.


