### PR TITLE
Add flag for support to beta functionality

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -20,5 +20,12 @@
     "api": {
       "url": "https://api.github.com/repos/adempiere/"
     }
+  },
+  "betaFunctionality": {
+    "window": false,
+    "process": false,
+    "report": false,
+    "smartBrowser": false,
+    "form": false
   }
 }


### PR DESCRIPTION
## Add beta functionality for current components
Just add some flags for determinate if a functionality is beta or it can be tested

This is the structure:

```JSON
"betaFunctionality": {
    "window": false,
    "process": false,
    "report": false,
    "smartBrowser": false,
    "form": false
  }
```