### PR TITLE
Fixed error with Search Product from Value instead name

### DIFF
--- a/src/components/ADempiere/Form/VPOS/KeyLayout/index.vue
+++ b/src/components/ADempiere/Form/VPOS/KeyLayout/index.vue
@@ -227,24 +227,13 @@ export default {
       if (!this.isEmptyValue(keyValue.subKeyLayoutUuid)) {
         this.loadKeyLayout(keyValue.subKeyLayoutUuid)
       } else {
-        const products = this.listOrderLine.find(item => item.lineDescription === keyValue.name)
-        // TODO: Change this dispatch
-        if (!this.isEmptyValue(products) && keyValue.quantity > 1) {
-          this.$store.dispatch('notifyActionKeyPerformed', {
-            value: {
-              QtyEntered: keyValue.quantity,
-              value: keyValue.name
-            }
-          })
-        } else {
-          this.$store.dispatch('notifyActionKeyPerformed', {
-            columnName: 'ProductValue',
-            value: {
-              QtyEntered: keyValue.quantity,
-              value: keyValue.name
-            }
-          })
-        }
+        this.$store.dispatch('notifyActionKeyPerformed', {
+          columnName: 'ProductValue',
+          value: {
+            QtyEntered: keyValue.quantity,
+            value: keyValue.productValue
+          }
+        })
       }
     },
     handleCommand(command) {

--- a/src/utils/ADempiere/apiConverts/pos.js
+++ b/src/utils/ADempiere/apiConverts/pos.js
@@ -115,7 +115,7 @@ export function convertKey(keyToConvert) {
     sequence: keyToConvert.sequence,
     spanX: keyToConvert.span_x,
     spanY: keyToConvert.span_y,
-    productUuid: keyToConvert.product_uuid,
+    productValue: keyToConvert.product_value,
     quantity: keyToConvert.quantity,
     resourceReference: convertResourceReference(
       keyToConvert.resource_reference


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
When a key layout is pressed and it has a product, the product is not found and is showed a product list for search
#### Steps to reproduce

1. Login to ADempiere
2. Go to POS form
3. Open right panel
4. Press the first key layout

#### Screenshot or Gif
![Peek 2021-03-22 03-28](https://user-images.githubusercontent.com/2333092/111955028-5686e600-8abf-11eb-87f5-9d4d85e91fd0.gif)


#### Link to minimal reproduction
https://demo-ui.erpya.com/#/7aa4242a-93c0-42d8-92be-8250002d3e3c/d97027fd-4cd5-445e-8fd8-ef5d3f7959b4/form/419?pos=1000002&action=b5c31ee3-53d1-41da-bba8-f15879eb9d7c

<!--
Please only use Codepen, JSFiddle, CodeSandbox or a github repo
-->

#### Expected behavior
The product should be finded and added to order

#### Other relevant information
- Your OS: Ubuntu
- Web Browser: Chrome
- Node.js version:
- adempiere-vue version: latest

#### Additional context
This change need the follows versions:

- [adempiere-gRPC-Server](https://github.com/adempiere/adempiere-gRPC-Server): [rt-19.8](https://github.com/adempiere/adempiere-gRPC-Server/releases/tag/rt-19.8)
- [proxy-adempiere-api](https://github.com/adempiere/proxy-adempiere-api): [rt-2.3](https://github.com/adempiere/proxy-adempiere-api/releases/tag/rt-2.3)