### PR TITLE
Fix translation in product information 

### DIFF
--- a/src/components/ADempiere/Form/VPOS/Order/line/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Order/line/index.vue
@@ -67,7 +67,7 @@
                   @click="checkclosePin(pin, field.columnName)"
                 />
               </span>
-              <el-button slojt="reference" type="text" disabled />
+              <el-button slot="reference" type="text" disabled />
             </el-popover>
             <field
               v-if="field.columnName === 'Discount'"

--- a/src/components/ADempiere/Form/VPOS/Order/orderLineMixin.js
+++ b/src/components/ADempiere/Form/VPOS/Order/orderLineMixin.js
@@ -50,6 +50,12 @@ export default {
           isNumeric: true,
           size: '110px'
         },
+        convertamount: {
+          columnName: 'GrandTotal',
+          label: this.$t('form.pos.collect.convertAmount'),
+          isNumeric: true,
+          size: '150px'
+        },
         grandTotal: {
           columnName: 'GrandTotal',
           label: 'Total',

--- a/src/lang/ADempiere/es.js
+++ b/src/lang/ADempiere/es.js
@@ -479,7 +479,7 @@ export default {
       price: 'Precio',
       taxAmount: 'Monto de Impuesto',
       grandTotal: 'Total General',
-      grandTotalConverted: 'Grand Total Convertido',
+      grandTotalConverted: 'Gran Total Convertido',
       quantityAvailable: 'Cantidad Disponible',
       upc: 'Código de Barras'
     }

--- a/src/lang/ADempiere/es.js
+++ b/src/lang/ADempiere/es.js
@@ -444,7 +444,7 @@ export default {
         pending: 'Pendiente',
         payment: 'Pago',
         change: 'Cambio',
-        convertAmount: 'Convertir Cantidad',
+        convertAmount: 'Convertir Monto',
         fullPayment: 'Cobro Completo',
         TenderType: {
           directDeposit: 'Depósito Directo',

--- a/src/lang/ADempiere/es.js
+++ b/src/lang/ADempiere/es.js
@@ -479,7 +479,7 @@ export default {
       price: 'Precio',
       taxAmount: 'Monto de Impuesto',
       grandTotal: 'Total General',
-      grandTotalConverted: 'Gran Total Convertido',
+      grandTotalConverted: 'Grand Total Convertido',
       quantityAvailable: 'Cantidad Disponible',
       upc: 'Código de Barras'
     }


### PR DESCRIPTION
## Bug report
there was a mistranslated word in the product information

#### Steps to reproduce

1. open the product information window
2. click on the product description to show all the information

#### Screenshot or Gif
![traduccion](https://user-images.githubusercontent.com/85173258/120488152-876b7d00-c384-11eb-9cbd-816300c62221.png)

#### Expected behavior
Instead of showing "grand total convertido" it shows "gran total convertido"