### PR TITLE
fix: Lock record get values with router

### DIFF
--- a/src/components/ADempiere/ContainerOptions/LockRecord/index.vue
+++ b/src/components/ADempiere/ContainerOptions/LockRecord/index.vue
@@ -17,29 +17,28 @@
 -->
 
 <template>
-  <div>
-    <span v-if="isFirstTab" key="tooltip">
-      <el-tooltip
-        v-if="isFirstTab"
-        :content="isLocked ? $t('data.lockRecord') : $t('data.unlockRecord')"
-        placement="top"
-      >
-        <el-button type="text" @click="lockRecord()">
-          <i
-            :class="isLocked ? 'el-icon-lock' : 'el-icon-unlock'"
-            style="font-size: 15px; color: black;"
-          />
-        </el-button>
-      </el-tooltip>
-      <span :style="isLocked ? 'color: red;' :'color: #1890ff;'">
-        {{ tabName }}
-      </span>
-    </span>
+  <span v-if="isFirstTab" key="withTooltip">
+    <el-tooltip
+      v-if="isFirstTab"
+      :content="isLocked ? $t('data.lockRecord') : $t('data.unlockRecord')"
+      placement="top"
+    >
+      <el-button type="text" @click="lockRecord()">
+        <i
+          :class="isLocked ? 'el-icon-lock' : 'el-icon-unlock'"
+          style="font-size: 15px; color: black;"
+        />
+      </el-button>
+    </el-tooltip>
 
-    <template v-else>
+    <span :style="isLocked ? 'color: red;' :'color: #1890ff;'">
       {{ tabName }}
-    </template>
-  </div>
+    </span>
+  </span>
+
+  <span v-else key="onlyName">
+    {{ tabName }}
+  </span>
 </template>
 
 <script>
@@ -49,6 +48,10 @@ export default defineComponent({
   name: 'LockRecord',
 
   props: {
+    tabUuid: {
+      type: String,
+      required: true
+    },
     tabPosition: {
       type: Number,
       default: 0
@@ -56,12 +59,16 @@ export default defineComponent({
     tabName: {
       type: String,
       required: true
+    },
+    tableName: {
+      type: String,
+      required: true
     }
   },
 
   setup(props, { root }) {
-    const { tabUuid: containerUuid } = root.$route.meta
-    const { tableName } = root.$route.params
+    const containerUuid = props.tabUuid
+    const tableName = props.tableName
 
     const isFirstTab = computed(() => {
       return props.tabPosition === 0

--- a/src/components/ADempiere/Tab/index.vue
+++ b/src/components/ADempiere/Tab/index.vue
@@ -28,12 +28,13 @@
         :disabled="Boolean(key > 0 && isCreateNew)"
         :style="tabParentStyle"
       >
-        <span slot="label">
-          <lock-record
-            :tab-position="key"
-            :tab-name="tabAttributes.name"
-          />
-        </span>
+        <lock-record
+          slot="label"
+          :tab-position="key"
+          :tab-uuid="tabAttributes.uuid"
+          :table-name="tabAttributes.tableName"
+          :tab-name="tabAttributes.name"
+        />
 
         <main-panel
           :parent-uuid="windowUuid"


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

values like tab uuid and table name are kept from the router, however when changing or opening the window by advanced search, reference, or zoom (in some cases), the tab uuid name and table name are undefined because they were not set when doing $router.push with those values in the parameters.


#### Expected behavior
It is set so that it gets those values as properties of the metadata of the tab that loads them, this being the best option since it gets the values directly from the metadata and does not expect them to be set in the parameters for each redirect with $router.push. 

#### Other relevant information
* Your OS: Linux Mint 19.1 Cinnamon x64. 
* Browser: Mozilla Firefox 88.0.1.
* Node.js version: 14.17.0.
* NPM version: 7.17.0.
* adempiere-vue version: 4.3.1.

#### Additional Context
Additional html tags have also been removed from the templates that were unnecessary.
