### PR TITLE
fix: Window references.

### DIFF
--- a/src/components/ADempiere/Panel/mainPanelMixin.js
+++ b/src/components/ADempiere/Panel/mainPanelMixin.js
@@ -266,11 +266,14 @@ export default {
             recordUuid: route.query.recordUuid,
             referenceUuid: route.query.referenceUuid
           })
+          if (!this.isEmptyValue(referenceInfo)) {
+            parameters.referenceUuid = referenceInfo.uuid
+            parameters.referenceWhereClause = referenceInfo.whereClause
+          }
+
           route.params.isReadParameters = true
           parameters.isLoadAllRecords = false
           parameters.isReference = true
-          parameters.referenceUuid = referenceInfo.uuid
-          parameters.referenceWhereClause = referenceInfo.whereClause
         } else if (route.query.action && route.query.action === 'create-new') {
           parameters.isNewRecord = true
         } else if (route.query.action && route.query.action === 'criteria') {

--- a/src/store/modules/ADempiere/windowControl/getters.js
+++ b/src/store/modules/ADempiere/windowControl/getters.js
@@ -1,3 +1,5 @@
+import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
+
 /**
  * Vuex Module, Window Control
  * Getters
@@ -18,6 +20,9 @@ export default {
 
   getReferencesInfo: (state, getters) => ({ windowUuid, recordUuid, referenceUuid }) => {
     const references = getters.getReferencesList(windowUuid, recordUuid)
+    if (isEmptyValue(references)) {
+      return undefined
+    }
     return references.referencesList.find(item => item.uuid === referenceUuid)
   },
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open Purchase Order window
2. Go to References Option
3. Select MRP records


#### Screenshot or Gif
![references-fix](https://user-images.githubusercontent.com/20288327/113373027-f2beb180-9337-11eb-8b38-7462186e3456.gif)


#### Link to minimal reproduction
https://demo-ui.erpya.com/#/fdb386e9-413e-4617-9d86-1a82557e857f/0/window/205?action=8b2bfc4c-99be-4708-a77a-787ece80b104&tabParent=0&tabChild=0


#### Other relevant information
- Your OS: Linux Mint 19.1 Cinnamon x64.
- Web Browser: Mozilla Firefox 85.0.
- Node.js version: 12.20.0.
- adempiere-vue version: 4.3.1.

#### Additional context
fixes https://github.com/adempiere/adempiere-vue/issues/708
