### PR TITLE
show the hide panel buttons while the table is loading

### DIFF
--- a/src/components/ADempiere/DataTable/dataTables-StyleGlobal.scss
+++ b/src/components/ADempiere/DataTable/dataTables-StyleGlobal.scss
@@ -2,6 +2,19 @@
 td.cell-align-right, .cell-align-right {
   text-align: right !important;
 }
+// loading
+.el-loading-mask {
+  position: absolute;
+  z-index: 4;
+  background-color: rgba(255, 255, 255, 0.9);
+  margin: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  -webkit-transition: opacity 0.3s;
+  transition: opacity 0.3s;
+}
 
 // options to record with contextual menu
 .contextual-menu {


### PR DESCRIPTION

## Bug report / Feature
modifying the style to be able to close the registration panel while loading the registration table

#### Screenshot or Gif
![image](https://user-images.githubusercontent.com/45974454/116292865-330d2600-a764-11eb-80b6-9790f61a0747.png)
