### PR TITLE
Support to Field Preference

### DIFF
--- a/src/api/ADempiere/field/preference.js
+++ b/src/api/ADempiere/field/preference.js
@@ -1,4 +1,4 @@
-export function requestFieldPreference({
+export function getPreference({
   parentUuid,
   containerUuid,
   panelType,
@@ -6,9 +6,25 @@ export function requestFieldPreference({
   value,
   level
 }) {
-  const { requestUpdateEntity } = require('@/api/ADempiere/persistence.js')
+  return getPreference({
+    parentUuid,
+    containerUuid,
+    panelType,
+    attribute,
+    value,
+    level
+  })
+}
 
-  return requestUpdateEntity({
+export function updatePreference({
+  parentUuid,
+  containerUuid,
+  panelType,
+  attribute,
+  value,
+  level
+}) {
+  return updatePreference({
     parentUuid,
     containerUuid,
     panelType,

--- a/src/api/ADempiere/field/preference.js
+++ b/src/api/ADempiere/field/preference.js
@@ -1,7 +1,19 @@
 export function requestFieldPreference({
-  attributes
+  parentUuid,
+  containerUuid,
+  panelType,
+  attribute,
+  value,
+  level
 }) {
   const { requestUpdateEntity } = require('@/api/ADempiere/persistence.js')
 
-  return requestUpdateEntity(attributes)
+  return requestUpdateEntity({
+    parentUuid,
+    containerUuid,
+    panelType,
+    attribute,
+    value,
+    level
+  })
 }

--- a/src/api/ADempiere/field/preference.js
+++ b/src/api/ADempiere/field/preference.js
@@ -1,0 +1,7 @@
+export function requestFieldPreference({
+  attributes
+}) {
+  const { requestUpdateEntity } = require('@/api/ADempiere/persistence.js')
+
+  return requestUpdateEntity(attributes)
+}

--- a/src/components/ADempiere/Field/index.vue
+++ b/src/components/ADempiere/Field/index.vue
@@ -52,7 +52,7 @@
           />
           <preference
             :field-attributes="fieldAttributes"
-            :field-value="recordDataFields"
+            :field-value="isEmptyValue(recordDataFields) ? field.value : recordDataFields"
             :panel-type="field.panelType"
           />
         </template>

--- a/src/components/ADempiere/Field/index.vue
+++ b/src/components/ADempiere/Field/index.vue
@@ -50,6 +50,10 @@
             :field-attributes="fieldAttributes"
             :field-value="recordDataFields"
           />
+          <preference
+            :field-attributes="fieldAttributes"
+            :field-value="recordDataFields"
+          />
         </template>
 
         <component
@@ -75,6 +79,7 @@
 <script>
 import contextInfo from '@/components/ADempiere/Field/popover/contextInfo'
 import documentStatus from '@/components/ADempiere/Field/popover/documentStatus'
+import preference from '@/components/ADempiere/Field/popover/preference/index'
 import operatorComparison from '@/components/ADempiere/Field/popover/operatorComparison'
 import translated from '@/components/ADempiere/Field/popover/translated'
 import calculator from '@/components/ADempiere/Field/popover/calculator'
@@ -93,7 +98,8 @@ export default {
     documentStatus,
     operatorComparison,
     translated,
-    calculator
+    calculator,
+    preference
   },
   props: {
     // receives the property that is an object with all the attributes

--- a/src/components/ADempiere/Field/index.vue
+++ b/src/components/ADempiere/Field/index.vue
@@ -53,6 +53,7 @@
           <preference
             :field-attributes="fieldAttributes"
             :field-value="recordDataFields"
+            :panel-type="field.panelType"
           />
         </template>
 

--- a/src/components/ADempiere/Field/index.vue
+++ b/src/components/ADempiere/Field/index.vue
@@ -52,11 +52,10 @@
           />
           <preference
             :field-attributes="fieldAttributes"
-            :field-value="isEmptyValue(recordDataFields) ? field.value : recordDataFields"
+            :field-value="recordDataFields"
             :panel-type="field.panelType"
           />
         </template>
-
         <component
           :is="componentRender"
           :ref="field.columnName"
@@ -86,7 +85,6 @@ import translated from '@/components/ADempiere/Field/popover/translated'
 import calculator from '@/components/ADempiere/Field/popover/calculator'
 import { DEFAULT_SIZE } from '@/utils/ADempiere/references'
 import { evalutateTypeField, fieldIsDisplayed } from '@/utils/ADempiere/dictionaryUtils'
-import { LOG_COLUMNS_NAME_LIST } from '@/utils/ADempiere/dataUtils.js'
 
 /**
  * This is the base component for linking the components according to the
@@ -214,10 +212,6 @@ export default {
       }
       return this.field.isMandatory || this.field.isMandatoryFromLogic
     },
-    /**
-     * Idicate if field is read only
-     * TODO: Create common method to evaluate isReadOnly
-     */
     isReadOnly() {
       if (this.isAdvancedQuery) {
         if (['NULL', 'NOT_NULL'].includes(this.field.operator)) {
@@ -230,16 +224,9 @@ export default {
         return true
       }
 
-      // records in columns manage by backend
-      const isLogColumns = LOG_COLUMNS_NAME_LIST.includes(this.field.columnName)
-
       const isUpdateableAllFields = this.field.isReadOnly || this.field.isReadOnlyFromLogic
 
       if (this.field.panelType === 'window') {
-        if (isLogColumns) {
-          return true
-        }
-
         if (this.field.isAlwaysUpdateable) {
           return false
         }
@@ -259,7 +246,7 @@ export default {
       } else if (this.field.panelType === 'browser') {
         if (this.inTable) {
           // browser result
-          return this.field.isReadOnly || isLogColumns
+          return this.field.isReadOnly
         }
         // query criteria
         return this.field.isReadOnlyFromLogic
@@ -439,12 +426,7 @@ export default {
     margin-left: 0px;
     margin-right: 0px;
   }
-  .el-textarea {
-    position: relative;
-    display: contents;
-    width: 100%;
-    vertical-align: bottom;
-  }
+
   /* Global Styles */
   .el-textarea__inner:not(.in-table) {
     min-height: 36px !important;

--- a/src/components/ADempiere/Field/popover/preference/filelistPreference.js
+++ b/src/components/ADempiere/Field/popover/preference/filelistPreference.js
@@ -5,7 +5,7 @@ export default [
     isFromDictionary: true,
     overwriteDefinition: {
       size: 24,
-      sequence: 8,
+      sequence: 0,
       isReadOnly: true,
       handleActionPerformed: true,
       handleContentSelection: true,
@@ -20,7 +20,7 @@ export default [
     isFromDictionary: true,
     overwriteDefinition: {
       size: 24,
-      sequence: 9,
+      sequence: 1,
       handleActionPerformed: true,
       handleContentSelection: true,
       handleActionKeyPerformed: true,
@@ -34,7 +34,7 @@ export default [
     isFromDictionary: true,
     overwriteDefinition: {
       size: 24,
-      sequence: 10,
+      sequence: 2,
       isReadOnly: true,
       handleActionPerformed: true,
       handleContentSelection: true,
@@ -49,7 +49,7 @@ export default [
     isFromDictionary: true,
     overwriteDefinition: {
       size: 24,
-      sequence: 10,
+      sequence: 3,
       isReadOnly: true,
       handleActionPerformed: true,
       handleContentSelection: true,

--- a/src/components/ADempiere/Field/popover/preference/filelistPreference.js
+++ b/src/components/ADempiere/Field/popover/preference/filelistPreference.js
@@ -1,0 +1,61 @@
+export default [
+  {
+    elementColumnName: 'AD_Client_ID',
+    columnName: 'AD_Client_ID',
+    isFromDictionary: true,
+    overwriteDefinition: {
+      size: 24,
+      sequence: 8,
+      isReadOnly: true,
+      handleActionPerformed: true,
+      handleContentSelection: true,
+      handleActionKeyPerformed: true,
+      componentPath: 'FieldYesNo',
+      value: true
+    }
+  },
+  {
+    elementColumnName: 'AD_Org_ID',
+    columnName: 'AD_Org_ID',
+    isFromDictionary: true,
+    overwriteDefinition: {
+      size: 24,
+      sequence: 9,
+      handleActionPerformed: true,
+      handleContentSelection: true,
+      handleActionKeyPerformed: true,
+      componentPath: 'FieldYesNo',
+      value: false
+    }
+  },
+  {
+    elementColumnName: 'AD_User_ID',
+    columnName: 'AD_User_ID',
+    isFromDictionary: true,
+    overwriteDefinition: {
+      size: 24,
+      sequence: 10,
+      isReadOnly: true,
+      handleActionPerformed: true,
+      handleContentSelection: true,
+      handleActionKeyPerformed: true,
+      componentPath: 'FieldYesNo',
+      value: true
+    }
+  },
+  {
+    elementColumnName: 'AD_Window_ID',
+    columnName: 'AD_Window_ID',
+    isFromDictionary: true,
+    overwriteDefinition: {
+      size: 24,
+      sequence: 10,
+      isReadOnly: true,
+      handleActionPerformed: true,
+      handleContentSelection: true,
+      handleActionKeyPerformed: true,
+      componentPath: 'FieldYesNo',
+      value: true
+    }
+  }
+]

--- a/src/components/ADempiere/Field/popover/preference/index.vue
+++ b/src/components/ADempiere/Field/popover/preference/index.vue
@@ -18,7 +18,7 @@
             class="demo-form-inline"
           >
             <el-form-item :label="$t('components.preference.attribute')">
-              {{ fieldAttributes.columnName }}
+              {{ fieldAttributes.name }}
             </el-form-item>
           </el-form>
           <el-form
@@ -28,7 +28,20 @@
             <el-form-item
               :label="$t('components.preference.code')"
             >
-              {{ code }}
+              <el-switch
+                v-if="fieldAttributes.componentPath === 'FieldYesNo'"
+                v-model="code"
+                :active-text="$t('components.preference.yes')"
+                :inactive-text="$t('components.preference.no')"
+                :disabled="true"
+              />
+              <div
+                v-else
+              >
+                {{
+                  code
+                }}
+              </div>
             </el-form-item>
           </el-form>
           <el-form
@@ -55,11 +68,13 @@
                 type="danger"
                 class="custom-button-address-location"
                 icon="el-icon-close"
+                @click="close()"
               />
               <el-button
                 type="primary"
                 class="custom-button-address-location"
                 icon="el-icon-check"
+                @click="close()"
               />
             </samp>
           </el-col>
@@ -109,12 +124,16 @@ export default {
   },
   watch: {
     isActive(value) {
-      const preferenceValue = this.isEmptyValue(this.fieldValue) ? this.fieldAttributes.value : this.fieldValue
+      const preferenceValue = this.fieldValue
       if (value && this.isEmptyValue(this.metadataList)) {
         this.setFieldsList()
       }
       if (!this.isEmptyValue(preferenceValue)) {
-        this.code = (typeof preferenceValue !== 'string') ? preferenceValue.toString() : preferenceValue
+        if ((typeof preferenceValue !== 'string') && (this.fieldAttributes.componentPath !== 'FieldYesNo')) {
+          this.code = preferenceValue.toString()
+        } else {
+          this.code = preferenceValue
+        }
       }
     }
   },
@@ -127,6 +146,9 @@ export default {
   methods: {
     createFieldFromDictionary,
     attributePreference,
+    close() {
+      this.$children[0].visible = false
+    },
     notSubmitForm(event) {
       event.preventDefault()
       return false

--- a/src/components/ADempiere/Field/popover/preference/index.vue
+++ b/src/components/ADempiere/Field/popover/preference/index.vue
@@ -87,7 +87,7 @@
 <script>
 // import { ID, INTEGER } from '@/utils/ADempiere/references'
 import filelistPreference from './filelistPreference.js'
-import { requestFieldPreference } from '@/api/ADempiere/field/preference.js'
+import { getPreference } from '@/api/ADempiere/field/preference.js'
 import { createFieldFromDictionary } from '@/utils/ADempiere/lookupFactory'
 import { attributePreference } from '@/utils/ADempiere/valueUtils'
 
@@ -178,7 +178,7 @@ export default {
         value: this.code,
         level: list
       })
-      requestFieldPreference(preference)
+      getPreference(preference)
     },
     changeValue(value) {
       switch (value.columName) {

--- a/src/components/ADempiere/Field/popover/preference/index.vue
+++ b/src/components/ADempiere/Field/popover/preference/index.vue
@@ -18,12 +18,6 @@
             class="demo-form-inline"
           >
             <el-form-item :label="$t('components.preference.attribute')">
-              <el-input
-                v-model="fieldAttributes.name"
-                :disabled="true"
-              />
-            </el-form-item>
-            <el-form-item>
               {{ fieldAttributes.columnName }}
             </el-form-item>
           </el-form>
@@ -34,12 +28,6 @@
             <el-form-item
               :label="$t('components.preference.code')"
             >
-              <el-input
-                v-model="code"
-                :disabled="true"
-              />
-            </el-form-item>
-            <el-form-item>
               {{ code }}
             </el-form-item>
           </el-form>

--- a/src/components/ADempiere/Field/popover/preference/index.vue
+++ b/src/components/ADempiere/Field/popover/preference/index.vue
@@ -1,0 +1,285 @@
+<template>
+  <el-dropdown trigger="click">
+    <el-button type="text" :disabled="fieldAttributes.readonly">
+      <i class="el-icon-notebook-2 el-icon--right" @click="isActive = !isActive" />
+    </el-button>
+
+    <el-dropdown-menu slot="dropdown" class="dropdown-calc">
+      <el-card class="box-card">
+        <div slot="header" class="clearfix">
+          <span>
+            {{ $t('components.preference.title') }}
+            {{ fieldAttributes.name }}
+          </span>
+        </div>
+        <div class="text item">
+          <el-form
+            :inline="true"
+            class="demo-form-inline"
+          >
+            <el-form-item :label="$t('components.preference.attribute')">
+              <el-input
+                v-model="fieldAttributes.name"
+                :disabled="true"
+              />
+            </el-form-item>
+            <el-form-item>
+              {{ fieldAttributes.columnName }}
+            </el-form-item>
+          </el-form>
+          <el-form
+            :inline="true"
+            class="demo-form-inline"
+          >
+            <el-form-item
+              :label="$t('components.preference.code')"
+            >
+              <el-input
+                v-model="code"
+                :disabled="true"
+              />
+            </el-form-item>
+            <el-form-item>
+              {{ code }}
+            </el-form-item>
+          </el-form>
+          <el-form
+            label-position="top"
+            :inline="true"
+            class="demo-form-inline"
+          >
+            <el-form-item
+              v-for="(field) in metadataList"
+              :key="field.columnName"
+              :label="field.name"
+            >
+              <el-switch
+                v-model="field.value"
+              />
+            </el-form-item>
+          </el-form>
+        </div>
+        <br>
+        <el-row>
+          <el-col :span="24">
+            <samp style="float: right; padding-right: 10px;">
+              <el-button
+                type="danger"
+                class="custom-button-address-location"
+                icon="el-icon-close"
+              />
+              <el-button
+                type="primary"
+                class="custom-button-address-location"
+                icon="el-icon-check"
+              />
+            </samp>
+          </el-col>
+        </el-row>
+      </el-card>
+    </el-dropdown-menu>
+  </el-dropdown>
+</template>
+
+<script>
+// import { ID, INTEGER } from '@/utils/ADempiere/references'
+import filelistPreference from './filelistPreference.js'
+import { requestFieldPreference } from '@/api/ADempiere/field/preference.js'
+import { createFieldFromDictionary } from '@/utils/ADempiere/lookupFactory'
+
+export default {
+  name: 'Preference',
+  props: {
+    fieldAttributes: {
+      type: [Object],
+      required: true,
+      default: null
+    },
+    fieldValue: {
+      type: [String, Number, Boolean, Date, Array, Object],
+      required: true,
+      default: ''
+    },
+    containerUuid: {
+      type: String,
+      default: 'fiel-reference'
+    }
+  },
+  data() {
+    return {
+      filelistPreference,
+      metadataList: [],
+      code: '',
+      isActive: false,
+      unsubscribe: () => {}
+    }
+  },
+  watch: {
+    isActive(value) {
+      if (value && this.isEmptyValue(this.metadataList)) {
+        this.setFieldsList()
+      }
+      if (typeof this.fieldValue !== 'string') {
+        this.code = this.fieldValue.toString()
+      } else {
+        this.code = this.fieldValue
+      }
+    },
+    fieldValue(value) {
+      if (typeof value !== 'string') {
+        this.code = value.toString()
+      } else {
+        this.code = value
+      }
+    }
+  },
+  created() {
+    this.unsubscribe = this.subscribeChanges()
+  },
+  beforeDestroy() {
+    this.unsubscribe()
+  },
+  methods: {
+    createFieldFromDictionary,
+    notSubmitForm(event) {
+      event.preventDefault()
+      return false
+    },
+    setFieldsList() {
+      const fieldsList = []
+      // Product Code
+      this.filelistPreference.forEach(element => {
+        this.createFieldFromDictionary(element)
+          .then(metadata => {
+            const data = metadata
+            fieldsList.push({
+              ...data,
+              containerUuid: this.containerUuid
+            })
+          }).catch(error => {
+            console.warn(`LookupFactory: Get Field From Server (State) - Error ${error.code}: ${error.message}.`)
+          })
+      })
+      this.metadataList = fieldsList
+    },
+    sendValue(row, column) {
+      const client = this.$store.getters.getValueOfField({
+        containerUuid: this.containerUuid,
+        columnName: 'AD_Client_ID'
+      })
+      const org = this.$store.getters.getValueOfField({
+        containerUuid: this.containerUuid,
+        columnName: 'AD_Org_ID'
+      })
+      const user = this.$store.getters.getValueOfField({
+        containerUuid: this.containerUuid,
+        columnName: 'AD_User_ID'
+      })
+      const window = this.$store.getters.getValueOfField({
+        containerUuid: this.containerUuid,
+        columnName: 'AD_Window_ID'
+      })
+      const attributes = {
+        client,
+        org,
+        user,
+        window
+      }
+      requestFieldPreference({
+        attributes
+      })
+    },
+    changeValue(value) {
+      switch (value.columName) {
+        // case 'options':
+        case 'AD_Client_ID':
+          this.$store.commit('updateValueOfField', {
+            containerUuid: 'fiel-reference',
+            columnName: value.columName,
+            value: value.value
+          })
+          break
+        case 'AD_Org_ID':
+          this.$store.commit('updateValueOfField', {
+            containerUuid: 'fiel-reference',
+            columnName: value.columName,
+            value: value.value
+          })
+          break
+        case 'AD_User_ID':
+          this.$store.commit('updateValueOfField', {
+            containerUuid: 'fiel-reference',
+            columnName: value.columName,
+            value: value.value
+          })
+          break
+        case 'AD_Window_ID':
+          this.$store.commit('updateValueOfField', {
+            containerUuid: 'fiel-reference',
+            columnName: value.columName,
+            value: value.value
+          })
+          break
+      }
+    },
+    subscribeChanges() {
+      return this.$store.subscribe((mutation, state) => {
+        if (mutation.type === 'updateValueOfField') {
+          // const values = this.$store.getters.getValuesView({
+          //   containerUuid: mutation.payload.containerUuid,
+          //   format: 'object'
+          // })
+          // this.changeValue(values)
+        }
+      })
+    }
+  }
+}
+</script>
+
+<style>
+  .calculator-input > .el-input__inner,
+  .calculator-input .el-input__inner {
+    border-radius: 0px !important;
+  }
+
+  .calculator-input {
+    width: 202px;
+    font-size: 16px;
+    padding-left: 4px;
+  }
+
+  /* row color with hover */
+	.el-table--enable-row-hover .el-table__body tr:hover > td {
+		background-color: #ffffff !important;
+	}
+
+  .calculator-table .el-table__body-wrapper > table {
+    border-spacing: 5px;
+  }
+
+  /* Button shadow and border */
+  .calculator-table .el-table__body tr > td {
+    box-shadow: 0px 0px 2px 0px rgba(0,0,0,0.5);
+    border-radius: 5px;
+    cursor: pointer;
+  }
+
+  .calculator-table th, .calculator-table td,
+  .calculator-table > th, .calculator-table > td {
+    padding: 0px !important;
+    height: 0px !important;
+    padding-left: 0px !important;
+  }
+
+  .calculator-table .el-table .cell {
+    padding-right: 5px !important;
+    padding-left: 5px !important;
+  }
+  .calculator-table .el-table > .cell, .calculator-table .el-table .cell {
+    padding-left: 0px !important;
+  }
+  .calculator-table .el-table th.is-leaf, .el-table td {
+    border-bottom: 0px solid #dfe6ec !important;
+  }
+</style>

--- a/src/components/ADempiere/Field/popover/preference/index.vue
+++ b/src/components/ADempiere/Field/popover/preference/index.vue
@@ -9,25 +9,31 @@
         <div slot="header" class="clearfix">
           <span>
             {{ $t('components.preference.title') }}
-            {{ fieldAttributes.name }}
+            <b>
+              {{ fieldAttributes.name }}
+            </b>
           </span>
         </div>
+        <div v-if="!isEmptyValue(description)" class="text item">
+          <span v-if="description[0] === 'Usuario'">
+            {{ $t('components.preference.defaulMessageUser') }}
+          </span>
+          <span v-else>
+            {{ $t('components.preference.defaulMessage') }}
+          </span>
+          {{
+            description.join(', ')
+          }}
+        </div>
+        <br>
         <div class="text item">
           <el-form
             :inline="true"
-            class="demo-form-inline"
           >
-            <el-form-item :label="$t('components.preference.attribute')">
-              {{ fieldAttributes.name }}
-            </el-form-item>
-          </el-form>
-          <el-form
-            :inline="true"
-            class="demo-form-inline"
-          >
-            <el-form-item
-              :label="$t('components.preference.code')"
-            >
+            <el-form-item>
+              <el-button slot="label" class="title" type="text">
+                {{ fieldAttributes.name }}
+              </el-button>
               <el-switch
                 v-if="fieldAttributes.componentPath === 'FieldYesNo'"
                 v-model="code"
@@ -38,9 +44,11 @@
               <div
                 v-else
               >
-                {{
-                  code
-                }}
+                <el-button class="value" type="text">
+                  {{
+                    code
+                  }}
+                </el-button>
               </div>
             </el-form-item>
           </el-form>
@@ -48,6 +56,7 @@
             label-position="top"
             :inline="true"
             class="demo-form-inline"
+            size="medium"
           >
             <el-form-item
               v-for="(field) in metadataList"
@@ -56,7 +65,11 @@
             >
               <el-switch
                 v-model="field.value"
+                @change="displaye(field.value, field.name)"
               />
+              {{
+                field.columnNam
+              }}
             </el-form-item>
           </el-form>
         </div>
@@ -118,6 +131,7 @@ export default {
       filelistPreference,
       metadataList: [],
       code: '',
+      description: [],
       isActive: false,
       unsubscribe: () => {}
     }
@@ -130,7 +144,7 @@ export default {
       }
       if (!this.isEmptyValue(preferenceValue)) {
         if ((typeof preferenceValue !== 'string') && (this.fieldAttributes.componentPath !== 'FieldYesNo')) {
-          this.code = preferenceValue.toString()
+          this.code = preferenceValue
         } else {
           this.code = preferenceValue
         }
@@ -146,6 +160,15 @@ export default {
   methods: {
     createFieldFromDictionary,
     attributePreference,
+    displaye(value, label) {
+      if (value) {
+        const index = this.metadataList.findIndex(item => item.name === label)
+        this.description.splice((index + 1), 0, label)
+      } else {
+        const index = this.description.findIndex(item => item === label)
+        this.description.splice(index, 1)
+      }
+    },
     close() {
       this.$children[0].visible = false
     },
@@ -164,6 +187,9 @@ export default {
               ...data,
               containerUuid: 'fiel-reference'
             })
+            if (data.value) {
+              this.description.push(data.name)
+            }
           }).catch(error => {
             console.warn(`LookupFactory: Get Field From Server (State) - Error ${error.code}: ${error.message}.`)
           })
@@ -229,48 +255,18 @@ export default {
 </script>
 
 <style>
-  .calculator-input > .el-input__inner,
-  .calculator-input .el-input__inner {
-    border-radius: 0px !important;
+ .title {
+    color: #000000;
+    text-size-adjust: 20px;
+    font-size: 120%;
+    /* font-weight: 605!important;
+    left: 50%; */
   }
-
-  .calculator-input {
-    width: 202px;
-    font-size: 16px;
-    padding-left: 4px;
-  }
-
-  /* row color with hover */
-	.el-table--enable-row-hover .el-table__body tr:hover > td {
-		background-color: #ffffff !important;
-	}
-
-  .calculator-table .el-table__body-wrapper > table {
-    border-spacing: 5px;
-  }
-
-  /* Button shadow and border */
-  .calculator-table .el-table__body tr > td {
-    box-shadow: 0px 0px 2px 0px rgba(0,0,0,0.5);
-    border-radius: 5px;
-    cursor: pointer;
-  }
-
-  .calculator-table th, .calculator-table td,
-  .calculator-table > th, .calculator-table > td {
-    padding: 0px !important;
-    height: 0px !important;
-    padding-left: 0px !important;
-  }
-
-  .calculator-table .el-table .cell {
-    padding-right: 5px !important;
-    padding-left: 5px !important;
-  }
-  .calculator-table .el-table > .cell, .calculator-table .el-table .cell {
-    padding-left: 0px !important;
-  }
-  .calculator-table .el-table th.is-leaf, .el-table td {
-    border-bottom: 0px solid #dfe6ec !important;
+  .value {
+    color: #606266;
+    text-size-adjust: 20px;
+    font-size: 120%;
+    /* font-weight: 605!important;
+    left: 50%; */
   }
 </style>

--- a/src/lang/ADempiere/en.js
+++ b/src/lang/ADempiere/en.js
@@ -154,7 +154,9 @@ export default {
       attribute: 'Attribute',
       code: 'Code',
       yes: 'Yes',
-      no: 'No'
+      no: 'No',
+      defaulMessage: 'For This ',
+      defaulMessageUser: 'For This '
     }
   },
   views: {

--- a/src/lang/ADempiere/en.js
+++ b/src/lang/ADempiere/en.js
@@ -155,8 +155,8 @@ export default {
       code: 'Code',
       yes: 'Yes',
       no: 'No',
-      defaulMessage: 'For This ',
-      defaulMessageUser: 'For This '
+      defaulMessage: 'Applies for this ',
+      defaulMessageUser: 'Applies for this '
     }
   },
   views: {

--- a/src/lang/ADempiere/en.js
+++ b/src/lang/ADempiere/en.js
@@ -148,7 +148,12 @@ export default {
     resetAllFilters: 'Reset all filters',
     switchActiveText: 'Yes',
     switchInactiveText: 'Not',
-    contextFieldTitle: 'Context Information'
+    contextFieldTitle: 'Context Information',
+    preference: {
+      title: 'Preference Value',
+      attribute: 'Attribute',
+      code: 'Code'
+    }
   },
   views: {
     browser: 'Smart Browser',

--- a/src/lang/ADempiere/en.js
+++ b/src/lang/ADempiere/en.js
@@ -152,7 +152,9 @@ export default {
     preference: {
       title: 'Preference Value',
       attribute: 'Attribute',
-      code: 'Code'
+      code: 'Code',
+      yes: 'Yes',
+      no: 'No'
     }
   },
   views: {

--- a/src/lang/ADempiere/es.js
+++ b/src/lang/ADempiere/es.js
@@ -148,7 +148,12 @@ export default {
     resetAllFilters: 'Reiniciar todos los filtros',
     switchActiveText: 'Si',
     switchInactiveText: 'No',
-    contextFieldTitle: 'Información de Contexto'
+    contextFieldTitle: 'Información de Contexto',
+    preference: {
+      title: 'Valor de Preferencia',
+      attribute: 'Atributo',
+      code: 'Codigo'
+    }
   },
   views: {
     browser: 'Consulta Inteligente',

--- a/src/lang/ADempiere/es.js
+++ b/src/lang/ADempiere/es.js
@@ -155,8 +155,8 @@ export default {
       code: 'Codigo',
       yes: 'Si',
       no: 'No',
-      defaulMessage: 'Para Esta ',
-      defaulMessageUser: 'Para Este '
+      defaulMessage: 'Aplica para Esta ',
+      defaulMessageUser: 'Aplica para Este '
     }
   },
   views: {

--- a/src/lang/ADempiere/es.js
+++ b/src/lang/ADempiere/es.js
@@ -154,7 +154,9 @@ export default {
       attribute: 'Atributo',
       code: 'Codigo',
       yes: 'Si',
-      no: 'No'
+      no: 'No',
+      defaulMessage: 'Para Esta ',
+      defaulMessageUser: 'Para Este '
     }
   },
   views: {

--- a/src/lang/ADempiere/es.js
+++ b/src/lang/ADempiere/es.js
@@ -152,7 +152,9 @@ export default {
     preference: {
       title: 'Valor de Preferencia',
       attribute: 'Atributo',
-      code: 'Codigo'
+      code: 'Codigo',
+      yes: 'Si',
+      no: 'No'
     }
   },
   views: {

--- a/src/utils/ADempiere/valueUtils.js
+++ b/src/utils/ADempiere/valueUtils.js
@@ -250,7 +250,7 @@ export const recursiveTreeSearch = ({
 }
 
 /**
- * Parsed value to component type
+ * Preference Value
  * @author Elsio Sanchez <elsiosanches@gmail.com>
  * @param {mixed} value, value to parsed
  * @param {string} componentPath
@@ -529,4 +529,40 @@ export function tenderTypeFind({
 }
 export function clearVariables() {
   partialValue = ''
+}
+
+/**
+ * Search the Payment List for the Current Payment
+ * @param {string} parentUuid Uuid the Parent
+ * @param {string} containerUuid Uuid the Container
+ * @param {string} panelType Panel Type
+ * @param {string} attribute ColumName Field
+ * @param {boolean| string | number} value Value
+ * @param {array} level list value the preference
+ */
+export function attributePreference({
+  parentUuid,
+  containerUuid,
+  panelType,
+  attribute,
+  value,
+  level
+}) {
+  let levelPanel
+  if (level) {
+    levelPanel = level.map(parameter => {
+      return {
+        key: parameter.columnName,
+        value: parameter.value
+      }
+    })
+  }
+  return {
+    parentUuid,
+    containerUuid,
+    panelType,
+    attribute,
+    value,
+    level: levelPanel
+  }
 }

--- a/src/views/login/index.vue
+++ b/src/views/login/index.vue
@@ -132,7 +132,8 @@ export default {
       loading: false,
       showDialog: false,
       redirect: undefined,
-      otherQuery: {}
+      otherQuery: {},
+      default: 'dashboard'
     }
   },
   watch: {
@@ -212,6 +213,9 @@ export default {
     },
     clientIdRedirect(query, expr) {
       const redirect = query.split(expr)
+      if (redirect[1] === this.default) {
+        return
+      }
       return redirect[1]
     },
     organizationIdRedirect(query, expr) {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

Field preference support in ADempiere-Vue
Unlike the ZK interface in ADempiere-Vue you can open the reference popover in all fields.

#### Steps to reproduce

1. Open a window 
2. Open Field Reference popover 
3. Any type of field

#### Screenshot or Gif
### Referencia de Campo en la Interfaz ADempiere-ZK
![zk](https://user-images.githubusercontent.com/45974454/110875615-58c19700-82ac-11eb-98a8-a0bd2d1e4166.gif)
### Referencia de Campo en la Interfaz ADempiere-VUe
![preference](https://user-images.githubusercontent.com/45974454/110875631-61b26880-82ac-11eb-9f49-35d3b973e80a.gif)


#### Link to minimal reproduction

https://demo-ui.erpya.com//#/a48d2596-fb40-11e8-a479-7a0060f0aa01/a3e5c878-fb40-11e8-a479-7a0060f0aa01/window/113?tabParent=0&action=a61073be-fb40-11e8-a479-7a0060f0aa01

#### Other relevant information
- Your OS: Debian 9
- Web Browser: Chrome
- Node.js version: 10.9.0

#### Additional context
In the ADempiere-Vue interface you can open the field reference in any field type. In the ADempiere-ZK interface you can only open the field reference in select and text fields.
#### Issues:
Fixes: #145