### PR TITLE
fix: Get lookup item

### DIFF
--- a/src/api/ADempiere/window.js
+++ b/src/api/ADempiere/window.js
@@ -16,7 +16,6 @@
 
 // Get Instance for connection
 import { request } from '@/utils/ADempiere/request'
-
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 
 /**
@@ -31,13 +30,17 @@ export function requestLookup({
   directQuery,
   value
 }) {
+  const filters = [{
+    value
+  }]
+
   return request({
     url: '/user-interface/window/lookup-item',
     method: 'get',
     params: {
       table_name: tableName,
       query: directQuery,
-      value
+      filters
     }
   })
     .then(respose => {

--- a/src/api/ADempiere/window.js
+++ b/src/api/ADempiere/window.js
@@ -31,17 +31,13 @@ export function requestLookup({
   directQuery,
   value
 }) {
-  const valuesList = []
-  if (!isEmptyValue(value)) {
-    valuesList.push(value)
-  }
   return request({
     url: '/user-interface/window/lookup-item',
     method: 'get',
     params: {
       table_name: tableName,
       query: directQuery,
-      values_list: valuesList
+      value
     }
   })
     .then(respose => {

--- a/src/api/ADempiere/window.js
+++ b/src/api/ADempiere/window.js
@@ -31,11 +31,9 @@ export function requestLookup({
   directQuery,
   value
 }) {
-  let filters = []
+  const valuesList = []
   if (!isEmptyValue(value)) {
-    filters = [{
-      value
-    }]
+    valuesList.push(value)
   }
   return request({
     url: '/user-interface/window/lookup-item',
@@ -43,7 +41,7 @@ export function requestLookup({
     params: {
       table_name: tableName,
       query: directQuery,
-      filters
+      values_list: valuesList
     }
   })
     .then(respose => {

--- a/src/components/ADempiere/Field/FieldSelect.vue
+++ b/src/components/ADempiere/Field/FieldSelect.vue
@@ -337,11 +337,14 @@ export default {
         value: this.value
       })
         .then(responseLookupItem => {
-          this.displayedValue = responseLookupItem.label
-          this.uuidValue = responseLookupItem.uuid
-          this.$nextTick(() => {
-            this.optionsList = this.getterLookupAll
-          })
+          // with value response update local component list
+          if (!this.isEmptyValue(responseLookupItem)) {
+            this.displayedValue = responseLookupItem.label
+            this.uuidValue = responseLookupItem.uuid
+            this.$nextTick(() => {
+              this.optionsList = this.getterLookupAll
+            })
+          }
         })
         .finally(() => {
           this.isLoading = false

--- a/src/store/modules/ADempiere/lookup.js
+++ b/src/store/modules/ADempiere/lookup.js
@@ -1,6 +1,22 @@
+// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import { requestLookup, requestLookupList } from '@/api/ADempiere/window.js'
 import { getToken as getSession } from '@/utils/auth'
-import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
+import { isEmptyValue, convertBooleanToString, typeValue } from '@/utils/ADempiere/valueUtils'
 import { parseContext } from '@/utils/ADempiere/contextUtils'
 
 const initStateLookup = {
@@ -54,9 +70,27 @@ const lookup = {
           isBooleanToString: true
         }).value
       }
+
+      // TODO: Remove this code, it should be fixed in  Proxy API and gRPC-API
       if (parsedDirectQuery.includes('?')) {
-        parsedDirectQuery = directQuery.replace('?', value)
+        let parsedValue = value
+        const type = typeValue(value)
+        // to date convert to timestamp or long value
+        if (type === 'DATE') {
+          parsedValue = value.getTime()
+        }
+        // to boolean convert to Y and N string value
+        if (type === 'BOOLEAN') {
+          parsedValue = convertBooleanToString(value)
+        }
+        // set doble quotes if is string value in query
+        if (typeValue(parsedValue) === 'STRING') {
+          parsedValue = `"${parsedValue}"`
+        }
+
+        parsedDirectQuery = parsedDirectQuery.replace('?', parsedValue)
       }
+
       return requestLookup({
         tableName,
         directQuery: parsedDirectQuery,

--- a/src/store/modules/ADempiere/lookup.js
+++ b/src/store/modules/ADempiere/lookup.js
@@ -16,7 +16,8 @@
 
 import { requestLookup, requestLookupList } from '@/api/ADempiere/window.js'
 import { getToken as getSession } from '@/utils/auth'
-import { isEmptyValue, convertBooleanToString, typeValue } from '@/utils/ADempiere/valueUtils'
+import { isEmptyValue, typeValue } from '@/utils/ADempiere/valueUtils.js'
+import { convertBooleanToString } from '@/utils/ADempiere/valueFormat.js'
 import { parseContext } from '@/utils/ADempiere/contextUtils'
 
 const initStateLookup = {

--- a/src/store/modules/ADempiere/lookup.js
+++ b/src/store/modules/ADempiere/lookup.js
@@ -86,7 +86,7 @@ const lookup = {
         }
         // set doble quotes if is string value in query
         if (typeValue(parsedValue) === 'STRING') {
-          parsedValue = `"${parsedValue}"`
+          parsedValue = `'${parsedValue}'`
         }
 
         parsedDirectQuery = parsedDirectQuery.replace('?', parsedValue)

--- a/src/store/modules/ADempiere/lookup.js
+++ b/src/store/modules/ADempiere/lookup.js
@@ -72,26 +72,6 @@ const lookup = {
         }).value
       }
 
-      // TODO: Remove this code, it should be fixed in  Proxy API and gRPC-API
-      if (parsedDirectQuery.includes('?')) {
-        let parsedValue = value
-        const type = typeValue(value)
-        // to date convert to timestamp or long value
-        if (type === 'DATE') {
-          parsedValue = value.getTime()
-        }
-        // to boolean convert to Y and N string value
-        if (type === 'BOOLEAN') {
-          parsedValue = convertBooleanToString(value)
-        }
-        // set doble quotes if is string value in query
-        if (typeValue(parsedValue) === 'STRING') {
-          parsedValue = `'${parsedValue}'`
-        }
-
-        parsedDirectQuery = parsedDirectQuery.replace('?', parsedValue)
-      }
-
       return requestLookup({
         tableName,
         directQuery: parsedDirectQuery,

--- a/src/store/modules/ADempiere/lookup.js
+++ b/src/store/modules/ADempiere/lookup.js
@@ -16,8 +16,7 @@
 
 import { requestLookup, requestLookupList } from '@/api/ADempiere/window.js'
 import { getToken as getSession } from '@/utils/auth'
-import { isEmptyValue, typeValue } from '@/utils/ADempiere/valueUtils.js'
-import { convertBooleanToString } from '@/utils/ADempiere/valueFormat.js'
+import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 import { parseContext } from '@/utils/ADempiere/contextUtils'
 
 const initStateLookup = {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open the Product Organization process.

#### Screenshot or Gif

Before this PR:
https://user-images.githubusercontent.com/20288327/120051353-496e0200-bfee-11eb-867c-31fe640a3a8a.mp4

After this PR:
https://user-images.githubusercontent.com/20288327/120051427-9c47b980-bfee-11eb-89ae-476c08e0115e.mp4



#### Expected behavior
Lookup fields are expected to get the heats with the lookup item request if they have a default value.
And if they don't get values they should not give error.

#### Other relevant information
* Your OS: Linux Mint 19.1 Cinnamon x64. 
* Browser: Mozilla Firefox 88.0.1.
* Node.js version: 12.20.0.
* adempiere-vue version: 4.3.1.

#### Additional context
Related to but not dependent on adempiere/gRPC-API#3
Related to but not dependent on https://github.com/adempiere/gRPC-API/pull/3
