### PR TITLE
fix: Date field range distorts field list.

### DIFF
--- a/src/components/ADempiere/Field/index.vue
+++ b/src/components/ADempiere/Field/index.vue
@@ -386,6 +386,13 @@ export default {
   }
 
   /**
+   * Maximum height to avoid distorting the field list
+   */
+  .el-form-item__content {
+    max-height: 36px !important;
+  }
+
+  /**
    * Reduce the spacing between the form element and its label
    */
   .el-form--label-top .el-form-item__label {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open report **Open Items**
2. Show all fields.

#### Screenshot or Gif
Before this PR:
![field-date-range](https://user-images.githubusercontent.com/20288327/120121190-0e93d780-c170-11eb-9d11-0fd7ced1f637.png)

After this PR:
![date-range-fix](https://user-images.githubusercontent.com/20288327/120121199-12bff500-c170-11eb-9f0e-0fb4fe0041e7.png)

#### Expected behavior
It is expected that the fields will not be distorted.

#### Other relevant information
* Your OS: Linux Mint 19.1 Cinnamon x64. 
* Browser: Mozilla Firefox 88.0.1.
* Node.js version: 12.20.0.
* adempiere-vue version: 4.3.1.

#### Additional context
closes https://github.com/adempiere/adempiere-vue/issues/5
