### PR TITLE
feat: Use intl to Number, Date and Time format.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "js-cookie": "2.2.1",
     "jsonlint": "1.6.3",
     "jszip": "3.5.0",
-    "moment": "^2.29.1",
     "normalize.css": "8.0.1",
     "nprogress": "0.2.0",
     "path-to-regexp": "6.2.0",

--- a/src/components/ADempiere/ContextMenu/contextMenuMixin.js
+++ b/src/components/ADempiere/ContextMenu/contextMenuMixin.js
@@ -16,7 +16,8 @@
 
 import { showNotification } from '@/utils/ADempiere/notification.js'
 import ItemsRelations from './itemsRelations'
-import { clientDateTime, convertFieldsListToShareLink, recursiveTreeSearch } from '@/utils/ADempiere/valueUtils.js'
+import { clientDateTime } from '@/utils/ADempiere/dateTimeFormat.js'
+import { convertFieldsListToShareLink, recursiveTreeSearch } from '@/utils/ADempiere/valueUtils.js'
 import { supportedTypes, exportFileFromJson } from '@/utils/ADempiere/exportUtil.js'
 import ROUTES from '@/utils/ADempiere/constants/zoomWindow'
 import relationsMixin from './relationsMixin.js'

--- a/src/components/ADempiere/DataTable/dataTables-Script.js
+++ b/src/components/ADempiere/DataTable/dataTables-Script.js
@@ -21,6 +21,7 @@ import TableContextMenu from '@/components/ADempiere/DataTable/menu/tableContext
 import TableMainMenu from '@/components/ADempiere/DataTable/menu'
 import IconElement from '@/components/ADempiere/IconElement'
 import { formatField } from '@/utils/ADempiere/valueFormat.js'
+import { formatQuantity } from '@/utils/ADempiere/numberFormat.js'
 import MainPanel from '@/components/ADempiere/Panel'
 import { sortFields } from '@/utils/ADempiere/dictionaryUtils'
 import { FIELDS_DECIMALS, FIELDS_QUANTITY, COLUMNS_READ_ONLY_FORM } from '@/utils/ADempiere/references'
@@ -699,7 +700,8 @@ export default {
             }
             return prev
           }, 0)
-          sums[index] = this.formatNumber({
+
+          sums[index] = formatQuantity({
             displayType,
             number: total
           })
@@ -707,14 +709,6 @@ export default {
       })
 
       return sums
-    },
-    formatNumber({ displayType, number }) {
-      let fixed = 0
-      // Amount, Costs+Prices, Number
-      if (FIELDS_DECIMALS.includes(displayType)) {
-        fixed = 2
-      }
-      return new Intl.NumberFormat().format(number.toFixed(fixed))
     },
     handleChangePage(newPage) {
       this.$store.dispatch('setPageNumber', {

--- a/src/components/ADempiere/DataTable/dataTables-Script.js
+++ b/src/components/ADempiere/DataTable/dataTables-Script.js
@@ -20,7 +20,7 @@ import FixedColumns from '@/components/ADempiere/DataTable/fixedColumns'
 import TableContextMenu from '@/components/ADempiere/DataTable/menu/tableContextMenu'
 import TableMainMenu from '@/components/ADempiere/DataTable/menu'
 import IconElement from '@/components/ADempiere/IconElement'
-import { formatField } from '@/utils/ADempiere/valueFormat'
+import { formatField } from '@/utils/ADempiere/valueFormat.js'
 import MainPanel from '@/components/ADempiere/Panel'
 import { sortFields } from '@/utils/ADempiere/dictionaryUtils'
 import { FIELDS_DECIMALS, FIELDS_QUANTITY, COLUMNS_READ_ONLY_FORM } from '@/utils/ADempiere/references'
@@ -368,51 +368,16 @@ export default {
      * @param {object} field, field with attributes
      */
     displayedValue(row, field) {
-      const { columnName, componentPath, displayColumnName, displayType } = field
+      const { columnName, displayColumnName, defaultValue, displayType } = field
+      const value = row[columnName]
+      const displayedValue = row[displayColumnName]
 
-      let valueToShow
-      switch (componentPath) {
-        case 'FieldDate':
-        case 'FieldTime': {
-          let cell = row[columnName]
-          if (this.typeValue(cell) === 'DATE') {
-            cell = cell.getTime()
-          }
-          // replace number timestamp value for date
-          valueToShow = formatField(cell, displayType)
-          break
-        }
-
-        case 'FieldNumber':
-          if (this.isEmptyValue(row[columnName])) {
-            valueToShow = undefined
-            break
-          }
-          valueToShow = this.formatNumber({
-            displayType,
-            number: row[columnName]
-          })
-          break
-
-        case 'FieldSelect':
-          valueToShow = row[displayColumnName]
-          if (this.isEmptyValue(valueToShow) && row[columnName] === 0) {
-            valueToShow = field.defaultValue
-            break
-          }
-          break
-
-        case 'FieldYesNo':
-          // replace boolean true-false value for 'Yes' or 'Not' ('Si' or 'No' for spanish)
-          valueToShow = row[columnName]
-            ? this.$t('components.switchActiveText')
-            : this.$t('components.switchInactiveText')
-          break
-
-        default:
-          valueToShow = row[columnName]
-          break
-      }
+      const valueToShow = formatField({
+        value,
+        defaultValue,
+        displayedValue,
+        displayType
+      })
 
       return valueToShow
     },

--- a/src/components/ADempiere/DataTable/menu/menuTableMixin.js
+++ b/src/components/ADempiere/DataTable/menu/menuTableMixin.js
@@ -15,7 +15,8 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { supportedTypes, exportFileFromJson, exportZipFile } from '@/utils/ADempiere/exportUtil.js'
-import { clientDateTime, recursiveTreeSearch } from '@/utils/ADempiere/valueUtils.js'
+import { recursiveTreeSearch } from '@/utils/ADempiere/valueUtils.js'
+import { clientDateTime } from '@/utils/ADempiere/dateTimeFormat.js'
 import { FIELDS_QUANTITY } from '@/utils/ADempiere/references'
 import TableMixin from '@/components/ADempiere/DataTable/mixin/tableMixin.js'
 

--- a/src/components/ADempiere/Field/FieldNumber.vue
+++ b/src/components/ADempiere/Field/FieldNumber.vue
@@ -62,6 +62,7 @@
 <script>
 import fieldMixin from '@/components/ADempiere/Field/mixin/mixinField.js'
 import { FIELDS_CURRENCY, FIELDS_DECIMALS } from '@/utils/ADempiere/references'
+import { formatPrice, formatQuantity } from '@/utils/ADempiere/numberFormat.js'
 
 export default {
   name: 'FieldNumber',
@@ -132,32 +133,18 @@ export default {
       if (this.isEmptyValue(value)) {
         value = 0
       }
-      if (!this.isDecimal) {
-        return value
-      }
 
-      let options = {
-        useGrouping: true,
-        minimumIntegerDigits: 1,
-        minimumFractionDigits: this.precision,
-        maximumFractionDigits: this.precision
-      }
-      let lang
       if (this.isCurrency) {
-        lang = this.countryLanguage
-        options = {
-          ...options,
-          style: 'currency',
-          currency: this.currencyCode
-        }
+        return formatPrice({
+          value,
+          currencyCode: this.currencyCode
+        })
       }
 
-      // TODO: Check the grouping of thousands
-      const formatterInstance = new Intl.NumberFormat(lang, options)
-      return formatterInstance.format(value)
-    },
-    countryLanguage() {
-      return this.$store.getters.getCountryLanguage
+      return formatQuantity({
+        value,
+        displayType: this.metadata.displayType
+      })
     },
     currencyCode() {
       if (!this.isEmptyValue(this.metadata.labelCurrency)) {

--- a/src/components/ADempiere/Form/BarcodeReader/index.vue
+++ b/src/components/ADempiere/Form/BarcodeReader/index.vue
@@ -56,7 +56,12 @@
               <div class="product-price-base">
                 Precio Base
                 <span class="amount">
-                  {{ formatPrice(productPrice.priceBase, productPrice.currency.iSOCode) }}
+                  {{
+                    formatPrice({
+                      value: productPrice.priceBase,
+                      currencyCode
+                    })
+                  }}
                 </span>
               </div>
               <br><br><br>
@@ -64,13 +69,23 @@
               <div class="product-tax">
                 {{ productPrice.taxName }}
                 <span class="amount">
-                  {{ formatPrice(productPrice.taxAmt, productPrice.currency.iSOCode) }}
+                  {{
+                    formatPrice({
+                      value: productPrice.taxAmt,
+                      currencyCode
+                    })
+                  }}
                 </span>
               </div>
               <br><br><br>
 
               <div class="product-price amount">
-                {{ formatPrice(productPrice.grandTotal, productPrice.currency.iSOCode) }}
+                {{
+                  formatPrice({
+                    vaue: productPrice.grandTotal,
+                    currencyCode
+                  })
+                }}
               </div>
             </el-col>
           </el-row>
@@ -92,7 +107,7 @@
 <script>
 import formMixin from '@/components/ADempiere/Form/formMixin.js'
 import fieldsList from './fieldsListBarCode.js'
-import { formatPercent, formatPrice } from '@/utils/ADempiere/valueFormat.js'
+import { formatPrice, getTaxAmount } from '@/utils/ADempiere/numberFormat.js'
 import { buildImageFromArrayBuffer } from '@/utils/ADempiere/resource.js'
 import { requestImage } from '@/api/ADempiere/common/resource.js'
 
@@ -130,6 +145,12 @@ export default {
     defaultImage() {
       return require('@/image/ADempiere/priceChecking/no-image.jpg')
     },
+    currencyCode() {
+      if (!this.isEmptyValue(this.productPrice)) {
+        return this.productPrice.currency.iSOCode
+      }
+      return 'USD'
+    },
     backgroundForm() {
       if (this.isEmptyValue(this.currentImageOfProduct)) {
         return this.organizationBackground
@@ -147,6 +168,8 @@ export default {
     this.unsubscribe()
   },
   methods: {
+    formatPrice,
+    getTaxAmount,
     async getImage(imageName = '') {
       let isSetOrg = false
       if (this.isEmptyValue(imageName)) {
@@ -178,8 +201,6 @@ export default {
     focusProductValue() {
       this.$refs.ProductValue[0].$children[0].$children[0].$children[1].$children[0].focus()
     },
-    formatPercent,
-    formatPrice,
     subscribeChanges() {
       return this.$store.subscribe((mutation, state) => {
         // if ((mutation.type === 'updateValueOfField' || mutation.type === 'addActionKeyPerformed') && mutation.payload.columnName === 'ProductValue') {
@@ -234,12 +255,6 @@ export default {
         //   }
         // }
       })
-    },
-    getTaxAmount(basePrice, taxRate) {
-      if (this.isEmptyValue(basePrice) || this.isEmptyValue(taxRate)) {
-        return 0
-      }
-      return (basePrice * taxRate) / 100
     },
     getGrandTotal(basePrice, taxRate) {
       if (this.isEmptyValue(basePrice)) {

--- a/src/components/ADempiere/Form/PriceChecking/index.vue
+++ b/src/components/ADempiere/Form/PriceChecking/index.vue
@@ -1,7 +1,7 @@
 <!--
  ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
  Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
- Contributor(s): Edwin Betancourt edwinBetanc0urt@hotmail.com www.erpya.com
+ Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
@@ -58,7 +58,12 @@
               <div class="product-price-base">
                 {{ $t('form.priceChecking.basePrice') }}
                 <span class="amount">
-                  {{ formatPrice(productPrice.priceBase, productPrice.currency.iSOCode) }}
+                  {{
+                    formatPrice({
+                      value: productPrice.priceBase,
+                      currencyCode: productPrice.currency.iSOCode
+                    })
+                  }}
                 </span>
               </div>
               <br><br><br>
@@ -66,14 +71,31 @@
               <div class="product-tax">
                 {{ productPrice.taxName }}
                 <span class="amount">
-                  {{ formatPrice(productPrice.taxAmt, productPrice.currency.iSOCode) }}
+                  {{
+                    formatPrice({
+                      value: productPrice.taxAmt,
+                      currencyCode: productPrice.currency.iSOCode
+                    })
+                  }}
                 </span>
               </div>
               <br><br><br>
 
               <div class="product-price amount">
-                <span style="float: right;"> {{ formatPrice(productPrice.grandTotal, productPrice.currency.iSOCode) }} </span> <br>
-                {{ formatPrice(productPrice.schemaGrandTotal, productPrice.schemaCurrency.iSOCode) }}
+                <span style="float: right;">
+                  {{
+                    formatPrice({
+                      value: productPrice.grandTotal,
+                      currencyCode: productPrice.currency.iSOCode
+                    })
+                  }}
+                </span> <br>
+                {{
+                  formatPrice({
+                    value: productPrice.schemaGrandTotal,
+                    currencyCode: productPrice.schemaCurrency.iSOCode
+                  })
+                }}
               </div>
             </el-col>
           </el-row>
@@ -105,7 +127,7 @@
 import formMixin from '@/components/ADempiere/Form/formMixin.js'
 import fieldsList from './fieldsList.js'
 import { getProductPrice } from '@/api/ADempiere/form/price-checking.js'
-import { formatPercent, formatPrice } from '@/utils/ADempiere/valueFormat.js'
+import { formatPrice, getTaxAmount } from '@/utils/ADempiere/numberFormat.js'
 import { getImagePath } from '@/utils/ADempiere/resource.js'
 
 export default {
@@ -120,7 +142,7 @@ export default {
       productPrice: {},
       organizationBackground: '',
       currentImageOfProduct: '',
-      search: 'sad',
+      search: '',
       resul: '',
       backgroundForm: '',
       unsubscribe: () => {}
@@ -149,6 +171,8 @@ export default {
     this.unsubscribe()
   },
   methods: {
+    getTaxAmount,
+    formatPrice,
     focusProductValue() {
       if (!this.isEmptyValue(this.$refs.ProductValue[0])) {
         this.$refs.ProductValue[0].$children[0].$children[0].$children[1].$children[0].focus()
@@ -165,8 +189,6 @@ export default {
       })
       this.backgroundForm = image.uri
     },
-    formatPercent,
-    formatPrice,
     subscribeChanges() {
       return this.$store.subscribe((mutation, state) => {
         if ((mutation.type === 'currentPointOfSales') || (mutation.type === 'setListProductPrice') || (mutation.type === 'addFocusLost')) {
@@ -291,12 +313,6 @@ export default {
       setTimeout(() => {
         this.messageError = true
       }, 2000)
-    },
-    getTaxAmount(basePrice, taxRate) {
-      if (this.isEmptyValue(basePrice) || this.isEmptyValue(taxRate)) {
-        return 0
-      }
-      return (basePrice * taxRate) / 100
     },
     getGrandTotal(basePrice, taxRate) {
       if (this.isEmptyValue(basePrice)) {

--- a/src/components/ADempiere/Form/ProductInfo/index.vue
+++ b/src/components/ADempiere/Form/ProductInfo/index.vue
@@ -30,10 +30,6 @@
 import ProductInfoList from './productList'
 import fieldMixin from '@/components/ADempiere/Field/mixin/mixinField.js'
 import staticReportRoutes from '@/utils/ADempiere/constants/zoomReport'
-import {
-  formatPrice,
-  formatQuantity
-} from '@/utils/ADempiere/valueFormat.js'
 
 export default {
   name: 'ProductInfo',
@@ -92,8 +88,6 @@ export default {
     // }
   },
   methods: {
-    formatPrice,
-    formatQuantity,
     shortcutKeyMethod(event) {
       switch (event.srcKey) {
         case 'refreshList':

--- a/src/components/ADempiere/Form/ProductInfo/productList.vue
+++ b/src/components/ADempiere/Form/ProductInfo/productList.vue
@@ -33,6 +33,7 @@
         :metadata-field="field"
       />
     </el-form>
+
     <el-table
       ref="singleTable"
       v-loading="!productPrice.isLoaded"
@@ -57,11 +58,43 @@
             <el-divider />
             <p><b style="float: left">{{ $t('form.productInfo.code') }}</b><span style="float: right">{{ scope.row.product.value }}</span></p><br>
             <p><b style="float: left">{{ $t('form.productInfo.upc') }}</b><span style="float: right"> {{ scope.row.product.upc }} </span></p><br>
-            <p><b style="float: left">{{ $t('form.productInfo.quantityOnHand') }}</b><span style="float: right"> {{ formatQuantity(scope.row.quantityOnHand) }} </span></p><br>
-            <p><b style="float: left">{{ $t('form.productInfo.price') }}</b><span style="float: right"> {{ formatPrice(scope.row.priceStandard, scope.row.currency.iSOCode) }} </span></p><br>
-            <p><b style="float: left">{{ $t('form.productInfo.taxAmount') }}</b><span style="float: right"> {{ formatPrice(getTaxAmount(scope.row.priceStandard, scope.row.taxRate.rate), scope.row.currency.iSOCode) }} </span></p><br>
-            <p><b style="float: left">{{ $t('form.productInfo.grandTotal') }}</b><span style="float: right"><b> {{ formatPrice(getTaxAmount(scope.row.priceStandard, scope.row.taxRate.rate) + scope.row.priceStandard, scope.row.currency.iSOCode) }} </b></span></p><br>
-            <p><b style="float: left">{{ $t('form.productInfo.grandTotalConverted') }} ({{ scope.row.schemaCurrency.iSOCode }}) </b><span style="float: right"><b> {{ formatPrice(getTaxAmount(scope.row.schemaPriceStandard, scope.row.taxRate.rate) + scope.row.schemaPriceStandard, scope.row.schemaCurrency.iSOCode) }} </b></span></p>
+            <p><b style="float: left">{{ $t('form.productInfo.quantityOnHand') }}</b><span style="float: right">
+              {{
+                formatQuantity({
+                  value: scope.row.quantityOnHand
+                })
+              }}
+            </span></p><br>
+            <p><b style="float: left">{{ $t('form.productInfo.price') }}</b><span style="float: right">
+              {{
+                formatPrice({
+                  value: scope.row.priceStandard,
+                  currencyCode: scope.row.currency.iSOCode
+                })
+              }}
+            </span></p><br>
+            <p><b style="float: left">{{ $t('form.productInfo.taxAmount') }}</b><span style="float: right">
+              {{
+                formatPrice({
+                  value: getTaxAmount(scope.row.priceStandard, scope.row.taxRate.rate),
+                  currencyCode: scope.row.currency.iSOCode
+                })
+              }}
+            </span></p><br>
+            <p><b style="float: left">{{ $t('form.productInfo.grandTotal') }}</b><span style="float: right"><b>
+              {{
+                formatPrice({
+                  value: getTaxAmount(scope.row.priceStandard, scope.row.taxRate.rate) + scope.row.priceStandard,
+                  currencyCode: scope.row.currency.iSOCode
+                })
+              }} </b></span></p><br>
+            <p><b style="float: left">{{ $t('form.productInfo.grandTotalConverted') }} ({{ scope.row.schemaCurrency.iSOCode }}) </b><span style="float: right"><b>
+              {{
+                formatPrice({
+                  value: getTaxAmount(scope.row.schemaPriceStandard, scope.row.taxRate.rate) + scope.row.schemaPriceStandard,
+                  currencyCode: scope.row.schemaCurrency.iSOCode
+                })
+              }} </b></span></p>
             <div slot="reference" class="name-wrapper">
               {{ scope.row.product.name }}
             </div>
@@ -74,7 +107,11 @@
         width="100"
       >
         <template slot-scope="scope">
-          {{ formatQuantity(scope.row.quantityOnHand) }}
+          {{
+            formatQuantity({
+              value: scope.row.quantityOnHand
+            })
+          }}
         </template>
       </el-table-column>
       <el-table-column
@@ -83,7 +120,11 @@
         width="100"
       >
         <template slot-scope="scope">
-          {{ formatQuantity(scope.row.quantityAvailable) }}
+          {{
+            formatQuantity({
+              value: scope.row.quantityAvailable
+            })
+          }}
         </template>
       </el-table-column>
       <el-table-column
@@ -91,7 +132,12 @@
         align="right"
       >
         <template slot-scope="scope">
-          {{ formatPrice(scope.row.priceStandard, scope.row.currency.iSOCode) }}
+          {{
+            formatPrice({
+              value: scope.row.priceStandard,
+              currencyCode: scope.row.currency.iSOCode
+            })
+          }}
         </template>
       </el-table-column>
       <el-table-column
@@ -100,7 +146,12 @@
         width="200"
       >
         <template slot-scope="scope">
-          {{ formatPrice(getTaxAmount(scope.row.priceStandard, scope.row.taxRate.rate), scope.row.currency.iSOCode) }}
+          {{
+            formatPrice({
+              value: getTaxAmount(scope.row.priceStandard, scope.row.taxRate.rate),
+              currencyCode: scope.row.currency.iSOCode
+            })
+          }}
         </template>
       </el-table-column>
       <el-table-column
@@ -109,7 +160,12 @@
         width="300"
       >
         <template slot-scope="scope">
-          {{ formatPrice(getTaxAmount(scope.row.priceStandard, scope.row.taxRate.rate) + scope.row.priceStandard, scope.row.currency.iSOCode) }}
+          {{
+            formatPrice({
+              value: getTaxAmount(scope.row.priceStandard, scope.row.taxRate.rate) + scope.row.priceStandard,
+              currencyCode: scope.row.currency.iSOCode
+            })
+          }}
         </template>
       </el-table-column>
       <el-table-column
@@ -147,7 +203,7 @@
 import formMixin from '@/components/ADempiere/Form/formMixin.js'
 import CustomPagination from '@/components/ADempiere/Pagination'
 import fieldsListProductPrice from './fieldsList.js'
-import { formatPrice, formatQuantity } from '@/utils/ADempiere/valueFormat.js'
+import { formatPrice, formatQuantity, getTaxAmount } from '@/utils/ADempiere/numberFormat.js'
 
 export default {
   name: 'ProductList',
@@ -281,6 +337,7 @@ export default {
   methods: {
     formatPrice,
     formatQuantity,
+    getTaxAmount,
     getImageFromSource(keyValue) {
       if (this.isEmptyValue(keyValue)) {
         return this.defaultImage
@@ -358,12 +415,6 @@ export default {
         attribute: this.popoverName,
         isShowed: false
       })
-    },
-    getTaxAmount(basePrice, taxRate) {
-      if (this.isEmptyValue(basePrice) || this.isEmptyValue(taxRate)) {
-        return 0
-      }
-      return (basePrice * taxRate) / 100
     },
     associatedprocesses(product, report) {
       report.parametersList.push({ columnName: 'M_Product_ID', value: product }, { columnName: 'M_PriceList_ID', value: this.listPrice })

--- a/src/components/ADempiere/Form/VPOS/Collection/convertAmount/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Collection/convertAmount/index.vue
@@ -21,7 +21,12 @@
       <span>
         <b>
           {{ $t('form.pos.collect.convertAmount') }}:
-          {{ formatPrice(amountConvertionTotal, displayCurrency) }}
+          {{
+            formatPrice({
+              value: amountConvertionTotal,
+              currencyCode: displayCurrency
+            })
+          }}
         </b>
       </span>
     </div>
@@ -47,7 +52,7 @@
 </template>
 <script>
 import formMixin from '@/components/ADempiere/Form/formMixin'
-import { formatPrice } from '@/utils/ADempiere/valueFormat.js'
+import { formatPrice } from '@/utils/ADempiere/numberFormat.js'
 import fieldsListConvertAmountCollection from './fieldsListConvertAmountCollection.js'
 
 export default {

--- a/src/components/ADempiere/Form/VPOS/Collection/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Collection/index.vue
@@ -36,7 +36,12 @@
                       :currency="pointOfSalesCurrency"
                     />
                     <el-button slot="reference" type="text" style="color: #000000;font-weight: 604!important;font-size: 100%;">
-                      {{ formatPrice(currentOrder.grandTotal, pointOfSalesCurrency.iSOCode) }}
+                      {{
+                        formatPrice({
+                          value: currentOrder.grandTotal,
+                          currencyCode: pointOfSalesCurrency.iSOCode
+                        })
+                      }}
                     </el-button>
                   </el-popover>
                 </b>
@@ -54,7 +59,12 @@
                       :currency="pointOfSalesCurrency"
                     />
                     <el-button slot="reference" type="text" style="color: #000000;font-weight: 604!important;font-size: 100%;">
-                      {{ formatPrice(pending, pointOfSalesCurrency.iSOCode) }}
+                      {{
+                        formatPrice({
+                          value: pending,
+                          currencyCode: pointOfSalesCurrency.iSOCode
+                        })
+                      }}
                     </el-button>
                   </el-popover>
                 </b>
@@ -64,9 +74,12 @@
                 <!-- Conversion rate to date -->
                 <b v-if="!isEmptyValue(dateRate)" style="float: right;">
                   <span v-if="!isEmptyValue(dateRate.divideRate)">
-                    <span v-if="formatConversionCurrenty(dateRate.divideRate) > 1">
+                    <span v-if="Number(formatExponential(dateRate.divideRate)) > 1">
                       {{
-                        formatPrice(formatConversionCurrenty(dateRate.divideRate), dateRate.currencyTo.iSOCode)
+                        formatPrice({
+                          value: formatExponential(dateRate.divideRate),
+                          currencyCode: dateRate.currencyTo.iSOCode
+                        })
                       }}
                     </span>
                     <span v-else>
@@ -74,13 +87,16 @@
                         dateRate.currencyTo.iSOCode
                       }}
                       {{
-                        formatConversionCurrenty(dateRate.divideRate)
+                        formatExponential(dateRate.divideRate)
                       }}
                     </span>
                   </span>
                   <span v-else>
                     {{
-                      formatPrice(1, dateRate.iSOCode)
+                      formatPrice({
+                        value: 1,
+                        currencyCode: dateRate.iSOCode
+                      })
                     }}
                   </span>
                 </b>
@@ -187,7 +203,12 @@
                         :currency="pointOfSalesCurrency"
                       />
                       <el-button slot="reference" type="text" style="color: #000000;font-weight: 604!important;font-size: 100%;">
-                        {{ formatPrice(currentOrder.grandTotal, pointOfSalesCurrency.iSOCode) }}
+                        {{
+                          formatPrice({
+                            value: currentOrder.grandTotal,
+                            currencyCode: pointOfSalesCurrency.iSOCode
+                          })
+                        }}
                       </el-button>
                     </el-popover>
                   </b>
@@ -206,7 +227,12 @@
                         :currency="pointOfSalesCurrency"
                       />
                       <el-button slot="reference" type="text" style="color: #000000;font-weight: 604!important;font-size: 100%;">
-                        {{ formatPrice(pending, pointOfSalesCurrency.iSOCode) }}
+                        {{
+                          formatPrice({
+                            value: pending,
+                            currencyCode: pointOfSalesCurrency.iSOCode
+                          })
+                        }}
                       </el-button>
                     </el-popover>
                   </b>
@@ -225,7 +251,12 @@
                         :currency="pointOfSalesCurrency"
                       />
                       <el-button slot="reference" type="text" style="color: #000000;font-weight: 604!important;font-size: 100%;">
-                        {{ formatPrice(pay, pointOfSalesCurrency.iSOCode) }}
+                        {{
+                          formatPrice({
+                            value: pay,
+                            currencyCode: pointOfSalesCurrency.iSOCode
+                          })
+                        }}
                       </el-button>
                     </el-popover>
                   </b>
@@ -243,7 +274,12 @@
                         :currency="pointOfSalesCurrency"
                       />
                       <el-button slot="reference" type="text" style="color: #000000;font-weight: 604!important;font-size: 100%;">
-                        {{ formatPrice(change, pointOfSalesCurrency.iSOCode) }}
+                        {{
+                          formatPrice({
+                            value: change,
+                            currencyCode: pointOfSalesCurrency.iSOCode
+                          })
+                        }}
                       </el-button>
                     </el-popover>
                   </b>
@@ -263,9 +299,8 @@ import posMixin from '@/components/ADempiere/Form/VPOS/posMixin.js'
 import fieldsListCollection from './fieldsListCollection.js'
 import typeCollection from '@/components/ADempiere/Form/VPOS/Collection/typeCollection'
 import convertAmount from '@/components/ADempiere/Form/VPOS/Collection/convertAmount/index'
-import { formatPrice } from '@/utils/ADempiere/valueFormat.js'
 import { processOrder } from '@/api/ADempiere/form/point-of-sales.js'
-import { FIELDS_DECIMALS } from '@/utils/ADempiere/references'
+import { formatExponential } from '@/utils/ADempiere/numberFormat.js'
 
 export default {
   name: 'Collection',
@@ -618,20 +653,12 @@ export default {
     this.defaultValueCurrency()
   },
   methods: {
-    formatNumber({ displayType, number }) {
-      let fixed = 0
-      // Amount, Costs+Prices, Number
-      if (FIELDS_DECIMALS.includes(displayType)) {
-        fixed = 2
-      }
-      return new Intl.NumberFormat().format(number.toFixed(fixed))
-    },
-    formatPrice,
+    formatExponential,
     sumCash(cash) {
       let sum = 0
       if (cash) {
         cash.forEach((pay) => {
-          if (!this.isEmptyValue(pay.divideRate)) {
+          if (!this.isEmptyValue(pay.divideRate) && pay.divideRate !== 0) {
             sum += pay.amountConvertion / pay.divideRate
           } else {
             sum += pay.amount

--- a/src/components/ADempiere/Form/VPOS/Collection/typeCollection.vue
+++ b/src/components/ADempiere/Form/VPOS/Collection/typeCollection.vue
@@ -69,16 +69,31 @@
                       >
                         <p class="total">
                           <b v-if="!isEmptyValue(value.multiplyRate)" style="float: right;">
-                            {{ formatPrice(value.multiplyRate, currency.iSOCode) }}
+                            {{
+                              formatPrice({
+                                value: value.multiplyRate,
+                                currencyCode: currency.iSOCode
+                              })
+                            }}
                           </b>
                           <b v-else style="float: right;">
-                            {{ formatPrice(value.amount, currency.iSOCode) }}
+                            {{
+                              formatPrice({
+                                value: value.amount,
+                                currencyCode: currency.iSOCode
+                              })
+                            }}
                           </b>
                         </p>
                         <br>
                         <p v-if="!isEmptyValue(value.currencyConvertion)" class="total">
                           <b style="float: right;">
-                            {{ formatPrice(value.amountConvertion, value.currencyConvertion.iSOCode) }}
+                            {{
+                              formatPrice({
+                                value: value.amountConvertion,
+                                currencyCode: value.currencyConvertion.iSOCode
+                              })
+                            }}
                           </b>
                         </p>
                       </div>
@@ -95,10 +110,6 @@
 </template>
 
 <script>
-import {
-  formatDate,
-  formatPrice
-} from '@/utils/ADempiere/valueFormat.js'
 import {
   requestGetConversionRate
 } from '@/api/ADempiere/form/point-of-sales.js'
@@ -177,8 +188,6 @@ export default {
     }
   },
   methods: {
-    formatDate,
-    formatPrice,
     // If there are payments in another currency, search for conversion
     convertingPaymentMethods() {
       if (!this.isEmptyValue(this.paymentCurrency)) {

--- a/src/components/ADempiere/Form/VPOS/KeyLayout/index.vue
+++ b/src/components/ADempiere/Form/VPOS/KeyLayout/index.vue
@@ -64,7 +64,12 @@
                 </div>
                 <div class="footer-product">
                   <p class="quantity">
-                    Cantidad: {{ formatQuantity(keyValue.quantity) }}
+                    Cantidad:
+                    {{
+                      formatQuantity({
+                        value: keyValue.quantity
+                      })
+                    }}
                   </p>
                   <br>
                 </div>
@@ -95,7 +100,8 @@
 
 <script>
 import { getImagePath } from '@/utils/ADempiere/resource.js'
-import { formatQuantity } from '@/utils/ADempiere/valueFormat.js'
+import { formatQuantity } from '@/utils/ADempiere/numberFormat.js'
+
 export default {
   name: 'KeyLayout',
   data() {

--- a/src/components/ADempiere/Form/VPOS/Order/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Order/index.vue
@@ -146,13 +146,27 @@
                         <el-col :span="5">
                           <div style="float: right">
                             {{ $t('form.productInfo.price') }}:
-                            <b>{{ formatPrice(scope.row.product.priceStandard, pointOfSalesCurrency.iSOCode) }}</b>
+                            <b>
+                              {{
+                                formatPrice({
+                                  value: scope.row.product.priceStandard,
+                                  currencyCode: pointOfSalesCurrency.iSOCode
+                                })
+                              }}
+                            </b>
                             <br>
                             {{ $t('form.productInfo.taxAmount') }}:
                             <b>{{ scope.row.taxIndicator }}</b>
                             <br>
+
                             {{ $t('form.productInfo.quantityAvailable') }}:
-                            <b>{{ formatQuantity(scope.row.quantityOrdered) }}</b>
+                            <b>
+                              {{
+                                formatQuantity({
+                                  value: scope.row.quantityOrdered
+                                })
+                              }}
+                            </b>
                           </div>
                         </el-col>
                       </el-row>
@@ -307,7 +321,12 @@
                       :is-open="seeConversion"
                     />
                     <el-button slot="reference" type="text" style="color: #000000;font-weight: 604!important;font-size: 100%;" @click="seeConversion = !seeConversion">
-                      {{ formatPrice(currentOrder.grandTotal, pointOfSalesCurrency.iSOCode) }}
+                      {{
+                        formatPrice({
+                          value: currentOrder.grandTotal,
+                          currencyCode: pointOfSalesCurrency.iSOCode
+                        })
+                      }}
                     </el-button>
                   </el-popover>
                 </b>
@@ -375,12 +394,7 @@ import BusinessPartner from '@/components/ADempiere/Form/VPOS/BusinessPartner'
 import fieldLine from '@/components/ADempiere/Form/VPOS/Order/line/index'
 import ProductInfo from '@/components/ADempiere/Form/VPOS/ProductInfo'
 import convertAmount from '@/components/ADempiere/Form/VPOS/Collection/convertAmount/index'
-// Format of values ( Date, Price, Quantity )
-import {
-  formatDate,
-  formatPrice,
-  formatQuantity
-} from '@/utils/ADempiere/valueFormat.js'
+import { formatDate } from '@/utils/ADempiere/dateTimeFormat.js'
 
 export default {
   name: 'Order',
@@ -595,8 +609,6 @@ export default {
   },
   methods: {
     formatDate,
-    formatPrice,
-    formatQuantity,
     closeConvertion() {
       this.seeConversion = false
     },

--- a/src/components/ADempiere/Form/VPOS/Order/orderLineMixin.js
+++ b/src/components/ADempiere/Form/VPOS/Order/orderLineMixin.js
@@ -19,8 +19,11 @@ import {
   updateOrderLine,
   deleteOrderLine
 } from '@/api/ADempiere/form/point-of-sales.js'
-import { formatPercent } from '@/utils/ADempiere/valueFormat.js'
-import { showMessage } from '@/utils/ADempiere/notification.js'
+import {
+  formatPrice,
+  formatPercent,
+  formatQuantity
+} from '@/utils/ADempiere/numberFormat.js'
 
 export default {
   name: 'OrderLineMixin',
@@ -88,7 +91,9 @@ export default {
     }
   },
   methods: {
+    formatPrice,
     formatPercent,
+    formatQuantity,
     changeLine(command) {
       switch (command.option) {
         case 'Eliminar':
@@ -221,7 +226,7 @@ export default {
         })
         .catch(error => {
           console.warn(`conversionDivideRate: ${error.message}. Code: ${error.code}.`)
-          showMessage({
+          this.message({
             type: 'error',
             message: error.message,
             showClose: true
@@ -244,17 +249,29 @@ export default {
       if (columnName === 'LineDescription') {
         return row.lineDescription
       }
-      const currency = this.pointOfSalesCurrency.iSOCode
+      const currencyCode = this.pointOfSalesCurrency.iSOCode
       if (columnName === 'CurrentPrice') {
-        return this.formatPrice(row.priceActual, currency)
+        return this.formatPrice({
+          value: row.priceActual,
+          currencyCode
+        })
       } else if (columnName === 'QtyOrdered') {
-        return this.formatQuantity(row.quantityOrdered)
+        return this.formatQuantity({
+          value: row.quantityOrdered
+        })
       } else if (columnName === 'Discount') {
         return this.formatPercent(row.discount / 100)
       } else if (columnName === 'GrandTotal') {
-        return this.formatPrice(row.grandTotal, currency)
+        return this.formatPrice({
+          value: row.grandTotal,
+          currencyCode
+        })
       } else if (columnName === 'ConvertedAmount') {
-        return this.formatPrice(this.getTotalAmount(row.grandTotal, this.totalAmountConvertedLine.multiplyRate), this.totalAmountConvertedLine.iSOCode)
+        const value = this.getTotalAmount(row.grandTotal, this.totalAmountConvertedLine.multiplyRate)
+        return this.formatPrice({
+          value,
+          currencyCode: this.totalAmountConvertedLine.iSOCode
+        })
       }
     },
     productPrice(price, discount) {

--- a/src/components/ADempiere/Form/VPOS/OrderList/index.vue
+++ b/src/components/ADempiere/Form/VPOS/OrderList/index.vue
@@ -112,7 +112,11 @@
         width="120"
       >
         <template slot-scope="scope">
-          {{ formatQuantity(scope.row.grandTotal) }}
+          {{
+            formatQuantity({
+              value: scope.row.grandTotal
+            })
+          }}
         </template>
       </el-table-column>
     </el-table>
@@ -131,10 +135,6 @@ import fieldsListOrders from './fieldsListOrders.js'
 import {
   createFieldFromDictionary
 } from '@/utils/ADempiere/lookupFactory'
-import {
-  formatDate,
-  formatQuantity
-} from '@/utils/ADempiere/valueFormat.js'
 import Field from '@/components/ADempiere/Field'
 import posMixin from '@/components/ADempiere/Form/VPOS/posMixin.js'
 
@@ -233,8 +233,6 @@ export default {
     this.unsubscribe()
   },
   methods: {
-    formatDate,
-    formatQuantity,
     createFieldFromDictionary,
     keyAction(event) {
       switch (event.srcKey) {

--- a/src/components/ADempiere/Form/VPOS/ProductInfo/index.vue
+++ b/src/components/ADempiere/Form/VPOS/ProductInfo/index.vue
@@ -67,9 +67,18 @@
             </div>
             <div style="width: 30%;float: right;">
               <p style="overflow: hidden;text-overflow: ellipsis;text-align: end;">
-                {{ formatPrice(props.item.priceStandard, props.item.currency.iSOCode) }}
+                {{
+                  formatPrice({
+                    value: props.item.priceStandard,
+                    currencyCode: props.item.currency.iSOCode
+                  })
+                }}
                 <br>
-                {{ formatQuantity(props.item.quantityAvailable) }}
+                {{
+                  formatQuantity({
+                    value: props.item.quantityAvailable
+                  })
+                }}
               </p>
             </div>
           </div>
@@ -88,7 +97,7 @@ import fieldMixin from '@/components/ADempiere/Field/mixin/mixinField.js'
 import {
   formatPrice,
   formatQuantity
-} from '@/utils/ADempiere/valueFormat.js'
+} from '@/utils/ADempiere/numberFormat.js'
 
 export default {
   name: 'FieldProductInfo',

--- a/src/components/ADempiere/Form/VPOS/ProductInfo/productList.vue
+++ b/src/components/ADempiere/Form/VPOS/ProductInfo/productList.vue
@@ -63,7 +63,11 @@
         align="right"
       >
         <template slot-scope="scope">
-          {{ formatPrice(scope.row.priceStandard) }}
+          {{
+            formatPrice({
+              value: scope.row.priceStandard
+            })
+          }}
         </template>
       </el-table-column>
     </el-table>
@@ -79,7 +83,7 @@
 import formMixin from '@/components/ADempiere/Form/formMixin.js'
 import CustomPagination from '@/components/ADempiere/Pagination'
 import fieldsListProductPrice from './fieldsList.js'
-import { formatPrice } from '@/utils/ADempiere/valueFormat.js'
+import { formatPrice } from '@/utils/ADempiere/numberFormat.js'
 
 export default {
   name: 'ProductList',

--- a/src/components/ADempiere/Form/VPOS/posMixin.js
+++ b/src/components/ADempiere/Form/VPOS/posMixin.js
@@ -18,11 +18,7 @@ import {
   findProduct,
   updateOrderLine
 } from '@/api/ADempiere/form/point-of-sales.js'
-import {
-  formatDate,
-  formatPrice,
-  formatQuantity
-} from '@/utils/ADempiere/valueFormat.js'
+import { formatDate } from '@/utils/ADempiere/dateTimeFormat.js'
 import orderLineMixin from './Order/orderLineMixin.js'
 
 export default {
@@ -181,8 +177,6 @@ export default {
   },
   methods: {
     formatDate,
-    formatPrice,
-    formatQuantity,
     withoutPOSTerminal() {
       if (this.isEmptyValue(this.currentPointOfSales)) {
         this.$message({
@@ -370,7 +364,10 @@ export default {
       // this.order = orderToPush
     },
     getOrderTax(currency) {
-      return this.formatPrice(this.currentOrder.grandTotal - this.currentOrder.totalLines, currency)
+      return this.formatPrice({
+        value: this.currentOrder.grandTotal - this.currentOrder.totalLines,
+        currencyCode: currency
+      })
     },
     subscribeChanges() {
       return this.$store.subscribe((mutation, state) => {

--- a/src/store/modules/ADempiere/system.js
+++ b/src/store/modules/ADempiere/system.js
@@ -1,9 +1,25 @@
+// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import {
   requestGetCountryDefinition,
   requestLanguagesList
 } from '@/api/ADempiere/system-core.js'
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
-import { convertDateFormat } from '@/utils/ADempiere/valueFormat'
+import { convertDateFormat } from '@/utils/ADempiere/dateTimeFormat.js'
 
 const system = {
   state: {
@@ -79,13 +95,18 @@ const system = {
     getCountry: (state) => {
       return state.country
     },
-    getCurrency: (state) => {
-      const { currencyIsoCode, standardPrecision } = state.systemDefinition
+    getCurrency: (state, getter) => {
+      const { currencyIsoCode } = state.systemDefinition
 
       return {
-        standardPrecision: standardPrecision || 2,
+        standardPrecision: getter.getStandardPrecision,
         iSOCode: currencyIsoCode || 'USD'
       }
+    },
+    getStandardPrecision: (state) => {
+      const { standardPrecision } = state.systemDefinition
+
+      return standardPrecision || 2
     },
     getCountryLanguage: (state) => {
       return state.systemDefinition.language.replace('_', '-')

--- a/src/utils/ADempiere/dateTimeFormat.js
+++ b/src/utils/ADempiere/dateTimeFormat.js
@@ -1,0 +1,138 @@
+// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import store from '@/store'
+import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
+import { zeroPad } from '@/utils/ADempiere/numberFormat.js'
+
+/**
+ * Convert all java date format to moment format. For know about java format
+ * pattern see:
+ * https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html
+ * Also you can read moment docus: https://momentjs.com/docs/
+ */
+export function convertDateFormat(dateFormat) {
+  return dateFormat
+    //	Year
+    .replace(/\byy\b/g, 'YY')
+    .replace(/\byyyy\b/g, 'YYYY')
+    //	Short Day of month
+    .replace(/\bdd\b/g, 'DD')
+    // Week of Year
+    .replace(/\bw\b/g, 'W')
+    // Long Day
+    .replace(/\bEEE\b/g, 'ddd')
+    .replace(/\bu\b/g, 'dddd')
+    // Hour
+    .replace(/\bhh\b/g, 'h')
+    .replace(/\bK\b/g, 'h')
+    .replace(/\baaa\b/g, 'a')
+    // Hour 24
+    .replace(/\bk\b/g, 'HH')
+    // Day of Year
+    .replace(/\bD\b/g, 'DDD')
+    // Day of Week
+    .replace(/\bF\b/g, 'R')
+    // Time zone
+    .replace(/\bz\b/g, 'Z')
+}
+
+/**
+ * Format a date with specific format, if format is void use default date format
+ * for language
+ * @param {mixed} value
+ * @param {string} fromat
+ */
+export function formatDate({
+  value,
+  format,
+  isTime
+}) {
+  format = getDateFormat({
+    isTime,
+    format
+  })
+
+  if (isEmptyValue(value)) {
+    // instance the objet Data with current date from client
+    value = new Date()
+  } else {
+    if (typeof value !== 'object') {
+      // instance the objet Data with date or time send
+      value = new Date(value)
+    }
+  }
+
+  return format
+}
+
+// Get default format or optional
+export function getDateFormat({
+  format,
+  isDate = true,
+  isTime = false
+}) {
+  if (!isEmptyValue(format)) {
+    return format
+  }
+
+  // system format
+  const languageDefinition = store.getters['getCurrentLanguageDefinition']
+  if (languageDefinition) {
+    return isTime ? languageDefinition.timePattern : languageDefinition.datePattern
+  }
+}
+
+/**
+ * Get date and time from client in a object value
+ * @param {string} type Type value of return
+ * @returns {object|string}
+ * @deprecated TODO: replace with formatDate
+ */
+export function clientDateTime(date = null, type = '') {
+  if (date == null || date === undefined || (typeof date === 'string' && date.trim() === '')) {
+    // instance the objet Data with current date from client
+    date = new Date()
+  } else {
+    // instance the objet Data with date or time send
+    date = new Date(date)
+  }
+
+  const currentDate = date.getFullYear() +
+    '-' + zeroPad(date.getMonth() + 1) +
+    '-' + zeroPad(date.getDate())
+
+  const currentTime = date.getHours() +
+    ':' + date.getMinutes() +
+    ':' + date.getSeconds()
+
+  const currentDateTime = {
+    date: currentDate,
+    time: currentTime
+  }
+
+  if (type.toLowerCase() === 't') {
+    // time format HH:II:SS
+    return currentDateTime.time
+  } else if (type.toLowerCase() === 'd') {
+    // date format YYYY-MM-DD
+    return currentDateTime.date
+  } else if (type.toLocaleLowerCase() === 'o') {
+    // object format
+    return currentDateTime
+  }
+  return currentDateTime.date + ' ' + currentDateTime.time
+}

--- a/src/utils/ADempiere/globalMethods.js
+++ b/src/utils/ADempiere/globalMethods.js
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 export {
-  zeroPad,
   tagStatus,
   iconStatus,
   isEmptyValue,
@@ -23,7 +22,8 @@ export {
   clearVariables,
   currencyFind,
   tenderTypeFind,
-  formatConversionCurrenty,
   convertValuesToSend,
   typeValue
 } from '@/utils/ADempiere/valueUtils.js'
+
+export { zeroPad } from '@/utils/ADempiere/numberFormat.js'

--- a/src/utils/ADempiere/numberFormat.js
+++ b/src/utils/ADempiere/numberFormat.js
@@ -1,0 +1,175 @@
+// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
+import { INTEGER } from '@/utils/ADempiere/references.js'
+import store from '@/store'
+
+/**
+ * Get Default currency ISO code
+ */
+export function getCurrency() {
+  return store.getters.getCurrency.iSOCode
+}
+
+export function getStandardPrecision() {
+  return store.getters.getStandardPrecision
+}
+
+/**
+ * Get country code from store
+ */
+export function getCountryCode() {
+  return store.getters.getCountryLanguage
+}
+
+/**
+ * Get formatted price and show currency
+ * @param {number} value
+ * @param {string} currencyCode
+ * @param {string} countryCode
+ * @param {number} precision
+ */
+export function formatPrice({
+  value,
+  currencyCode,
+  countryCode,
+  precision
+}) {
+  if (isEmptyValue(value)) {
+    value = 0
+  }
+
+  if (isEmptyValue(currencyCode)) {
+    currencyCode = getCurrency()
+  }
+
+  if (isEmptyValue(countryCode)) {
+    countryCode = getCountryCode()
+  }
+
+  if (isEmptyValue(precision)) {
+    precision = getStandardPrecision()
+  }
+
+  // get formatted currency number
+  return new Intl.NumberFormat(countryCode, {
+    style: 'currency',
+    currency: currencyCode,
+    useGrouping: true,
+    minimumIntegerDigits: 1,
+    minimumFractionDigits: precision,
+    maximumFractionDigits: precision
+  }).format(value)
+}
+
+export function getTaxAmount(basePrice, taxRate) {
+  if (isEmptyValue(basePrice) || isEmptyValue(taxRate)) {
+    return 0
+  }
+
+  return (basePrice * taxRate) / 100
+}
+
+/**
+ * Get formatted number, integer and decimal
+ * @param {number} value
+ * @param {number} precision
+ * @param {number} displayType
+ */
+export function formatQuantity({
+  value,
+  precision,
+  displayType
+}) {
+  if (isEmptyValue(value)) {
+    value = 0
+  }
+
+  if (displayType === INTEGER.id) {
+    // without decimals
+    precision = 0
+  }
+  // if (!Number.isInteger(value)) {
+  //   return value
+  // }
+
+  if (isEmptyValue(precision)) {
+    precision = getStandardPrecision()
+  }
+
+  // get formatted decimal number
+  return new Intl.NumberFormat(undefined, {
+    useGrouping: true, // thousands separator
+    minimumIntegerDigits: 1,
+    minimumFractionDigits: precision,
+    maximumFractionDigits: precision
+  }).format(value)
+}
+
+/**
+ * Format percentage based on Intl library
+ * @param {number} value
+ */
+export function formatPercent(value) {
+  if (isEmptyValue(value)) {
+    return undefined
+  }
+
+  // get formatted number
+  return new Intl.NumberFormat(getCountryCode(), {
+    style: 'percent'
+  }).format(value)
+}
+
+/**
+ * zero pad
+ * @author EdwinBetanc0urt <EdwinBetanc0urt@oulook.com>
+ * @param {number|string} number
+ * @param {number} pad
+ * @returns {string}
+ */
+export function zeroPad(number, pad = 2) {
+  const zero = Number(pad) - number.toString().length + 1
+  return Array(+(zero > 0 && zero)).join('0') + number
+}
+
+/**
+ * Convert exponetial to decimals quantity
+ * @param {number} value ej: 314e-2, 4e+3
+ * @returns ej: 3.14, 400
+ */
+export function formatExponential(value) {
+  const regExpr = /(\d{1,})(e-)/g // number end e-
+  const strValue = value.toString()
+
+  if (regExpr.test(strValue)) {
+    let exponential = strValue.replace(regExpr, '')
+
+    if (isEmptyValue(exponential) || exponential <= 0) {
+      exponential = getStandardPrecision()
+    }
+
+    // return formatQuantity({
+    //   value,
+    //   precision: exponential
+    // })
+    return Number.parseFloat(value)
+      .toFixed(exponential)
+  }
+
+  return value
+}

--- a/src/utils/ADempiere/valueFormat.js
+++ b/src/utils/ADempiere/valueFormat.js
@@ -15,12 +15,20 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 // A util class for handle format for time, date and others values to beused to display information
-// Note that this file use moment library for a easy conversion
-import moment from 'moment'
+
 import language from '@/lang'
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
-import store from '@/store'
-import { DATE, DATE_PLUS_TIME, TIME, AMOUNT, COSTS_PLUS_PRICES, NUMBER, QUANTITY } from '@/utils/ADempiere/references.js'
+import {
+  DATE, DATE_PLUS_TIME, TIME,
+  // currencies
+  AMOUNT, COSTS_PLUS_PRICES,
+  //
+  NUMBER, QUANTITY, INTEGER,
+  isLookup,
+  YES_NO
+} from '@/utils/ADempiere/references.js'
+import { formatPrice, formatQuantity } from '@/utils/ADempiere/numberFormat.js'
+import { getDateFormat } from '@/utils/ADempiere/dateTimeFormat.js'
 
 /**
  * Convert string values ('Y' or 'N') to component compatible Boolean values
@@ -28,9 +36,9 @@ import { DATE, DATE_PLUS_TIME, TIME, AMOUNT, COSTS_PLUS_PRICES, NUMBER, QUANTITY
  */
 export const convertStringToBoolean = (valueToParsed) => {
   const valueString = String(valueToParsed).trim()
-  if (valueString === 'N' || valueString === 'false') {
+  if (['N', 'false'].includes(valueString)) {
     return false
-  } else if (valueString === 'Y' || valueString === 'true') {
+  } else if (['Y', 'true'].includes(valueString)) {
     return true
   }
 
@@ -114,167 +122,79 @@ export function convertObjectToHasMap({ object }) {
  */
 export function convertHasMapToObject({ map }) {
   return Object.fromEntries(map)
-  // const result = {}
-  // map.forEach((value, key) => {
-  //   result[key] = value
-  // })
-  // return result
 }
 
-// This function just convert all java date format to moment format.
-// For know about java format pattern see: https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html
-// Also you can read moment docus: https://momentjs.com/docs/
-export function convertDateFormat(dateFormat) {
-  return dateFormat
-    //	Year
-    .replace(/\byy\b/g, 'YY')
-    .replace(/\byyyy\b/g, 'YYYY')
-    //	Short Day of month
-    .replace(/\bdd\b/g, 'DD')
-    // Week of Year
-    .replace(/\bw\b/g, 'W')
-    // Long Day
-    .replace(/\bEEE\b/g, 'ddd')
-    .replace(/\bu\b/g, 'dddd')
-    // Hour
-    .replace(/\bhh\b/g, 'h')
-    .replace(/\bK\b/g, 'h')
-    .replace(/\baaa\b/g, 'a')
-    // Hour 24
-    .replace(/\bk\b/g, 'HH')
-    // Day of Year
-    .replace(/\bD\b/g, 'DDD')
-    // Day of Week
-    .replace(/\bF\b/g, 'R')
-    // Time zone
-    .replace(/\bz\b/g, 'Z')
-}
-
-// Format a date with specific format, if format is void use default date format for language
-export function formatDate(date, isTime = false) {
-  if (isEmptyValue(date)) {
-    return undefined
-  }
-  //  Format
-  return moment.utc(date).format(getDateFormat({
-    isTime
-  }))
-}
-
-//  Get Formatted Price
-export function formatPrice(number, currency) {
-  if (this.isEmptyValue(number)) {
-    return undefined
-  }
-  if (this.isEmptyValue(currency)) {
-    currency = getCurrency()
-  }
-  //  Get formatted number
-  return new Intl.NumberFormat(getCountryCode(), {
-    style: 'currency',
-    currency
-  }).format(number)
-}
-
-//  Format Quantity
-export function formatQuantity(number) {
-  if (this.isEmptyValue(number)) {
-    return undefined
-  }
-  if (!Number.isInteger(number)) {
-    return number
-  }
-  return Number.parseFloat(number).toFixed(2)
-  //  Get formatted number
-}
-
-// Format percentage based on Intl library
-export function formatPercent(number) {
-  if (this.isEmptyValue(number)) {
-    return undefined
-  }
-  //  Get formatted number
-  return new Intl.NumberFormat(getCountryCode(), {
-    style: 'percent'
-  }).format(number)
-}
-
-//  Get country code from store
-function getCountryCode() {
-  const languageDefinition = store.getters.getCurrentLanguageDefinition
-  return languageDefinition.languageISO + '-' + languageDefinition.countryCode
-}
-
-// Get Default country
-function getCurrency() {
-  const currencyDefinition = store.getters.getCurrency
-  return currencyDefinition.iSOCode
-}
-
-// Return a format for field depending of reference for him
-export function formatField(value, reference, optionalFormat) {
-  if (isEmptyValue(value)) {
-    return undefined
-  }
-  if (!reference) {
-    return value
-  }
-  //  Format
+/**
+ * Return a format for field depending of reference for him
+ */
+export function formatField({
+  value,
+  displayedValue,
+  defaultValue,
+  displayType,
+  optionalFormat
+}) {
   let formattedValue
-  switch (reference) {
+
+  //  format
+  switch (displayType) {
+    case (isLookup(displayType) && displayType):
+      if (isEmptyValue(displayedValue) && value === 0) {
+        // TODO: Verify parsedDefaultValue with getDefaultValue
+        formattedValue = defaultValue
+        break
+      }
+      formattedValue = displayedValue
+      break
+
     case DATE.id:
-      formattedValue = moment.utc(value).format(getDateFormat({
-        format: optionalFormat
-      }))
+      formattedValue = getDateFormat({
+        isDate: true,
+        isTime: false
+      })
       break
+
     case DATE_PLUS_TIME.id:
-      formattedValue = moment.utc(value).format(getDateFormat({
+      formattedValue = getDateFormat({
+        isDate: true,
         isTime: true
-      }))
+      })
       break
+
     case TIME.id:
-      formattedValue = moment.utc(value).format(getDateFormat({
+      formattedValue = getDateFormat({
+        isDate: false,
         isTime: true
-      }))
+      })
       break
+
     case AMOUNT.id:
-      formattedValue = formatPrice(value)
-      break
     case COSTS_PLUS_PRICES.id:
-      formattedValue = formatPrice(value)
+      formattedValue = formatPrice({
+        value
+      })
       break
+
     case NUMBER.id:
-      formattedValue = formatQuantity(value)
-      break
     case QUANTITY.id:
-      formattedValue = formatQuantity(value)
+    case INTEGER.id:
+      formattedValue = formatQuantity({
+        value,
+        displayType
+      })
       break
+
+    case YES_NO.id:
+      formattedValue = convertBooleanToTranslationLang(value)
+      break
+
+    // without format (String value)
     default:
       formattedValue = value
+      break
   }
+
   return formattedValue
-}
-
-// Get default format without format pattern
-export function getDefaultFormat(isTime) {
-  return getDateFormat({
-    isTime
-  })
-}
-
-// Get default format or optional
-function getDateFormat({
-  format,
-  isTime
-}) {
-  if (format) {
-    return format
-  }
-  //  Else
-  const languageDefinition = store.getters['getCurrentLanguageDefinition']
-  if (languageDefinition) {
-    return isTime ? languageDefinition.timePattern : languageDefinition.datePattern
-  }
 }
 
 /**
@@ -285,17 +205,19 @@ function getDateFormat({
  * @returns {string} ej: 'qwerty asd' | 'zxc 123'
  */
 export function trimPercentage(stringToParsed) {
-  if (!isEmptyValue(stringToParsed) && String(stringToParsed).includes('%')) {
-    let parsedValue = stringToParsed
-    if (parsedValue[0] === '%') {
-      parsedValue = parsedValue.slice(1)
-    }
-
-    const wordSize = parsedValue.length - 1
-    if (parsedValue[wordSize] === '%') {
-      parsedValue = parsedValue.slice(0, wordSize)
-    }
-    return parsedValue
+  if (isEmptyValue(stringToParsed) || !String(stringToParsed).includes('%')) {
+    return stringToParsed
   }
-  return stringToParsed
+
+  let parsedValue = stringToParsed
+  if (parsedValue[0] === '%') {
+    parsedValue = parsedValue.slice(1)
+  }
+
+  const wordSize = parsedValue.length - 1
+  if (parsedValue[wordSize] === '%') {
+    parsedValue = parsedValue.slice(0, wordSize)
+  }
+
+  return parsedValue
 }

--- a/src/utils/ADempiere/valueUtils.js
+++ b/src/utils/ADempiere/valueUtils.js
@@ -114,58 +114,6 @@ export function extractPagingToken(token) {
   return onlyToken
 }
 
-/**
- * zero pad
- * @author EdwinBetanc0urt <EdwinBetanc0urt@oulook.com>
- * @param {number|string} number
- * @param {number} pad
- * @returns {string}
- */
-export function zeroPad(number, pad = 2) {
-  const zero = Number(pad) - number.toString().length + 1
-  return Array(+(zero > 0 && zero)).join('0') + number
-}
-
-/**
- * Get date and time from client in a object value
- * @param {string} type Type value of return
- * @returns {object|string}
- */
-export function clientDateTime(date = null, type = '') {
-  if (date == null || date === undefined || (typeof date === 'string' && date.trim() === '')) {
-    // instance the objet Data with current date from client
-    date = new Date()
-  } else {
-    // instance the objet Data with date or time send
-    date = new Date(date)
-  }
-
-  const currentDate = date.getFullYear() +
-    '-' + zeroPad(date.getMonth() + 1) +
-    '-' + zeroPad(date.getDate())
-
-  const currentTime = date.getHours() +
-    ':' + date.getMinutes() +
-    ':' + date.getSeconds()
-
-  const currentDateTime = {
-    date: currentDate,
-    time: currentTime
-  }
-
-  if (type.toLowerCase() === 't') {
-    // time format HH:II:SS
-    return currentDateTime.time
-  } else if (type.toLowerCase() === 'd') {
-    // date format YYYY-MM-DD
-    return currentDateTime.date
-  } else if (type.toLocaleLowerCase() === 'o') {
-    // object format
-    return currentDateTime
-  }
-  return currentDateTime.date + ' ' + currentDateTime.time
-}
-
 export function convertFieldsListToShareLink(fieldsList) {
   let attributesListLink = ''
   fieldsList.map(fieldItem => {
@@ -498,6 +446,7 @@ export function calculationValue(value, event) {
     }
   }
 }
+
 /**
  * Search in the currency lists for the current currency
  * @author Elsio Sanchez <elsiosanches@gmail.com>
@@ -522,13 +471,13 @@ export function currencyFind({
   }
   return defaultCurrency.iSOCode
 }
+
 /**
  * Search the Payment List for the Current Payment
  * @author Elsio Sanchez <elsiosanches@gmail.com>
  * @param {string} currentPayment Current Payment
  * @param {array} listTypePayment Payment Type Listings
  */
-
 export function tenderTypeFind({
   currentPayment,
   listTypePayment
@@ -543,21 +492,11 @@ export function tenderTypeFind({
   }
   return currentPayment
 }
+
 export function clearVariables() {
   partialValue = ''
 }
-export function formatConversionCurrenty(params) {
-  let exponential, expre
-  const number = params.toString()
-  if (params > 0) {
-    if (number.includes('e')) {
-      expre = number.split('-')
-      exponential = params.toFixed(expre[1])
-      return exponential
-    }
-  }
-  return params
-}
+
 /**
  * convert Values To Send
  * @param {string, number, boolean, date} values


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
Eliminate duplicate methods and functions for number and date formatting.

Creating a generic method for formatting quantities (integers or decimals) as `formatQuantity`, prices as `formatPrice`, and numbers expressed in exponential form (e.g. 5e-3 = 0.05) as `formatExponential`, using Intl.NumberFormat(), and placing all the number functions of the utilities in the file `src/utils/ADempiere/numberFormat.js`.


#### Steps to reproduce
Display numerical values in the: 
- Data tables.
- Forms (POS, BarcodeReader, PriceChecking, ProductInfo).
- FieldNumber component.

#### Screenshot or Gif



#### Other relevant information
* Your OS: Linux Mint 19.1 Cinnamon x64. 
* Browser: Mozilla Firefox 88.0.1.
* Node.js version: 14.17.0.
* NPM version: 7.17.0.
* adempiere-vue version: 4.3.1.

#### Additional context
The `moment.js` library is removed due to the status of the https://momentjs.com/docs/#/-project-status/ project where some references are cited that discourage its use such as:

> Moment was built for the previous era of the JavaScript ecosystem.

> As an example, consider that Moment objects are mutable. See: https://momentjs.com/guides/#/lib-concepts/mutability/

> Another common argument against using Moment in modern applications is its size. Moment doesn't work well with modern "tree shaking" algorithms, so it tends to increase the size of web application bundles.

> Recently, Chrome Dev Tools started showing recommendations for replacing Moment for the size alone. We generally support this move. See https://twitter.com/addyosmani/status/1304676118822174721

<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
Eliminate duplicate methods and functions for number and date formatting.

Creating a generic method for formatting quantities (integers or decimals) as `formatQuantity`, prices as `formatPrice`, and numbers expressed in exponential form (e.g. 5e-3 = 0.05) as `formatExponential`, using Intl.NumberFormat(), and placing all the number functions of the utilities in the file `src/utils/ADempiere/numberFormat.js`.


#### Steps to reproduce
Display numerical values in the: 
- Data tables.
- Forms (POS, BarcodeReader, PriceChecking, ProductInfo).
- FieldNumber component.

#### Screenshot or Gif



#### Other relevant information
* Your OS: Linux Mint 19.1 Cinnamon x64. 
* Browser: Mozilla Firefox 88.0.1.
* Node.js version: 14.17.0.
* NPM version: 7.17.0.
* adempiere-vue version: 4.3.1.

#### Additional context
The `moment.js` library is removed due to the status of the https://momentjs.com/docs/#/-project-status/ project where some references are cited that discourage its use such as:

> Moment was built for the previous era of the JavaScript ecosystem.

> As an example, consider that Moment objects are mutable. See: https://momentjs.com/guides/#/lib-concepts/mutability/

> Another common argument against using Moment in modern applications is its size. Moment doesn't work well with modern "tree shaking" algorithms, so it tends to increase the size of web application bundles.

> Recently, Chrome Dev Tools started showing recommendations for replacing Moment for the size alone. We generally support this move. See https://twitter.com/addyosmani/status/1304676118822174721

In practice, this means:
- We will not be adding new features or capabilities.
- We will not be changing Moment's API to be immutable.
- We will not be addressing tree shaking or bundle size issues.
- We will not be making any major changes (no version 3).
- We may choose to not fix bugs or behavioral quirks, especially if they are long-standing known issues.

closes https://github.com/adempiere/adempiere-vue/issues/7, closes https://github.com/adempiere/adempiere-vue/issues/6, closes https://github.com/adempiere/adempiere-vue/issues/10, closes https://github.com/adempiere/adempiere-vue/issues/17, closes https://github.com/adempiere/adempiere-vue/issues/63