### PR TITLE
fixed styling of labels for select boxes in RolesNavbar

### DIFF
--- a/src/views/profile/components/RolesNavbar.vue
+++ b/src/views/profile/components/RolesNavbar.vue
@@ -1,6 +1,6 @@
 <template>
   <el-form>
-    {{ $t('route.role') }}
+    <label>{{ $t('route.role') }}</label>
     <el-select
       v-model="currentRoleUuid"
       :filterable="isFiltrable"
@@ -15,7 +15,7 @@
       />
     </el-select>
 
-    {{ $t('route.organization') }}
+    <label>{{ $t('route.organization') }}</label>
     <el-select
       v-model="currentOrganizationUuid"
       :filterable="isFiltrable"
@@ -31,7 +31,7 @@
       />
     </el-select>
 
-    {{ $t('route.warehouse') }}
+    <label>{{ $t('route.warehouse') }}</label>
     <el-select
       v-model="currentWarehouseUuid"
       :filterable="isFiltrable"
@@ -157,3 +157,11 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+label {
+  font-weight: 400;
+  display: block;
+  margin-top: 5%;
+}
+</style>


### PR DESCRIPTION
## Bug report / Feature
The styling of the labels for the select boxes in RolesNavbar was a bit off. There was no line break.

#### Steps to reproduce

1. run the dev environment
2. Login
3. Click on the "A" button on the top right corner

#### Screenshot or Gif
<img width="268" alt="Screen Shot 2021-03-16 at 7 39 52 pm" src="https://user-images.githubusercontent.com/54033498/111382955-b403e700-86fb-11eb-91e4-f295557e65ff.png">

