### PR TITLE
Add support to dashboard as chart

### DIFF
--- a/src/api/ADempiere/dashboard/dashboard.js
+++ b/src/api/ADempiere/dashboard/dashboard.js
@@ -41,8 +41,8 @@ export function requestLisDashboards({
 
       return {
         recordCount: dashboardsListResponse.record_count,
-        dashboardsList: dashboardsListResponse.records.map(favorite => {
-          return convertDashboard(favorite)
+        dashboardsList: dashboardsListResponse.records.map(dashboard => {
+          return convertDashboard(dashboard)
         }),
         nextPageToken: dashboardsListResponse.next_page_token
       }

--- a/src/components/ADempiere/Dashboard/index.vue
+++ b/src/components/ADempiere/Dashboard/index.vue
@@ -22,7 +22,7 @@
     accordion
   >
     <el-collapse-item
-      :name="dashboard.dashboardName"
+      :name="dashboard.name"
       :disabled="!dashboard.isCollapsible"
       class="custom-collapse-item"
     >
@@ -33,7 +33,7 @@
       </template>
       <component
         :is="renderDashboard"
-        :ref="dashboard.dashboardName"
+        :ref="dashboard.name"
         :metadata="dashboard"
       />
     </el-collapse-item>
@@ -53,7 +53,7 @@ export default {
     return {
       dashboard: this.metadata,
       unsupportedDashboards: ['activities', 'views', 'performance'],
-      activeDashboard: this.metadata.isOpenByDefault ? this.metadata.dashboardName : undefined
+      activeDashboard: this.metadata.isOpenByDefault ? this.metadata.name : undefined
     }
   },
   computed: {

--- a/tests/unit/utils/ADempiere/apiConverts/objects/converted/dashboard.json
+++ b/tests/unit/utils/ADempiere/apiConverts/objects/converted/dashboard.json
@@ -1,13 +1,15 @@
 {
   "windowUuid": "953269ba-a67b-11eb-bcbc-0242ac130002",
   "browserUuid": "95326a6e-a67b-11eb-bcbc-0242ac130002",
-  "dashboardName": "dashboard name",
-  "dashboardDescription": "dashboard description",
-  "dashboardHtml": "dashboard html",
+  "name": "dashboard name",
+  "description": "dashboard description",
+  "html": "dashboard html",
   "columnNo": 0,
   "lineNo": 1,
   "isCollapsible": true,
   "isOpenByDefault": true,
   "isEventRequired": false,
-  "fileName": "dashboard file name"
+  "fileName": "dashboard file name",
+  "dashboardType": "dashboard",
+  "chartType": ""
 }


### PR DESCRIPTION
Just add changes from proxy struct based on dashboard service:

Changes:

- dashboard_name changed by name
- dashboard_description changed by description
- dashboard_html changed by html

Add:

- dashboard_type: Allows define the type of dashboard, default is dashboard but for chart is used chart value on type
- chart_type: Define if a chart is bar, pie and other type