### PR TITLE
feat: Update adempiere proxy with redis config.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -71,6 +71,9 @@ services:
   vue-app:
     image: erpya/adempiere-vue
     container_name: adempiere-frontend
+    depends_on:
+      - api-rest
+      - grpc-backend
     stdin_open: true
     tty: true
     environment:
@@ -81,6 +84,9 @@ services:
   e-commerce:
     image: erpya/adempiere-ecommerce
     container_name: adempiere-ecommerce
+    depends_on:
+      - api-rest
+      - grpc-backend
     stdin_open: true
     tty: true
     environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -62,6 +62,9 @@ services:
       - VS_ENV=dev
       - INDEX=vue_storefront_catalog
       - RESTORE_DB=N
+      - REDIS_HOST=adempiere-redis
+      - REDIS_PORT=6379
+      - REDIS_DB=0
     ports:
       - 8085:8085
 
@@ -70,7 +73,7 @@ services:
     container_name: adempiere-frontend
     stdin_open: true
     tty: true
-    environment: 
+    environment:
       - API_URL=http://adempiere-proxy:8085
     ports:
       - 9526:80


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce
Updated the connection configuration of adempiere proxy to the redis container, implemented in the PR https://github.com/adempiere/proxy-adempiere-api-docker/pull/23 where the new environment variables are added `REDIS_HOST`, `REDIS_PORT` and `REDIS_DB`


For testing the adempiere vue stack, run the command `docker-compose up`.

#### Other relevant information
* Your OS: Linux Mint 19.1 Cinnamon x64. 
* Browser: Mozilla Firefox 88.0.1.
* Node.js version: 12.20.0.
* adempiere-vue version: 4.3.1.

#### Additional context
TODO: It is pending to add the configuration of the postgres container with an adempiere seed database.
