### PR TITLE
fix iSOcode pos

### DIFF
--- a/src/components/ADempiere/Form/VPOS/Order/line/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Order/line/index.vue
@@ -31,6 +31,7 @@
               :ref="field.columnName"
               :metadata-field="{
                 ...field,
+                labelCurrency: currencyPointOfSales,
                 isReadOnly: !isModifyPrice
               }"
             />
@@ -156,8 +157,15 @@ export default {
     },
     validatePin() {
       return this.$store.state['pointOfSales/orderLine/index'].validatePin
+    },
+    currencyPointOfSales() {
+      if (!this.isEmptyValue(this.currentPointOfSales)) {
+        return this.currentPointOfSales.priceList.currency
+      }
+      return {}
     }
   },
+
   watch: {
     showField(value) {
       this.visible = false


### PR DESCRIPTION
## Bug report
In the option of each line "edit quantities" the symbol opposite to the one selected at the point of sale is shown

#### Steps to reproduce

1. Open pos window
2. Select a product
3. Click on the line option "edit quantities"

#### Screenshot or Gif
![campo precio en opciones pos](https://user-images.githubusercontent.com/85173258/121050998-13b3e080-c787-11eb-8c45-bc8bc24514aa.png)


#### Expected behavior
Show the currency symbol corresponding to the selected one from the point of sale

![fix campo precio op pos](https://user-images.githubusercontent.com/85173258/121051076-25958380-c787-11eb-8fbf-6af0f541af4f.png)
