### PR TITLE
Add documentation for developer mode of the Lock/Unlock Logs service

### DIFF
--- a/docs/es/guide/components/lock-unlock-records.md
+++ b/docs/es/guide/components/lock-unlock-records.md
@@ -35,3 +35,35 @@ En la versión de escritorio, se ubica la pestaña donde se encuentra el registr
 En la versión móvil, se ubica la pestaña donde se encuentra el registro y finalmente se selecciona el icono de candado ubicado del lado izquierdo del nombre de la pestaña. Para desbloquear el registro, se realiza el mismo procedimiento.
 
 <img :src="$withBase('/images/components/lock-unlock-records/how-to-use-it-in-the-mobile-version.gif')" />
+
+## Opciones para el Desarrollador
+
+El boton de **Bloquear/Desbloquear Registros** se encuentra en la siguiente ruta:
+
+```bash
+└── src                         # Código fuente principal
+    └── components              # Componentes globales
+        └── ADempiere           # Componentes específicos de ADempiere
+            └── Tab             # Directorio principal donde se encuentra el boton de Bloquear/Desbloquear Registros
+```
+
+Aquí puede ver un [Demo](https://demo-ui.erpya.com/#/7aa4242a-93c0-42d8-92be-8250002d3e3c/d97027fd-4cd5-445e-8fd8-ef5d3f7959b4/window/53418?tabParent=0&action=fa50908e-40f1-11e9-91a1-0242ac140002)
+
+El llamado al consumo de servicio de **Lock/Unlock Records** se encuentra en la siguiente ruta:
+
+```bash
+└─ src                                 # Código fuente principal
+    └─ api                             # Servicios globales
+      └─ ADempiere                     # Servicios específicos de ADempiere
+            └─ actions                 # Directorio principal de los servicio de las acciones de registro
+                └─ private-access      # Directorio principal de los servicio Bloquear/Desbloquear Registros
+```
+
+Los servicios llamados del componente son:
+
+[POST /api/user-interface/component/private-access/unlock-private-access](https://adempiere.github.io/proxy-adempiere-api/guide/es/default-modules/adempiere-api/user-interface.html#post-api-user-interface-component-private-access-unlock-private-access)
+
+[POST /api/user-interface/component/private-access/lock-private-access](https://adempiere.github.io/proxy-adempiere-api/guide/es/default-modules/adempiere-api/user-interface.html#post-api-user-interface-component-private-access-lock-private-access)
+
+[GET /api/user-interface/component/private-access/private-access](https://adempiere.github.io/proxy-adempiere-api/guide/es/default-modules/adempiere-api/user-interface.html#get-api-user-interface-component-private-access-private-access)
+

--- a/docs/guide/components/lock-unlock-records.md
+++ b/docs/guide/components/lock-unlock-records.md
@@ -35,3 +35,34 @@ In the desktop version, the tab where the registry is located is located and fin
 In the mobile version, the tab where the record is located is located and finally the lock icon located on the left side of the name of the tab is selected. To unlock the registry, the same procedure is performed.
 
 <img :src="$withBase('/images/components/lock-unlock-records/how-to-use-it-in-the-mobile-version.gif')" />
+
+## Developer Options
+
+The **Lock/Unlock Records** button is located in the following path:
+
+```bash
+└── src                     # main source code
+    └── components          # Global components.
+        └─── ADempiere      # ADempiere specific components.
+            └─── Tab        # Main directory where the Lock/Unlock Records button is located.
+```
+
+Here you can see a [Demo](https://demo-ui.erpya.com/#/7aa4242a-93c0-42d8-92be-8250002d3e3c/d97027fd-4cd5-445e-8fd8-ef5d3f7959b4/window/53418?tabParent=0&action=fa50908e-40f1-11e9-91a1-0242ac140002)
+
+The **Lock/Unlock Records** service consumption call is located in the following path:
+
+```bash
+└─ src                              # Main source code.
+    └─ api                          # Global services.
+      └─ ADempiere                  # ADempiere specific services.
+            └─ actions              # Main directory of registration actions services.
+                └─ private-access   # Main directory of the Lock/Unlock Logs service.
+```
+
+The called services of the component are:
+
+[POST /api/user-interface/component/private-access/unlock-private-access](https://adempiere.github.io/proxy-adempiere-api/guide/default-modules/adempiere-api/user-interface.html#post-api-user-interface-component-private-access-unlock-private-access)
+
+[POST /api/user-interface/component/private-access/lock-private-access](https://adempiere.github.io/proxy-adempiere-api/guide/default-modules/adempiere-api/user-interface.html#post-api-user-interface-component-private-access-lock-private-access)
+
+[GET /api/user-interface/component/private-access/private-access](https://adempiere.github.io/proxy-adempiere-api/guide/default-modules/adempiere-api/user-interface.html#get-api-user-interface-component-private-access-private-access)

--- a/docs/zh/guide/components/lock-unlock-records.md
+++ b/docs/zh/guide/components/lock-unlock-records.md
@@ -35,3 +35,33 @@
 在移動版本中，找到記錄所在的選項卡，最後選擇位於選項卡名稱左側的鎖定圖標。要解鎖註冊表，請執行相同的過程。
 
 <img :src="$withBase('/images/components/lock-unlock-records/how-to-use-it-in-the-mobile-version.gif')" />
+
+## 开发者选项
+
+锁定/解锁记录的**按钮位于以下路径中。
+
+```bash
+└── src                  # 主要数据来源
+    └── components       # 全局组件
+        └── ADempiere    # ADempiere的特殊组件
+            └── Tab      # 主目录，其中有 Bloquear/Desbloquear Registros 的按钮。
+```
+
+在这里你可以看到一个[演示](https://demo-ui.erpya.com/#/7aa4242a-93c0-42d8-92be-8250002d3e3c/d97027fd-4cd5-445e-8fd8-ef5d3f7959b4/window/53418?tabParent=0&action=fa50908e-40f1-11e9-91a1-0242ac140002)
+
+锁定/解锁记录**服务消费调用位于以下路径
+
+```bash
+└─ src                                  # 主要源代码。
+    └─ api                              # 全局服务。
+      └─ ADempiere                      # ADempiere特定服务。
+            └── actions                 # 注册动作服务的主目录。
+                └── private-access      # 锁定/解锁日志服务的主目录。
+```
+该组件的调用服务是。
+
+[POST /api/user-interface/component/private-access/unlock-private-access](https://adempiere.github.io/proxy-adempiere-api/guide/default-modules/adempiere-api/user-interface.html#post-api-user-interface-component-private-access-unlock-private-access)
+
+[POST /api/user-interface/component/private-access/lock-private-access](https://adempiere.github.io/proxy-adempiere-api/guide/default-modules/adempiere-api/user-interface.html#post-api-user-interface-component-private-access-lock-private-access)
+
+[GET /api/user-interface/component/private-access/private-access](https://adempiere.github.io/proxy-adempiere-api/guide/default-modules/adempiere-api/user-interface.html#get-api-user-interface-component-private-access-private-access)


### PR DESCRIPTION
##  Feature
Add documentation for developer mode of the Lock/Unlock Logs service
### Screenshot or Gif
#### Spanish Language Documentation
![image](https://user-images.githubusercontent.com/45974454/119555664-1caab800-bd6c-11eb-98d9-86b01752325c.png)
#### English Language Documentation
![image](https://user-images.githubusercontent.com/45974454/119555705-28967a00-bd6c-11eb-8558-e771f44040e4.png)
#### Chinese Language Documentation
![image](https://user-images.githubusercontent.com/45974454/119555752-34823c00-bd6c-11eb-97ba-a5f16ce7dffb.png)

#### Other relevant information
- Your OS: Debian 9
- Web Browser: Chrome
- Node.js version: 10.9.1