### PR TITLE
fix: Export record's to zip, xls, json, xml, txt

### DIFF
--- a/src/components/ADempiere/ContextMenu/contextMenuMixin.js
+++ b/src/components/ADempiere/ContextMenu/contextMenuMixin.js
@@ -1,6 +1,6 @@
 import { showNotification } from '@/utils/ADempiere/notification.js'
 import ItemsRelations from './itemsRelations'
-import { convertFieldsListToShareLink, recursiveTreeSearch } from '@/utils/ADempiere/valueUtils.js'
+import { clientDateTime, convertFieldsListToShareLink, recursiveTreeSearch } from '@/utils/ADempiere/valueUtils.js'
 import { supportedTypes, exportFileFromJson } from '@/utils/ADempiere/exportUtil.js'
 import ROUTES from '@/utils/ADempiere/constants/zoomWindow'
 import relationsMixin from './relationsMixin.js'
@@ -342,11 +342,17 @@ export default {
         // TODO: Check usage as the selection is exported with the table menu
         list = this.getDataSelection
       }
+
+      let title = this.metadataMenu.name
+      if (this.isEmptyValue(title)) {
+        title = this.$route.meta.title
+      }
+
       const data = this.formatJson(filterVal, list)
       exportFileFromJson({
         header: tHeader,
         data,
-        filename: '',
+        fileName: `${title} ${clientDateTime()}`,
         exportType: fotmatToExport
       })
     },

--- a/src/components/ADempiere/DataTable/menu/menuTableMixin.js
+++ b/src/components/ADempiere/DataTable/menu/menuTableMixin.js
@@ -215,12 +215,17 @@ export default {
     /**
      * Export records as .txt into compressed .zip file
      */
-    exporZipRecordTable() {
+    exporZipRecordTable({
+      recordContexMenu = false
+    }) {
       const header = this.getterFieldsListHeader
       const filterVal = this.getterFieldsListValue
       let list = this.getDataSelection
       if (this.getDataSelection.length <= 0) {
         list = this.recordsData
+      }
+      if (recordContexMenu) {
+        list = [this.currentRow]
       }
       const data = this.formatJson(filterVal, list)
 

--- a/src/components/ADempiere/DataTable/menu/menuTableMixin.js
+++ b/src/components/ADempiere/DataTable/menu/menuTableMixin.js
@@ -1,5 +1,5 @@
-import { supportedTypes, exportFileFromJson, exportFileZip } from '@/utils/ADempiere/exportUtil.js'
-import { recursiveTreeSearch } from '@/utils/ADempiere/valueUtils.js'
+import { supportedTypes, exportFileFromJson, exportZipFile } from '@/utils/ADempiere/exportUtil.js'
+import { clientDateTime, recursiveTreeSearch } from '@/utils/ADempiere/valueUtils.js'
 import { FIELDS_QUANTITY } from '@/utils/ADempiere/references'
 import TableMixin from '@/components/ADempiere/DataTable/mixin/tableMixin.js'
 
@@ -197,15 +197,24 @@ export default {
         list = this.getDataSelection
       }
 
+      let title = this.panelMetadata.name
+      if (this.isEmptyValue(title)) {
+        title = this.$route.meta.title
+      }
+
       const data = this.formatJson(filterVal, list)
       exportFileFromJson({
         header,
         data,
-        filename: '',
+        fileName: `${title} ${clientDateTime()}`,
         exportType: formatToExport
       })
+
       this.closeMenu()
     },
+    /**
+     * Export records as .txt into compressed .zip file
+     */
     exporZipRecordTable() {
       const header = this.getterFieldsListHeader
       const filterVal = this.getterFieldsListValue
@@ -214,11 +223,17 @@ export default {
         list = this.recordsData
       }
       const data = this.formatJson(filterVal, list)
-      exportFileZip({
+
+      let title = this.panelMetadata.name
+      if (this.isEmptyValue(title)) {
+        title = this.$route.meta.title
+      }
+
+      exportZipFile({
         header,
         data,
-        title: this.$route.meta.title,
-        exportType: 'zip'
+        txtName: title,
+        zipName: `${title} ${clientDateTime()}`
       })
     },
     formatJson(filterVal, jsonData) {

--- a/src/components/ADempiere/DataTable/menu/tableContextMenu.vue
+++ b/src/components/ADempiere/DataTable/menu/tableContextMenu.vue
@@ -19,6 +19,13 @@
       </el-menu-item>
     </el-submenu>
     <el-menu-item
+      @click="exporZipRecordTable({
+        recordContexMenu: true
+      })"
+    >
+      {{ $t('table.dataTable.exportZip') }}
+    </el-menu-item>
+    <el-menu-item
       v-if="panelType === 'window'"
       index="delete"
       @click="deleteRecord()"

--- a/src/utils/ADempiere/exportUtil.js
+++ b/src/utils/ADempiere/exportUtil.js
@@ -1,6 +1,8 @@
 import { export_json_to_excel } from '@/vendor/Export2Excel'
 import { export_txt_to_zip } from '@/vendor/Export2Zip'
 import language from '@/lang'
+import { convertBooleanToTranslationLang } from '@/utils/ADempiere/valueFormat.js'
+import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 
 export const reportFormatsList = [
   'ps',
@@ -29,26 +31,28 @@ export const supportedTypes = {
  * @param {array} header
  * @param {array} data
  * @param {string} exportType, supportedTypes array
+ * @param {string} fileName .xlsx file name
  */
 export function exportFileFromJson({
   header,
   data,
-  exportType
+  exportType,
+  fileName = ''
 }) {
-  const Json = data.map(dataJson => {
-    Object.keys(dataJson).forEach(key => {
-      if (typeof dataJson[key] === 'boolean') {
-        dataJson[key] = dataJson[key]
-          ? language.t('components.switchActiveText')
-          : language.t('components.switchInactiveText')
+  const jsonData = data.map(row => {
+    Object.keys(row).forEach(column => {
+      if (typeof row[column] === 'boolean') {
+        row[column] = convertBooleanToTranslationLang(row[column])
       }
     })
-    return dataJson
+
+    return row
   })
+
   export_json_to_excel({
-    header: header,
-    data: Json,
-    filename: '',
+    header,
+    data: jsonData,
+    filename: fileName,
     bookType: exportType
   })
 }
@@ -58,27 +62,35 @@ export function exportFileFromJson({
  * @autor Edwin Betancourt <EdwinBetanc0urt@outlook.com>
  * @param {array} header
  * @param {array} data
- * @param {string} title
+ * @param {string} txtName .txt text file name
+ * @param {string} zipName .zip compressed file name
  */
-export function exportFileZip({
+export function exportZipFile({
   header,
   data,
-  title
+  txtName = '',
+  zipName = ''
 }) {
-  const Json = data.map(dataJson => {
-    Object.keys(dataJson).forEach(key => {
-      if (typeof dataJson[key] === 'boolean') {
-        dataJson[key] = dataJson[key]
-          ? language.t('components.switchActiveText')
-          : language.t('components.switchInactiveText')
+  const jsonData = data.map(row => {
+    Object.keys(row).forEach(column => {
+      if (typeof row[column] === 'boolean') {
+        row[column] = convertBooleanToTranslationLang(row[column])
       }
     })
-    return dataJson
+    return row
   })
+
+  if (isEmptyValue(zipName)) {
+    zipName = txtName
+  }
+  if (isEmptyValue(txtName)) {
+    txtName = zipName
+  }
 
   export_txt_to_zip(
     header,
-    Json,
-    title
+    jsonData,
+    txtName,
+    zipName
   )
 }

--- a/src/utils/ADempiere/valueFormat.js
+++ b/src/utils/ADempiere/valueFormat.js
@@ -1,6 +1,7 @@
 // A util class for handle format for time, date and others values to beused to display information
 // Note that this file use moment library for a easy conversion
 import moment from 'moment'
+import language from '@/lang'
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 import store from '@/store'
 import { DATE, DATE_PLUS_TIME, TIME, AMOUNT, COSTS_PLUS_PRICES, NUMBER, QUANTITY } from '@/utils/ADempiere/references.js'
@@ -25,6 +26,18 @@ export const convertBooleanToString = (booleanValue) => {
     return 'Y'
   }
   return 'N'
+}
+
+/**
+ * Convert boolean value to current translation language
+ * @param {boolean} booleanValue
+ * @returns {string} true => 'Yes' or 'Si', false => 'Not' or 'No'
+ */
+export const convertBooleanToTranslationLang = (booleanValue) => {
+  if (booleanValue || booleanValue === 'true') {
+    return language.t('components.switchActiveText')
+  }
+  return language.t('components.switchInactiveText')
 }
 
 /**


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Screenshot or Gif
![export-record-zip-fix](https://user-images.githubusercontent.com/20288327/110891727-f925b480-82c8-11eb-9eaa-475060a33b23.gif)


#### Link to minimal reproduction
https://demo-ui.erpya.com/#/a48d2596-fb40-11e8-a479-7a0060f0aa01/a3e5c878-fb40-11e8-a479-7a0060f0aa01/window/53228?tabParent=0&tabChild=1&action=a4cb51ea-fb40-11e8-a479-7a0060f0aa01

#### Other relevant information
- Your OS: Linux Mint 19.1 Cinnamon x64.
- Web Browser: Mozilla Firefox 85.0.
- Node.js version: 12.20.0.
- adempiere-vue version: 4.3.1.

#### Additional context
By default if no record has been selected it will export all available records of the selected tab to export.

The file to export will take the name of the tab to be exported, if it is a zip file it will additionally take the current date yyyy-MM-dd HH mm ss, only for the compressed file, the file inside it will only have the name of the tab.

fixes https://github.com/adempiere/adempiere-vue/issues/130  https://github.com/adempiere/adempiere-vue/issues/178 https://github.com/adempiere/adempiere-vue/issues/241