### PR TITLE
fix: Process logs request duplicated

### DIFF
--- a/src/store/modules/ADempiere/process/actions.js
+++ b/src/store/modules/ADempiere/process/actions.js
@@ -1,6 +1,5 @@
 import {
-  requestRunProcess,
-  requestListProcessesLogs
+  requestRunProcess
 } from '@/api/ADempiere/process'
 import { showNotification } from '@/utils/ADempiere/notification'
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
@@ -989,60 +988,7 @@ export default {
       })
     }
   },
-  /**
-   * List log of process/reports executed
-   * @author Edwin Betancourt <EdwinBetanc0urt@outlook.com>
-   * @param {string} pageToken
-   * @param {number} pageSize default 50
-   */
-  getSessionProcessFromServer({ commit, dispatch, getters, rootGetters }, {
-    pageToken,
-    pageSize
-  }) {
-    // process Activity
-    return requestListProcessesLogs({ pageToken, pageSize })
-      .then(processActivityResponse => {
-        const responseList = processActivityResponse.processLogsList.map(processLogItem => {
-          const processMetadata = rootGetters.getProcess(processLogItem.uuid)
 
-          // if no exists metadata into store and no request in progess
-          if (isEmptyValue(processMetadata)) {
-            const processRequest = getters.getInRequestMetadata(processLogItem.uuid)
-            if (isEmptyValue(processRequest)) {
-              commit('addInRequestMetadata', processLogItem.uuid)
-              dispatch('getProcessFromServer', {
-                containerUuid: processLogItem.uuid
-              })
-                .finally(() => {
-                  commit('deleteInRequestMetadata', processLogItem.uuid)
-                })
-            }
-          }
-
-          const process = {
-            ...processLogItem,
-            processUuid: processLogItem.uuid
-          }
-          return process
-        })
-
-        const processResponseList = {
-          recordCount: processActivityResponse.recordCount,
-          processList: responseList,
-          nextPageToken: processActivityResponse.nextPageToken
-        }
-        commit('setSessionProcess', processResponseList)
-        return processResponseList
-      })
-      .catch(error => {
-        showNotification({
-          title: language.t('notifications.error'),
-          message: error.message,
-          type: 'error'
-        })
-        console.warn(`Error getting process activity: ${error.message}. Code: ${error.code}.`)
-      })
-  },
   /**
    * Show modal dialog with process/report, tab (sequence) metadata
    * @param {String} type of panel or panelType ('process', 'report', 'window')

--- a/src/store/modules/ADempiere/process/getters.js
+++ b/src/store/modules/ADempiere/process/getters.js
@@ -25,18 +25,7 @@ export default {
   getNotificationProcess: (state) => {
     return state.notificationProcess
   },
-  /**
-   * Process receibed from server associated whith this session
-   */
-  getAllSessionProcess: (state) => {
-    return state.sessionProcess
-  },
-  /**
-   * Process request metadata from server filter form uuid process
-   */
-  getInRequestMetadata: (state) => (containerUuid) => {
-    return state.inRequestMetadata.find(item => item === containerUuid)
-  },
+
   getProcessResult: (state) => {
     return state.reportObject
   },

--- a/src/store/modules/ADempiere/process/mutations.js
+++ b/src/store/modules/ADempiere/process/mutations.js
@@ -18,14 +18,7 @@ export default {
   deleteInExecution(state, payload) {
     state.inExecution = state.inExecution.filter(item => item.containerUuid !== payload.containerUuid)
   },
-  // Add process in request metadata from server
-  addInRequestMetadata(state, payload) {
-    state.inRequestMetadata.push(payload)
-  },
-  // Delete process in request metadata
-  deleteInRequestMetadata(state, payload) {
-    state.inRequestMetadata = state.inRequestMetadata.filter(item => item !== payload)
-  },
+
   addStartedProcess(state, payload) {
     state.process.push(payload)
   },
@@ -52,9 +45,7 @@ export default {
       state.reportList.push(payload)
     }
   },
-  setSessionProcess(state, payload) {
-    state.sessionProcess = payload.processList
-  },
+
   changeFormatReport(state, payload) {
     state.reportFormat = payload
   },
@@ -64,9 +55,7 @@ export default {
   setTotalResponse(state, payload) {
     state.totalResponse = payload
   },
-  setTotalSelection(state, payload) {
-    state.totalSelection = payload
-  },
+
   setSuccessSelection(state, payload) {
     state.successSelection = payload
   },

--- a/src/store/modules/ADempiere/process/state.js
+++ b/src/store/modules/ADempiere/process/state.js
@@ -9,9 +9,7 @@ export default {
   reportList: [],
   metadata: {},
   process: [], // process to run finish
-  sessionProcess: [],
   notificationProcess: [],
-  inRequestMetadata: [],
   reportViewList: [],
   totalResponse: 0,
   totalRequest: 0,

--- a/src/store/modules/ADempiere/processLog.js
+++ b/src/store/modules/ADempiere/processLog.js
@@ -1,0 +1,112 @@
+import {
+  requestListProcessesLogs
+} from '@/api/ADempiere/process.js'
+import { showNotification } from '@/utils/ADempiere/notification.js'
+import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
+import language from '@/lang'
+
+/**
+ * Process Vuex Module
+ * @author Edwin Betancourt <EdwinBetanc0urt@outlook.com>
+ */
+const processLog = {
+  state: {
+    sessionProcess: [],
+    inRequestMetadata: []
+  },
+
+  mutations: {
+    setSessionProcess(state, payload) {
+      state.sessionProcess = payload.processList
+    },
+
+    // Add process in request metadata from server
+    addInRequestMetadata(state, payload) {
+      state.inRequestMetadata.push(payload)
+    },
+
+    // Delete process in request metadata
+    deleteInRequestMetadata(state, payload) {
+      state.inRequestMetadata = state.inRequestMetadata.filter(item => item !== payload)
+    }
+  },
+
+  actions: {
+    /**
+     * List log of process/reports executed
+     * @author Edwin Betancourt <EdwinBetanc0urt@outlook.com>
+     * @param {string} pageToken
+     * @param {number} pageSize default 50
+     */
+    getSessionProcessFromServer({ commit, dispatch, getters, rootGetters }, {
+      pageToken,
+      pageSize
+    }) {
+      // process Activity
+      return requestListProcessesLogs({ pageToken, pageSize })
+        .then(processActivityResponse => {
+          const responseList = processActivityResponse.processLogsList.map(processLogItem => {
+            const { uuid: containerUuid } = processLogItem
+            const processMetadata = rootGetters.getProcess(containerUuid)
+
+            // if no exists metadata into store
+            if (isEmptyValue(processMetadata)) {
+              const processRequest = getters.getInRequestMetadata(containerUuid)
+              // if no request dictionary metadata in progess
+              if (isEmptyValue(processRequest)) {
+                commit('addInRequestMetadata', containerUuid)
+
+                dispatch('getProcessFromServer', {
+                  containerUuid
+                })
+                  .finally(() => {
+                    commit('deleteInRequestMetadata', containerUuid)
+                  })
+              }
+            }
+
+            const process = {
+              ...processLogItem,
+              processUuid: containerUuid
+            }
+            return process
+          })
+
+          const processResponseList = {
+            recordCount: processActivityResponse.recordCount,
+            processList: responseList,
+            nextPageToken: processActivityResponse.nextPageToken
+          }
+          commit('setSessionProcess', processResponseList)
+
+          return processResponseList
+        })
+        .catch(error => {
+          showNotification({
+            title: language.t('notifications.error'),
+            message: error.message,
+            type: 'error'
+          })
+          console.warn(`Error getting process activity: ${error.message}. Code: ${error.code}.`)
+        })
+    }
+  },
+
+  getters: {
+    /**
+     * Process request metadata from server filter form uuid process
+     */
+    getInRequestMetadata: (state) => (containerUuid) => {
+      return state.inRequestMetadata.find(item => item === containerUuid)
+    },
+
+    /**
+     * Process receibed from server associated whith this session
+     */
+    getAllSessionProcess: (state) => {
+      return state.sessionProcess
+    }
+  }
+}
+
+export default processLog

--- a/src/store/modules/ADempiere/processLog.js
+++ b/src/store/modules/ADempiere/processLog.js
@@ -1,3 +1,19 @@
+// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import {
   requestListProcessesLogs
 } from '@/api/ADempiere/process.js'

--- a/src/utils/ADempiere/apiConverts/process.js
+++ b/src/utils/ADempiere/apiConverts/process.js
@@ -20,7 +20,7 @@ import { convertReportOutput } from './report.js'
 
 export function convertProcessLog(processLog) {
   const convertedProcessLog = camelizeObjectKeys(processLog)
-  convertedProcessLog.paramenters = []
+  convertedProcessLog.parameters = []
   convertedProcessLog.output = isEmptyValue(processLog.output) ? {} : convertReportOutput(processLog.output)
   return convertedProcessLog
 }

--- a/src/views/ADempiere/ProcessActivity/modeDesktop.vue
+++ b/src/views/ADempiere/ProcessActivity/modeDesktop.vue
@@ -30,96 +30,127 @@
       >
         <el-card>
           <div slot="header" class="clearfix">
-            <span><b>{{ activity.name }}</b></span>
+            <span>
+              <b> {{ activity.name }} </b>
+            </span>
+
             <div class="actions">
               <el-dropdown @command="handleCommand">
                 <span class="el-dropdown-link">
-                  {{ $t('components.contextMenuActions') }}<i class="el-icon-arrow-down el-icon--right" />
+                  {{ $t('components.contextMenuActions') }}
+                  <i class="el-icon-arrow-down el-icon--right" />
                 </span>
+
                 <el-dropdown-menu slot="dropdown">
-                  <el-dropdown-item v-if="activity.isReport" :command="{ ...activity, command: 'seeReport' }">
+                  <el-dropdown-item
+                    v-if="activity.isReport"
+                    :command="{ ...activity, command: 'seeReport' }"
+                  >
                     {{ $t('views.seeReport') }}
                   </el-dropdown-item>
+
                   <el-dropdown-item :command="{ ...activity, command: 'zoomIn' }">
                     {{ $t('table.ProcessActivity.zoomIn') }}
                   </el-dropdown-item>
+
                   <!-- TODO: add more actions -->
                 </el-dropdown-menu>
               </el-dropdown>
             </div>
           </div>
+
           <el-form label-position="top">
             <el-form-item v-if="activity.description" :label="generateTitle('Description')">
-              <span><b>{{ activity.description }}</b></span>
-              <span v-if="activity.isReport">{{ activity.output.description }}</span>
+              <span>
+                <b> {{ activity.description }} </b>
+              </span>
+
+              <span v-if="activity.isReport">
+                {{ activity.output.description }}
+              </span>
             </el-form-item>
+
             <el-form-item :label="generateTitle('Status')">
               <!-- show only when it is error -->
               <el-popover
-                v-if="activity.isError && !activity.summary && !activity.isReport"
+                v-if="activity.isError && !activity.isReport"
                 :key="index + 'is-error'"
                 placement="right"
+                title="Error"
                 width="700"
                 trigger="hover"
               >
-                <div>
-                  {{ activity.message }}
+                <div v-if="!isEmptyValue(activity.summary)" key="withSummary">
+                  {{ activity.summary }}
                 </div>
+                <div v-else key="withoutSummary">
+                  {{ $t('route.withoutLog') }}
+                </div>
+
                 <el-tag slot="reference" :type="checkStatus(activity).type">
                   {{ checkStatus(activity).text }}
                 </el-tag>
               </el-popover>
+
               <!-- show only when bring logs -->
               <el-popover
                 v-else-if="!isEmptyValue(activity.logsList) || !isEmptyValue(activity.summary)"
                 :key="index + 'is-summary'"
                 placement="right"
+                :title="$t('table.ProcessActivity.Logs')"
                 width="500"
                 trigger="hover"
               >
-                <b>{{ $t('table.ProcessActivity.Logs') }}</b><br>
                 <ul>
-                  <li @click="handleCommand({ ...activity, command: 'zoomIn' })"> {{ activity.summary }} </li>
+                  <li @click="handleCommand({ ...activity, command: 'zoomIn' })">
+                    {{ activity.summary }}
+                  </li>
                   <el-scrollbar wrap-class="popover-scroll">
                     <li v-for="(logItem, key) in activity.logsList" :key="key" @click="zoomIn(activity)">
                       {{ logItem.log }}
                     </li>
                   </el-scrollbar>
                 </ul>
+
                 <el-tag slot="reference" :type="checkStatus(activity).type">
                   {{ checkStatus(activity).text }}
                 </el-tag>
               </el-popover>
+
               <!-- show only when bring output -->
               <el-popover
                 v-else-if="activity.isReport"
                 :key="index + 'is-output'"
                 placement="right"
+                :title="$t('table.ProcessActivity.Output')"
                 width="700"
                 trigger="hover"
               >
-                <div>
-                  <span> {{ $t('table.ProcessActivity.Output') }} </span><br>
-                  <span>{{ $t('table.ProcessActivity.Name') }}: {{ activity.output.name }}</span><br>
-                  <span>{{ $t('table.ProcessActivity.Description') }}: {{ activity.output.description }}</span><br>
-                  <span>{{ $t('table.ProcessActivity.FileName') }}: {{ activity.output.fileName }}</span><br>
+                <div v-if="!activity.isError" key="withOutput">
+                  <span>
+                    {{ $t('table.ProcessActivity.Name') }}: {{ activity.output.name }}
+                  </span><br>
+                  <span>
+                    {{ $t('table.ProcessActivity.Description') }}: {{ activity.output.description }}
+                  </span><br>
+                  <span>
+                    {{ $t('table.ProcessActivity.FileName') }}: {{ activity.output.fileName }}
+                  </span><br>
                   <a type="text" :href="activity.url" :download="activity.download">
-                    {{ $t('components.contextMenuDownload') }} <i class="el-icon-download" />
+                    {{ $t('components.contextMenuDownload') }}
+                    <i class="el-icon-download" />
                   </a>
                 </div>
-                <el-tag slot="reference" :type="checkStatus(activity).type">
-                  {{ checkStatus(activity).text }}
-                </el-tag>
-              </el-popover>
-              <el-popover
-                v-else
-                :key="index + 'is-other'"
-                placement="top-start"
-                :title="$t('table.ProcessActivity.Logs')"
-                width="200"
-                trigger="hover"
-                :content="activity.summary"
-              >
+
+                <div v-else key="withError">
+                  <template v-if="!isEmptyValue(activity.summary)">
+                    {{ activity.summary }}
+                  </template>
+                  <template v-else>
+                    {{ $t('route.withoutLog') }}
+                  </template>
+                </div>
+
                 <el-tag slot="reference" :type="checkStatus(activity).type">
                   {{ checkStatus(activity).text }}
                 </el-tag>
@@ -130,20 +161,15 @@
       </el-timeline-item>
     </el-timeline>
   </div>
+
   <div v-else key="without-process">
-    <h1 class="text-center">{{ $t('views.noProcess') }}</h1>
+    <h1 class="text-center">
+      {{ $t('views.noProcess') }}
+    </h1>
   </div>
 </template>
 
-<script>
-import MixinProcessActivity from './index.vue'
-
-export default {
-  name: 'ModeDesktop',
-  mixins: [
-    MixinProcessActivity
-  ]
-}
+<script src="./processActivity.js">
 </script>
 
 <style lang="scss" scoped src="./processActivityStyle.scss">

--- a/src/views/ADempiere/ProcessActivity/modeMobile.vue
+++ b/src/views/ADempiere/ProcessActivity/modeMobile.vue
@@ -30,102 +30,127 @@
       >
         <el-card>
           <div slot="header" class="clearfix">
-            <span><b>{{ activity.name }}</b></span>
+            <span>
+              <b> {{ activity.name }} </b>
+            </span>
+
             <div class="actions">
               <el-dropdown @command="handleCommand">
                 <span class="el-dropdown-link">
-                  {{ $t('components.contextMenuActions') }}<i class="el-icon-arrow-down el-icon--right" />
+                  {{ $t('components.contextMenuActions') }}
+                  <i class="el-icon-arrow-down el-icon--right" />
                 </span>
+
                 <el-dropdown-menu slot="dropdown">
-                  <el-dropdown-item v-if="activity.isReport" :command="{ ...activity, command: 'seeReport' }">
+                  <el-dropdown-item
+                    v-if="activity.isReport"
+                    :command="{ ...activity, command: 'seeReport' }"
+                  >
                     {{ $t('views.seeReport') }}
                   </el-dropdown-item>
+
                   <el-dropdown-item :command="{ ...activity, command: 'zoomIn' }">
                     {{ $t('table.ProcessActivity.zoomIn') }}
                   </el-dropdown-item>
+
                   <!-- TODO: add more actions -->
                 </el-dropdown-menu>
               </el-dropdown>
             </div>
           </div>
+
           <el-form label-position="top">
             <el-form-item v-if="activity.description" :label="generateTitle('Description')">
-              <span><b>{{ activity.description }}</b></span>
-              <span v-if="activity.isReport">{{ activity.output.description }}</span>
+              <span>
+                <b> {{ activity.description }} </b>
+              </span>
+
+              <span v-if="activity.isReport">
+                {{ activity.output.description }}
+              </span>
             </el-form-item>
+
             <el-form-item :label="generateTitle('Status')">
               <!-- show only when it is error -->
               <el-popover
-                v-if="activity.isError"
+                v-if="activity.isError && !activity.isReport"
                 :key="index + 'is-error'"
                 placement="right"
                 width="300"
                 trigger="click"
               >
-                <div v-if="!isEmptyValue(activity.summary)">
-                  {{ activity.message }}
+                <div v-if="!isEmptyValue(activity.summary)" key="withSummary">
+                  {{ activity.summary }}
                 </div>
-                <div v-else>
+                <div v-else key="withoutSummary">
                   {{ $t('route.withoutLog') }}
                 </div>
+
                 <el-tag slot="reference" :type="checkStatus(activity).type">
                   {{ checkStatus(activity).text }}
                 </el-tag>
               </el-popover>
+
               <!-- show only when bring logs -->
               <el-popover
-                v-else-if="activity.panelType === 'process'"
+                v-else-if="!isEmptyValue(activity.logsList) || !isEmptyValue(activity.summary)"
                 :key="index + 'is-summary'"
                 placement="right"
+                :title="$t('table.ProcessActivity.Logs')"
                 width="300"
                 trigger="click"
               >
-                <b>{{ $t('table.ProcessActivity.Logs') }}</b><br>
                 <ul>
-                  <li @click="handleCommand({ ...activity, command: 'zoomIn' })"> {{ activity.summary }} </li>
+                  <li @click="handleCommand({ ...activity, command: 'zoomIn' })">
+                    {{ activity.summary }}
+                  </li>
+
                   <el-scrollbar wrap-class="popover-scroll">
                     <li v-for="(logItem, key) in activity.logsList" :key="key" @click="zoomIn(activity)">
                       {{ logItem.log }}
                     </li>
                   </el-scrollbar>
                 </ul>
+
                 <el-tag slot="reference" :type="checkStatus(activity).type">
                   {{ checkStatus(activity).text }}
                 </el-tag>
               </el-popover>
+
               <!-- show only when bring output -->
               <el-popover
-                v-else-if="activity.panelType === 'report'"
+                v-else-if="activity.isReport"
                 :key="index + 'is-output'"
                 placement="right"
+                :title="$t('table.ProcessActivity.Output')"
                 width="300"
                 trigger="click"
               >
-                <div v-if="!isEmptyValue(activity.summary)">
-                  <span> {{ $t('table.ProcessActivity.Output') }} </span><br>
-                  <span>{{ $t('table.ProcessActivity.Name') }}: {{ activity.output.name }}</span><br>
-                  <span>{{ $t('table.ProcessActivity.Description') }}: {{ activity.output.description }}</span><br>
-                  <span>{{ $t('table.ProcessActivity.FileName') }}: {{ activity.output.fileName }}</span><br>
+                <div v-if="!activity.isError" key="withOutput">
+                  <span>
+                    {{ $t('table.ProcessActivity.Name') }}: {{ activity.output.name }}
+                  </span><br>
+                  <span>
+                    {{ $t('table.ProcessActivity.Description') }}: {{ activity.output.description }}
+                  </span><br>
+                  <span>
+                    {{ $t('table.ProcessActivity.FileName') }}: {{ activity.output.fileName }}
+                  </span><br>
                   <a type="text" :href="activity.url" :download="activity.download">
-                    {{ $t('components.contextMenuDownload') }} <i class="el-icon-download" />
+                    {{ $t('components.contextMenuDownload') }}
+                    <i class="el-icon-download" />
                   </a>
                 </div>
-                <div v-else>
-                  {{ $t('route.withoutLog') }}
+
+                <div v-else key="withError">
+                  <template v-if="!isEmptyValue(activity.summary)">
+                    {{ activity.summary }}
+                  </template>
+                  <template v-else>
+                    {{ $t('route.withoutLog') }}
+                  </template>
                 </div>
-                <el-tag slot="reference" :type="checkStatus(activity).type">
-                  {{ checkStatus(activity).text }} {{ activity.type }}
-                </el-tag>
-              </el-popover>
-              <el-popover
-                v-else
-                :key="index + 'is-other'"
-                placement="top-start"
-                :title="$t('table.ProcessActivity.Logs')"
-                width="200"
-                trigger="click"
-                :content="activity.summary"
-              >
+
                 <el-tag slot="reference" :type="checkStatus(activity).type">
                   {{ checkStatus(activity).text }}
                 </el-tag>
@@ -136,20 +161,15 @@
       </el-timeline-item>
     </el-timeline>
   </div>
+
   <div v-else key="without-process">
-    <h1 class="text-center">{{ $t('views.noProcess') }}</h1>
+    <h1 class="text-center">
+      {{ $t('views.noProcess') }}
+    </h1>
   </div>
 </template>
 
-<script>
-import MixinProcessActivity from './index.vue'
-
-export default {
-  name: 'ProcessActivity',
-  mixins: [
-    MixinProcessActivity
-  ]
-}
+<script src="./processActivity.js">
 </script>
 
 <style lang="scss" scoped src="./processActivityStyle.scss">

--- a/src/views/ADempiere/ProcessActivity/processActivity.js
+++ b/src/views/ADempiere/ProcessActivity/processActivity.js
@@ -1,0 +1,188 @@
+
+import { defineComponent, computed, onMounted, ref } from '@vue/composition-api'
+
+import { recursiveTreeSearch } from '@/utils/ADempiere/valueUtils.js'
+
+export default defineComponent({
+  name: 'ProcessActivity',
+
+  setup(props, { root }) {
+    const processActivity = ref([])
+    const recordCount = ref(0)
+    const pageToken = ref('')
+    const pageSize = ref(50)
+
+    // process local is running
+    const getterAllInExecution = computed(() => {
+      return root.$store.getters.getAllInExecution
+    })
+
+    // process local and send with response
+    const getterAllFinishProcess = computed(() => {
+      return root.$store.getters.getAllFinishProcess
+    })
+
+    // session process from server
+    const getterAllSessionProcess = computed(() => {
+      return root.$store.getters.getAllSessionProcess
+    })
+
+    // all process
+    const getRunProcessAll = computed(() => {
+      const processAll = [].concat(
+        getterAllInExecution.value,
+        getterAllFinishProcess.value,
+        getterAllSessionProcess.value
+      )
+      const processAllReturned = []
+
+      processAll.forEach(element => {
+        const processMetadataReturned = {}
+        let infoMetadata = getProcessMetadata(element.processUuid)
+        if (!infoMetadata) {
+          infoMetadata = {}
+        }
+
+        Object.assign(processMetadataReturned, element, infoMetadata)
+        processMetadataReturned.parametersList = element.parametersList
+        const indexRepeat = processAllReturned.findIndex(item => {
+          return item.instanceUuid === element.instanceUuid && !root.isEmptyValue(element.instanceUuid)
+        })
+
+        if (indexRepeat > -1) {
+          // update attributes in exists process to return
+          // Object.assign(processAllReturned[indexRepeat], processMetadataReturned)
+          const other = Object.assign(processMetadataReturned, processAllReturned[indexRepeat])
+          processAllReturned[indexRepeat] = other
+          return
+        }
+
+        // add new process to show
+        processAllReturned.push(processMetadataReturned)
+      })
+
+      return processAllReturned.sort((a, b) => {
+        // sort by most recently date
+        return new Date(b.lastRun) - new Date(a.lastRun)
+      })
+    })
+
+    const getProcessLog = computed(() => {
+      return getRunProcessAll.value.filter(element => {
+        const { isError, isProcessing } = element
+        if (!root.isEmptyValue(isError) && !root.isEmptyValue(isProcessing)) {
+          return element
+        }
+      })
+    })
+
+    const language = computed(() => {
+      return root.$store.getters.language
+    })
+
+    const permissionRoutes = computed(() => {
+      return root.$store.getters.permission_routes
+    })
+
+    onMounted(() => {
+      root.$store.dispatch('getSessionProcessFromServer', {
+        pageToken: pageToken.value,
+        pageSize: pageSize.value
+      })
+        .then(response => {
+          pageToken.value = response.nextPageToken
+        })
+    })
+
+    const getProcessMetadata = (uuid) => {
+      return root.$store.getters.getProcess(uuid)
+    }
+
+    const handleCommand = (activity) => {
+      if (activity.command === 'seeReport') {
+        root.$router.push({
+          name: 'Report Viewer',
+          params: {
+            processId: activity.processId,
+            instanceUuid: activity.instanceUuid,
+            fileName: activity.output.fileName
+          }
+        }, () => {})
+      } else if (activity.command === 'zoomIn') {
+        const viewSearch = recursiveTreeSearch({
+          treeData: permissionRoutes.value,
+          attributeValue: activity.uuid,
+          attributeName: 'meta',
+          secondAttribute: 'uuid',
+          attributeChilds: 'children'
+        })
+
+        if (viewSearch) {
+          root.$router.push({
+            name: viewSearch.name,
+            query: {
+              ...root.$route.query,
+              ...activity.parametersList
+            }
+          }, () => {})
+        }
+      }
+    }
+
+    const checkStatus = ({ isError, isProcessing, isReport }) => {
+      const status = {
+        text: root.$t('notifications.completed'),
+        type: 'success',
+        color: '#67C23A'
+      }
+      // is executing
+      if (isProcessing) {
+        status.text = root.$t('notifications.processing')
+        status.type = 'info'
+        status.color = '#909399'
+        return status
+      }
+      // is with error
+      if (isError) {
+        status.text = root.$t('notifications.error')
+        status.type = 'danger'
+        status.color = '#F56C6C'
+        return status
+      }
+      // is completed
+      return status
+    }
+
+    const generateTitle = (title) => {
+      const hasKey = root.$te('table.ProcessActivity.' + title)
+      if (hasKey) {
+        // $t : this method from vue-i18n, inject in @/lang/index.js
+        const translatedTitle = root.$t('table.ProcessActivity.' + title)
+        return translatedTitle
+      }
+      return title
+    }
+
+    const translateDate = (value) => {
+      return root.$d(new Date(value), 'long', language.value)
+    }
+
+    return {
+      processActivity,
+      recordCount,
+      pageToken,
+      pageSize,
+      // computeds
+      getRunProcessAll,
+      getProcessLog,
+      language,
+      permissionRoutes,
+      // methods
+      getProcessMetadata,
+      handleCommand,
+      checkStatus,
+      generateTitle,
+      translateDate
+    }
+  }
+})

--- a/src/views/ADempiere/ProcessActivity/processActivity.js
+++ b/src/views/ADempiere/ProcessActivity/processActivity.js
@@ -1,3 +1,18 @@
+// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { defineComponent, computed, onMounted, ref } from '@vue/composition-api'
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Execute `Cache Reset` process.
2. Refresh page (F5).
3. Open Process Acivity
4. Show in browser tools the network requests (F12 to Mozilla Firefox)

#### Screenshot or Gif

Before this PR:
https://user-images.githubusercontent.com/20288327/123334885-bacba280-d511-11eb-9451-1544b07fb9a9.mp4

After this PR:
https://user-images.githubusercontent.com/20288327/123334314-e9954900-d510-11eb-9476-74cabbe87c5f.mp4


#### Expected behavior
The request for the process-log of the session is being made twice, this is due to a bad definition in the logic. It is expected that when opening the `Process Activity` view only one process-log request is made.

#### Other relevant information
* Your OS: Linux Mint 19.1 Cinnamon x64. 
* Browser: Mozilla Firefox 88.0.1.
* Node.js version: 14.17.0.
* NPM version: 7.17.0.
* adempiere-vue version: 4.3.1.

#### Additional context
If the metadata of the executed process is not stored in the processDefinition store, a request is made to the server to check the metadata and get the name and description of the process.

This request and the traversing and mixing of process-log arrays with the process metadata could be avoided if the process-log also returns the process name and description.

