### PR TITLE
fix: Field isActive not edit with false value.

### DIFF
--- a/src/components/ADempiere/DataTable/dataTables-Script.js
+++ b/src/components/ADempiere/DataTable/dataTables-Script.js
@@ -8,7 +8,7 @@ import IconElement from '@/components/ADempiere/IconElement'
 import { formatField } from '@/utils/ADempiere/valueFormat'
 import MainPanel from '@/components/ADempiere/Panel'
 import { sortFields } from '@/utils/ADempiere/dictionaryUtils'
-import { FIELDS_DECIMALS, FIELDS_QUANTITY, FIELDS_READ_ONLY_FORM } from '@/utils/ADempiere/references'
+import { FIELDS_DECIMALS, FIELDS_QUANTITY, COLUMNS_READ_ONLY_FORM } from '@/utils/ADempiere/references'
 import { LOG_COLUMNS_NAME_LIST } from '@/utils/ADempiere/dataUtils.js'
 import { fieldIsDisplayed } from '@/utils/ADempiere'
 import evaluator from '@/utils/ADempiere/evaluator'
@@ -407,7 +407,7 @@ export default {
       }
       if (fieldIsDisplayed(field)) {
         // columnName: IsActive
-        const fieldReadOnlyForm = FIELDS_READ_ONLY_FORM.find(item => {
+        const fieldReadOnlyForm = COLUMNS_READ_ONLY_FORM.find(item => {
           return !item.isChangedAllForm &&
             // columnName: IsActive, Processed, Processing
             Object.prototype.hasOwnProperty.call(row, item.columnName)

--- a/src/components/ADempiere/Field/FieldYesNo.vue
+++ b/src/components/ADempiere/Field/FieldYesNo.vue
@@ -16,23 +16,15 @@
 
 <script>
 import { fieldIsDisplayed } from '@/utils/ADempiere'
-import { FIELDS_READ_ONLY_FORM } from '@/utils/ADempiere/references'
+import { COLUMNS_READ_ONLY_FORM } from '@/utils/ADempiere/references'
 import fieldMixin from '@/components/ADempiere/Field/mixin/mixinField.js'
 import { convertStringToBoolean } from '@/utils/ADempiere/valueFormat.js'
 
 export default {
   name: 'FieldYesNo',
-  mixins: [fieldMixin],
-  data() {
-    return {
-      valuesReadOnly: [
-        {
-          columnName: 'IsActive',
-          isReadOnlyValue: false
-        }
-      ]
-    }
-  },
+  mixins: [
+    fieldMixin
+  ],
   computed: {
     cssClassStyle() {
       let styleClass = ' custom-field-yes-no '
@@ -40,6 +32,16 @@ export default {
         styleClass += this.metadata.cssClassName
       }
       return styleClass
+    },
+    columnReadOnlyForm() {
+      return COLUMNS_READ_ONLY_FORM.find(item => {
+        return item.columnName === this.metadata.columnName
+      })
+    }
+  },
+  mounted() {
+    if (!this.isEmptyValue(this.columnReadOnlyForm)) {
+      this.isReadOnlyForm(this.value)
     }
   },
   methods: {
@@ -53,9 +55,10 @@ export default {
       }
     },
     isReadOnlyForm(value) {
-      const fieldReadOnlyForm = FIELDS_READ_ONLY_FORM.find(item => item.columnName === this.metadata.columnName)
+      const fieldReadOnlyForm = this.columnReadOnlyForm
+
       // columnName: IsActive, Processed, Processing
-      if (fieldReadOnlyForm && fieldIsDisplayed(this.metadata)) {
+      if (!this.isEmptyValue(fieldReadOnlyForm) && fieldIsDisplayed(this.metadata)) {
         const fieldsExcludes = []
         // if isChangedAllForm it does not exclude anything, otherwise it excludes this columnName
         if (!fieldReadOnlyForm.isChangedAllForm) {

--- a/src/components/ADempiere/Field/FieldYesNo.vue
+++ b/src/components/ADempiere/Field/FieldYesNo.vue
@@ -58,7 +58,7 @@ export default {
       if (fieldReadOnlyForm && fieldIsDisplayed(this.metadata)) {
         const fieldsExcludes = []
         // if isChangedAllForm it does not exclude anything, otherwise it excludes this columnName
-        if (fieldReadOnlyForm.isChangedAllForm) {
+        if (!fieldReadOnlyForm.isChangedAllForm) {
           fieldsExcludes.push(this.metadata.columnName)
         }
 

--- a/src/store/modules/ADempiere/panel/actions.js
+++ b/src/store/modules/ADempiere/panel/actions.js
@@ -274,6 +274,7 @@ const actions = {
       valueAttribute: true
     })
   },
+
   /**
    * Set default values to panel
    * @param {string}  parentUuid
@@ -356,31 +357,54 @@ const actions = {
         attributes: defaultAttributes
       })
         .then(() => {
-          if (['browser', 'form', 'process', 'report'].includes(panelType)) {
-          // const fieldsUser = []
-            panel.fieldsList.forEach(itemField => {
-              if (!itemField.isAdvancedQuery || itemField.isActiveLogics) {
+          const windowPanel = (itemField) => {
+            if (!itemField.isAdvancedQuery || itemField.isActiveLogics) {
+              // enable edit fields in panel
+              commit('changeFieldAttribure', {
+                attributeName: 'isReadOnlyFromForm',
+                field: itemField,
+                attributeValue: false
+              })
+            }
+          }
+
+          const othersPanel = (itemField) => {
+            if (!itemField.isAdvancedQuery || itemField.isActiveLogics) {
+              // enable edit fields in panel
+              commit('changeFieldAttribure', {
+                attributeName: 'isReadOnlyFromForm',
+                field: itemField,
+                attributeValue: false
+              })
+
               // Change Dependents
-                dispatch('changeDependentFieldsList', {
-                  field: itemField
-                })
-              }
+              dispatch('changeDependentFieldsList', {
+                field: itemField
+              })
+            }
             // if (itemField.isShowedFromUserDefault || !isEmptyValue(itemField.value)) {
             //   fieldsUser.push(itemField.columnName)
             // }
-            })
-
-          // dispatch('changeFieldShowedFromUser', {
-          //   containerUuid,
-          //   fieldsUser,
-          //   groupField: ''
-          // })
           }
+
+          let execute = windowPanel
+          if (['browser', 'form', 'process', 'report'].includes(panelType)) {
+            // const fieldsUser = []
+            execute = othersPanel
+
+            // dispatch('changeFieldShowedFromUser', {
+            //   containerUuid,
+            //   fieldsUser,
+            //   groupField: ''
+            // })
+          }
+          panel.fieldsList.forEach(execute)
         })
 
       resolve(defaultAttributes)
     })
   },
+
   seekRecord({ dispatch, getters }, {
     parentUuid,
     containerUuid,

--- a/src/utils/ADempiere/references.js
+++ b/src/utils/ADempiere/references.js
@@ -583,28 +583,40 @@ export const FIELDS_HIDDEN = [
   BUTTON
 ]
 
+export const COLUMN_IS_ACTIVE = {
+  columnName: 'IsActive', // column name of field
+  defaultValue: true, // default value when loading
+  valueIsReadOnlyForm: false, // value that activates read-only form
+  isChangedAllForm: false // change the entire form to read only including this field
+}
+
+export const COLUMN_PROCESSED = {
+  columnName: 'Processed',
+  defaultValue: false,
+  valueIsReadOnlyForm: true,
+  isChangedAllForm: true
+}
+
+export const COLUMN_PROCESSING = {
+  columnName: 'Processing',
+  defaultValue: true,
+  valueIsReadOnlyForm: false,
+  isChangedAllForm: true
+}
+
+export const COLUMNS_NAME_READ_ONLY = [
+  COLUMN_IS_ACTIVE.columnName,
+  COLUMN_PROCESSED.columnName,
+  COLUMN_PROCESSING.columnName
+]
+
 /**
  * Fields with this column name, changed all fields is read only
  */
-export const FIELDS_READ_ONLY_FORM = [
-  {
-    columnName: 'IsActive', // column name of field
-    defaultValue: true, // default value when loading
-    valueIsReadOnlyForm: false, // value that activates read-only form
-    isChangedAllForm: false // change the entire form to read only including this field
-  },
-  {
-    columnName: 'Processed',
-    defaultValue: false,
-    valueIsReadOnlyForm: true,
-    isChangedAllForm: true
-  },
-  {
-    columnName: 'Processing',
-    defaultValue: true,
-    valueIsReadOnlyForm: false,
-    isChangedAllForm: true
-  }
+export const COLUMNS_READ_ONLY_FORM = [
+  COLUMN_IS_ACTIVE,
+  COLUMN_PROCESSED,
+  COLUMN_PROCESSING
 ]
 
 export const FIELDS_DECIMALS = [


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Screenshot or Gif
![is-readonly-is-active-fix](https://user-images.githubusercontent.com/20288327/112243268-b0082580-8c23-11eb-9276-7d9161da6077.gif)


#### Link to minimal reproduction
https://demo-ui.erpya.com/#/567acca9-225c-44ea-9a6e-809ea01199b2/a3e5c878-fb40-11e8-a479-7a0060f0aa01/window/190?tabParent=0&action=8af3f668-0c15-4017-a298-dcdca3586220

#### Other relevant information
- Your OS: Linux Mint 19.1 Cinnamon x64.
- Web Browser: Mozilla Firefox 85.0.
- Node.js version: 12.20.0.
- adempiere-vue version: 4.3.1.

#### Additional context
fixes https://github.com/adempiere/adempiere-vue/issues/691
