### PR TITLE
Feature/add column pos

### DIFF
--- a/src/components/ADempiere/Form/VPOS/Order/line/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Order/line/index.vue
@@ -31,6 +31,7 @@
               :ref="field.columnName"
               :metadata-field="{
                 ...field,
+                labelCurrency: currencyPointOfSales,
                 isReadOnly: !isModifyPrice
               }"
             />
@@ -156,8 +157,15 @@ export default {
     },
     validatePin() {
       return this.$store.state['pointOfSales/orderLine/index'].validatePin
+    },
+    currencyPointOfSales() {
+      if (!this.isEmptyValue(this.currentPointOfSales)) {
+        return this.currentPointOfSales.priceList.currency
+      }
+      return {}
     }
   },
+
   watch: {
     showField(value) {
       this.visible = false

--- a/src/components/ADempiere/Form/VPOS/Order/line/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Order/line/index.vue
@@ -158,7 +158,6 @@ export default {
       return this.$store.state['pointOfSales/orderLine/index'].validatePin
     }
   },
-
   watch: {
     showField(value) {
       this.visible = false

--- a/src/components/ADempiere/Form/VPOS/Order/line/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Order/line/index.vue
@@ -31,7 +31,6 @@
               :ref="field.columnName"
               :metadata-field="{
                 ...field,
-                labelCurrency: currencyPointOfSales,
                 isReadOnly: !isModifyPrice
               }"
             />
@@ -157,12 +156,6 @@ export default {
     },
     validatePin() {
       return this.$store.state['pointOfSales/orderLine/index'].validatePin
-    },
-    currencyPointOfSales() {
-      if (!this.isEmptyValue(this.currentPointOfSales)) {
-        return this.currentPointOfSales.priceList.currency
-      }
-      return {}
     }
   },
 

--- a/src/components/ADempiere/Form/VPOS/Order/orderLineMixin.js
+++ b/src/components/ADempiere/Form/VPOS/Order/orderLineMixin.js
@@ -86,9 +86,7 @@ export default {
   created() {
     const currentCurrency = this.$store.getters.posAttributes.listPointOfSales.find(pos =>
       pos.priceList.currency.uuid !== this.$store.getters.posAttributes.currentPointOfSales.priceList.currency.uuid)
-    // return console.log(currentCurrency.priceList.currency.uuid)
     this.totalAmountConverted(currentCurrency.priceList.currency)
-    // console.log(currentCurrency.priceList.currency.iSOCode)
   },
   methods: {
     formatPercent,
@@ -216,7 +214,6 @@ export default {
       return [year, month, day].join('-')
     },
     totalAmountConverted(value) {
-      // return console.log(value.uuid)
       this.$store.dispatch('conversionDivideRate', {
         conversionTypeUuid: this.currentPointOfSales.conversionTypeUuid,
         currencyFromUuid: this.pointOfSalesCurrency.uuid,

--- a/src/components/ADempiere/Form/VPOS/Order/orderLineMixin.js
+++ b/src/components/ADempiere/Form/VPOS/Order/orderLineMixin.js
@@ -85,7 +85,7 @@ export default {
   created() {
     const currentCurrency = this.$store.getters.posAttributes.listPointOfSales.find(pos =>
       pos.priceList.currency.uuid !== this.$store.getters.posAttributes.currentPointOfSales.priceList.currency.uuid)
-    this.totalAmountConverted(currentCurrency.priceList.currency)
+    this.convertedAmountAsTotal(currentCurrency.priceList.currency)
   },
   methods: {
     formatPercent,
@@ -200,23 +200,10 @@ export default {
           })
         })
     },
-    formatDate2(date) {
-      let month = '' + (date.getMonth() + 1)
-      let day = '' + date.getDate()
-      const year = date.getFullYear()
-      if (month.length < 2) {
-        month = '0' + month
-      }
-      if (day.length < 2) {
-        day = '0' + day
-      }
-      return [year, month, day].join('-')
-    },
-    totalAmountConverted(value) {
+    convertedAmountAsTotal(value) {
       this.$store.dispatch('conversionDivideRate', {
         conversionTypeUuid: this.currentPointOfSales.conversionTypeUuid,
         currencyFromUuid: this.pointOfSalesCurrency.uuid,
-        conversionDate: this.formatDate2(new Date()),
         currencyToUuid: value.uuid
       })
         .then(response => {

--- a/src/components/ADempiere/Form/VPOS/Order/orderLineMixin.js
+++ b/src/components/ADempiere/Form/VPOS/Order/orderLineMixin.js
@@ -20,7 +20,6 @@ import {
   requestDeleteOrderLine
 } from '@/api/ADempiere/form/point-of-sales.js'
 import { formatPercent } from '@/utils/ADempiere/valueFormat.js'
-import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 import { showMessage } from '@/utils/ADempiere/notification.js'
 
 export default {
@@ -221,7 +220,7 @@ export default {
         currencyToUuid: value.uuid
       })
         .then(response => {
-          if (!isEmptyValue(response.currencyTo)) {
+          if (!this.isEmptyValue(response.currencyTo)) {
             const currency = {
               ...response.currencyTo,
               amountConvertion: response.divideRate,

--- a/src/components/ADempiere/Form/VPOS/Order/orderLineMixin.js
+++ b/src/components/ADempiere/Form/VPOS/Order/orderLineMixin.js
@@ -86,7 +86,9 @@ export default {
   created() {
     const currentCurrency = this.$store.getters.posAttributes.listPointOfSales.find(pos =>
       pos.priceList.currency.uuid !== this.$store.getters.posAttributes.currentPointOfSales.priceList.currency.uuid)
-    this.totalAmountConverted(currentCurrency.priceList.currency.uuid)
+    // return console.log(currentCurrency.priceList.currency.uuid)
+    this.totalAmountConverted(currentCurrency.priceList.currency)
+    // console.log(currentCurrency.priceList.currency.iSOCode)
   },
   methods: {
     formatPercent,
@@ -214,11 +216,12 @@ export default {
       return [year, month, day].join('-')
     },
     totalAmountConverted(value) {
+      // return console.log(value.uuid)
       this.$store.dispatch('conversionDivideRate', {
         conversionTypeUuid: this.currentPointOfSales.conversionTypeUuid,
         currencyFromUuid: this.pointOfSalesCurrency.uuid,
         conversionDate: this.formatDate2(new Date()),
-        currencyToUuid: value
+        currencyToUuid: value.uuid
       })
         .then(response => {
           if (!isEmptyValue(response.currencyTo)) {
@@ -228,6 +231,9 @@ export default {
               multiplyRate: response.multiplyRate
             }
             this.totalAmountConvertedLine = currency
+          } else {
+            this.totalAmountConvertedLine.multiplyRate = '1'
+            this.totalAmountConvertedLine.iSOCode = value.iSOCode
           }
         })
         .catch(error => {
@@ -238,6 +244,12 @@ export default {
             showClose: true
           })
         })
+    },
+    getTotalAmount(basePrice, multiplyRate) {
+      if (this.isEmptyValue(basePrice) || this.isEmptyValue(multiplyRate)) {
+        return 0
+      }
+      return (basePrice * multiplyRate)
     },
     /**
      * Show the correct display format
@@ -259,8 +271,7 @@ export default {
       } else if (columnName === 'GrandTotal') {
         return this.formatPrice(row.grandTotal, currency)
       } else if (columnName === 'ConvertedAmount') {
-        var suma = row.grandTotal * this.totalAmountConvertedLine.multiplyRate
-        return this.formatPrice(suma, this.totalAmountConvertedLine.iSOCode)
+        return this.formatPrice(this.getTotalAmount(row.grandTotal, this.totalAmountConvertedLine.multiplyRate), this.totalAmountConvertedLine.iSOCode)
       }
     },
     productPrice(price, discount) {

--- a/src/lang/ADempiere/es.js
+++ b/src/lang/ADempiere/es.js
@@ -446,6 +446,7 @@ export default {
         payment: 'Pago',
         change: 'Cambio',
         convertAmount: 'Convertir Cantidad',
+        convertedAmount: 'Monto Convertido',
         fullPayment: 'Cobro Completo',
         dayRate: 'Tasa del Día',
         TenderType: {

--- a/src/store/modules/ADempiere/pointOfSales/payments/actions.js
+++ b/src/store/modules/ADempiere/pointOfSales/payments/actions.js
@@ -112,7 +112,7 @@ export default {
     payment.splice(0)
   },
   conversionDivideRate({ commit, dispatch }, params) {
-    requestGetConversionRate({
+    return requestGetConversionRate({
       conversionTypeUuid: params.conversionTypeUuid,
       currencyFromUuid: params.currencyFromUuid,
       currencyToUuid: params.currencyToUuid,
@@ -137,6 +137,7 @@ export default {
           commit('currencyMultiplyRate', multiplyRate)
           commit('currencyDivideRateCollection', divideRate)
         }
+        return response
       })
       .catch(error => {
         console.warn(`conversionDivideRate: ${error.message}. Code: ${error.code}.`)


### PR DESCRIPTION
## Feature
The column amount converted in the point of sale was added

#### Steps to reproduce

1. set the rates of the day
2. open point of sale.
2. select a product from the catalog to add to the order.

#### Screenshot or Gif
![feature-add-column-convertedAmount](https://user-images.githubusercontent.com/85173258/121044369-81f6a400-c783-11eb-9cdf-368371781bdb.gif)


#### Link to minimal reproduction
![feature-add-column-bss-usd](https://user-images.githubusercontent.com/85173258/121044658-9470dd80-c783-11eb-93b4-4dd7ede1b80b.gif)


#### Expected behavior
Automatically show in the column created the conversion of the price of each product as long as the rate of the day is loaded.