### PR TITLE
Support to Private Access

### DIFF
--- a/src/api/ADempiere/actions/private-access.js
+++ b/src/api/ADempiere/actions/private-access.js
@@ -35,8 +35,9 @@ export function getPrivateAccess({
     .then(responsePrivateAccess => {
       return {
         tableName: responsePrivateAccess.table_name,
-        recordId: responsePrivateAccess.record_id,
-        recordUuid: responsePrivateAccess.record_uuid
+        recordId: responsePrivateAccess.id,
+        recordUuid: responsePrivateAccess.uuid,
+        isLocked: responsePrivateAccess.is_locked
       }
     })
 }

--- a/src/components/ADempiere/Tab/index.vue
+++ b/src/components/ADempiere/Tab/index.vue
@@ -31,10 +31,10 @@
         <span v-if="key === 0" slot="label">
           <el-tooltip v-if="key === 0" :content="lock ? $t('data.lockRecord') : $t('data.unlockRecord')" placement="top">
             <el-button type="text" @click="lockRecord()">
-              <i :class="lock ? 'el-icon-unlock' : 'el-icon-lock'" style="font-size: 15px;color: black;" />
+              <i :class="!lock ? 'el-icon-unlock' : 'el-icon-lock'" style="font-size: 15px;color: black;" />
             </el-button>
           </el-tooltip>
-          <span :style="lock ? 'color: #1890ff;': 'color: red;'">
+          <span :style="!lock ? 'color: #1890ff;': 'color: red;'">
             {{ tabAttributes.name }}
           </span>
         </span>
@@ -129,14 +129,13 @@ export default {
   methods: {
     lockRecord() {
       const tableName = this.windowMetadata.firstTab.tableName
-      const action = this.lock ? 'lockRecord' : 'unlockRecord'
+      const action = this.lock ? 'unlockRecord' : 'lockRecord'
       this.$store.dispatch(action, {
         tableName,
         recordId: this.record[tableName + '_ID'],
         recordUuid: this.record.UUID
       })
         .then(() => {
-          this.lock = !this.lock
           this.$message({
             type: 'success',
             message: this.$t('data.notification.' + action),
@@ -144,12 +143,21 @@ export default {
           })
         })
         .catch(() => {
-          this.lock = !this.lock
           this.$message({
             type: 'error',
             message: this.$t('data.isError') + this.$t('data.' + action),
             showClose: true
           })
+        })
+        .finally(() => {
+          this.$store.dispatch('getPrivateAccessFromServer', {
+            tableName,
+            recordId: this.record[tableName + '_ID'],
+            recordUuid: this.record.UUID
+          })
+            .then(privateAccessResponse => {
+              this.lock = privateAccessResponse.isLocked
+            })
         })
     },
     setCurrentTab() {

--- a/src/store/modules/ADempiere/data/actions.js
+++ b/src/store/modules/ADempiere/data/actions.js
@@ -765,18 +765,8 @@ const actions = {
       recordUuid
     })
       .then(privateAccessResponse => {
-        // TODO: Evaluate uuid record
-        if (!isEmptyValue(privateAccessResponse.tableName)) {
-          return {
-            isLocked: false,
-            tableName,
-            recordId,
-            recordUuid
-          }
-        }
         return {
-          ...privateAccessResponse,
-          isLocked: true
+          ...privateAccessResponse
         }
       })
       .catch(error => {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
Support to Private Access

#### Screenshot or Gif

![image](https://user-images.githubusercontent.com/45974454/118907870-54d67480-b8ee-11eb-8ad7-61d8da331546.png)

#### Other relevant information
- Your OS: Debian 9
- Web Browser: Chrome
- Node.js version: 10.9.2


#### Additional context
In the main tab you can see an icon of a padlock which can lock or unlock the current record. 
###Note
when the record is locked the tab title turns red

