### PR TITLE
fix translation in product information

### DIFF
--- a/src/lang/ADempiere/es.js
+++ b/src/lang/ADempiere/es.js
@@ -479,7 +479,7 @@ export default {
       price: 'Precio',
       taxAmount: 'Monto de Impuesto',
       grandTotal: 'Total General',
-      grandTotalConverted: 'Grand Total Convertido',
+      grandTotalConverted: 'Gran Total Convertido',
       quantityAvailable: 'Cantidad Disponible',
       upc: 'Código de Barras'
     }


### PR DESCRIPTION
### Bug report

there was a mistranslated word in the product information

#### Steps to reproduce
1. open the product information window
2. click on the product description to show all the information

#### Screenshot or Gif
![traduccion](https://user-images.githubusercontent.com/85173258/120491204-08c40f00-c387-11eb-8e65-3d856ad9acaa.png)

#### Expected behavior
Instead of showing "grand total convertido" it shows "gran total convertido"