### PR TITLE
feat: Delete related vuex store logic

### DIFF
--- a/src/components/ADempiere/Field/index.vue
+++ b/src/components/ADempiere/Field/index.vue
@@ -38,6 +38,10 @@
           :is="componentRender"
           :id="field.panelType !== 'form' ? field.columnName : ''"
           :ref="field.columnName"
+          :parent-uuid="parentUuid"
+          :container-uuid="containerUuid"
+          :container-manager="containerManager"
+          :field-metadata="fieldAttributes"
           :metadata="fieldAttributes"
           :value-model="recordDataFields"
         />
@@ -50,6 +54,10 @@
     :id="field.panelType !== 'form' ? field.columnName : ''"
     key="is-table-template"
     :class="classField"
+    :parent-uuid="parentUuid"
+    :container-uuid="containerUuid"
+    :container-manager="containerManager"
+    :field-metadata="fieldAttributes"
     :metadata="fieldAttributes"
     :value-model="recordDataFields"
     :in-table="true"
@@ -72,7 +80,23 @@ export default {
   },
 
   props: {
+    parentUuid: {
+      type: String,
+      default: undefined
+    },
+    containerUuid: {
+      type: String,
+      required: true
+    },
+    containerManager: {
+      type: String,
+      required: true
+    },
     // receives the property that is an object with all the attributes
+    fieldMetadata: {
+      type: Object,
+      default: () => ({})
+    },
     metadataField: {
       type: Object,
       default: () => ({})

--- a/src/components/ADempiere/Field/mixin/mixinField.js
+++ b/src/components/ADempiere/Field/mixin/mixinField.js
@@ -16,6 +16,22 @@
 
 export default {
   props: {
+    parentUuid: {
+      type: String,
+      default: undefined
+    },
+    containerUuid: {
+      type: String,
+      required: true
+    },
+    containerManager: {
+      type: String,
+      required: true
+    },
+    fieldMetadata: {
+      type: Object,
+      required: true
+    },
     metadata: {
       type: Object,
       required: true
@@ -158,7 +174,7 @@ export default {
     },
     actionKeyPerformed(value) {
       // TODO: Delete for production
-      console.info('actionKeyPerformed ', value)
+      console.info('actionKeyPerformed ', this.containerManager, value)
       if (this.metadata.handleActionKeyPerformed) {
         this.$store.dispatch('notifyActionKeyPerformed', {
           containerUuid: this.metadata.containerUuid,

--- a/src/components/ADempiere/PanelDefinition/StandardPanel.vue
+++ b/src/components/ADempiere/PanelDefinition/StandardPanel.vue
@@ -35,11 +35,12 @@
             <el-row>
               <template v-for="(fieldAttributes, subKey) in fieldsList">
                 <field-definition
-                  :ref="fieldAttributes.columnName"
                   :key="subKey"
-                  :metadata-field="{
-                    ...fieldAttributes
-                  }"
+                  :parent-uuid="parentUuid"
+                  :container-uuid="containerUuid"
+                  :container-manager="containerManager"
+                  :field-metadata="fieldAttributes"
+                  :metadata-field="fieldAttributes"
                 />
               </template>
             </el-row>
@@ -65,7 +66,15 @@ export default defineComponent({
   },
 
   props: {
+    parentUuid: {
+      type: String,
+      default: undefined
+    },
     containerUuid: {
+      type: String,
+      required: true
+    },
+    containerManager: {
       type: String,
       required: true
     },

--- a/src/components/ADempiere/PanelDefinition/index.vue
+++ b/src/components/ADempiere/PanelDefinition/index.vue
@@ -20,6 +20,7 @@
   <component
     :is="componentRender"
     :container-uuid="containerUuid"
+    :container-manager="containerManager"
     :panel-metadata="metadata"
   />
 </template>
@@ -37,6 +38,10 @@ export default defineComponent({
       default: undefined
     },
     containerUuid: {
+      type: String,
+      required: true
+    },
+    containerManager: {
       type: String,
       required: true
     },

--- a/src/components/ADempiere/PanelDefinition/index.vue
+++ b/src/components/ADempiere/PanelDefinition/index.vue
@@ -25,7 +25,8 @@
 </template>
 
 <script>
-import { defineComponent, computed } from '@vue/composition-api'
+import { defineComponent, computed, ref } from '@vue/composition-api'
+import { generatePanelAndFields } from './panelUtils'
 
 export default defineComponent({
   name: 'PanelDefinition',
@@ -45,10 +46,8 @@ export default defineComponent({
     }
   },
 
-  setup(props, { root }) {
-    const storedMetadata = computed(() => {
-      return root.$store.getters.getPanel(props.containerUuid)
-    })
+  setup(props) {
+    const metadata = ref({})
 
     const componentRender = computed(() => {
       return () => import('@/components/ADempiere/PanelDefinition/StandardPanel')
@@ -59,22 +58,15 @@ export default defineComponent({
      * the fields it contains
      */
     const getPanel = () => {
-      let panel = storedMetadata.value
-      if (root.isEmptyValue(panel)) {
-        // not in store, set with prop
-        panel = props.panelMetadata
-      }
-      if (!root.isEmptyValue(panel) && panel.fieldsList) {
-        // not regenerate fields
-        return
-      }
-
-      // generate fields and set into store
-      root.$store.dispatch('getFieldsFromTab', {
+      // generated panel properties
+      const panel = generatePanelAndFields({
         parentUuid: props.parentUuid,
         containerUuid: props.containerUuid,
-        panelMetadata: panel
+        panelMetadata: props.panelMetadata
       })
+
+      // set panel genereated
+      metadata.value = panel
     }
 
     getPanel()
@@ -82,7 +74,7 @@ export default defineComponent({
     return {
       // computeds
       componentRender,
-      metadata: storedMetadata
+      metadata
     }
   }
 })

--- a/src/components/ADempiere/PanelDefinition/panelUtils.js
+++ b/src/components/ADempiere/PanelDefinition/panelUtils.js
@@ -1,0 +1,76 @@
+
+import { generateField } from '@/utils/ADempiere/dictionaryUtils'
+import { getFieldTemplate } from '@/utils/ADempiere/lookupFactory'
+
+export function generatePanelAndFields({
+  parentUuid,
+  containerUuid,
+  panelMetadata: tabMetadata = {}
+}) {
+  const fieldAdditionalAttributes = {
+    parentUuid,
+    containerUuid,
+    containerType: tabMetadata.containerType,
+    // tab attributes
+    tabTableName: tabMetadata.tableName,
+    tabQuery: tabMetadata.query,
+    tabWhereClause: tabMetadata.whereClause,
+    // app attributes
+    isShowedFromUser: true,
+    isReadOnlyFromForm: false
+  }
+
+  let isWithUuidField = false // indicates it contains the uuid field
+  let fieldLinkColumnName
+
+  // convert fields and add app attributes
+  const fieldsList = tabMetadata.fields.map((fieldItem, index) => {
+    fieldItem = generateField({
+      fieldToGenerate: fieldItem,
+      moreAttributes: {
+        ...fieldAdditionalAttributes,
+        fieldsListIndex: index
+      }
+    })
+
+    if (!isWithUuidField && fieldItem.columnName === 'UUID') {
+      isWithUuidField = true
+    }
+
+    if (fieldItem.isParent) {
+      fieldLinkColumnName = fieldItem.columnName
+    }
+
+    return fieldItem
+  })
+
+  // add field uuid column name
+  if (!isWithUuidField) {
+    const fieldUuid = getFieldTemplate({
+      ...fieldAdditionalAttributes,
+      fieldsListIndex: fieldsList.length,
+      isShowedFromUser: false,
+      name: 'UUID',
+      columnName: 'UUID',
+      componentPath: 'FieldText'
+    })
+
+    fieldsList.push(fieldUuid)
+  }
+
+  // panel for save on store
+  const panel = {
+    ...tabMetadata,
+    containerUuid,
+    fieldLinkColumnName,
+    fieldsList,
+    // app attributes
+    isLoadedFieldsList: true,
+    isShowedTotals: false
+  }
+
+  // delete unused and dupicated property with 'fieldsList'
+  delete panel.fields
+
+  return panel
+}

--- a/src/components/ADempiere/PanelDefinition/panelUtils.js
+++ b/src/components/ADempiere/PanelDefinition/panelUtils.js
@@ -10,7 +10,6 @@ export function generatePanelAndFields({
   const fieldAdditionalAttributes = {
     parentUuid,
     containerUuid,
-    containerType: tabMetadata.containerType,
     // tab attributes
     tabTableName: tabMetadata.tableName,
     tabQuery: tabMetadata.query,
@@ -19,9 +18,6 @@ export function generatePanelAndFields({
     isShowedFromUser: true,
     isReadOnlyFromForm: false
   }
-
-  let isWithUuidField = false // indicates it contains the uuid field
-  let fieldLinkColumnName
 
   // convert fields and add app attributes
   const fieldsList = tabMetadata.fields.map((fieldItem, index) => {
@@ -33,17 +29,21 @@ export function generatePanelAndFields({
       }
     })
 
-    if (!isWithUuidField && fieldItem.columnName === 'UUID') {
-      isWithUuidField = true
-    }
-
-    if (fieldItem.isParent) {
-      fieldLinkColumnName = fieldItem.columnName
-    }
-
     return fieldItem
   })
 
+  // parent link column name
+  let fieldLinkColumnName = fieldsList.find(fieldItem => {
+    return fieldItem.isParent
+  })
+  if (fieldLinkColumnName) {
+    fieldLinkColumnName = fieldLinkColumnName.columnName
+  }
+
+  // indicates it contains the uuid field
+  const isWithUuidField = fieldsList.some(fieldItem => {
+    return fieldItem.columnName === 'UUID'
+  })
   // add field uuid column name
   if (!isWithUuidField) {
     const fieldUuid = getFieldTemplate({

--- a/src/components/ADempiere/TabManager/index.vue
+++ b/src/components/ADempiere/TabManager/index.vue
@@ -105,11 +105,7 @@ export default defineComponent({
     }
 
     const setCurrentTab = () => {
-      root.$store.dispatch('setCurrentTab', {
-        parentUuid: props.windowUuid,
-        containerUuid: tabUuid.value,
-        window: props.windowMetadata
-      })
+      // TODO: Add store current tab
     }
 
     /**
@@ -150,13 +146,7 @@ export default defineComponent({
     }
 
     const getData = () => {
-      root.$store.dispatch('getDataListTab', {
-        parentUuid: props.windowUuid,
-        containerUuid: tabUuid.value
-      })
-        .catch(error => {
-          console.warn(`Error getting data list tab. Message: ${error.message}, code ${error.code}.`)
-        })
+      // TODO: Add store get data from tab
     }
 
     getData()

--- a/src/components/ADempiere/TabManager/index.vue
+++ b/src/components/ADempiere/TabManager/index.vue
@@ -26,9 +26,8 @@
       <el-tab-pane
         :key="key"
         :label="tabAttributes.name"
-        :windowuuid="windowUuid"
-        :tabuuid="tabAttributes.uuid"
         :name="String(key)"
+        :tabuuid="tabAttributes.uuid"
         :tabindex="String(key)"
         lazy
         :disabled="isDisabledTab(key)"
@@ -43,8 +42,9 @@
         />
 
         <panel-definition
-          :parent-uuid="windowUuid"
+          :parent-uuid="parentUuid"
           :container-uuid="tabAttributes.uuid"
+          :container-manager="containerManager"
           :panel-metadata="tabAttributes"
           :group-tab="tabAttributes.tabGroup"
         />
@@ -68,13 +68,13 @@ export default defineComponent({
   },
 
   props: {
-    windowUuid: {
+    parentUuid: {
       type: String,
-      default: ''
+      required: true
     },
-    windowMetadata: {
-      type: Object,
-      default: () => {}
+    containerManager: {
+      type: String,
+      required: true
     },
     tabsList: {
       type: Array,
@@ -155,7 +155,6 @@ export default defineComponent({
 
     return {
       currentTab,
-      tabUuid,
       // computed
       tabStyle,
       // meyhods

--- a/src/store/modules/ADempiere/panel/actions.js
+++ b/src/store/modules/ADempiere/panel/actions.js
@@ -214,6 +214,10 @@ const actions = {
     fieldsExcludes = []
   }) {
     const panel = getters.getPanel(containerUuid)
+    if (isEmptyValue(panel)) {
+      // panel is with prop, not stored in vuex
+      return
+    }
 
     const fieldsList = panel.fieldsList.map(itemField => {
       const { columnName } = itemField

--- a/src/views/ADempiere/WindowView/StandardWindow.vue
+++ b/src/views/ADempiere/WindowView/StandardWindow.vue
@@ -18,8 +18,8 @@
 
 <template>
   <tab-manager
-    :window-uuid="windowUuid"
-    :window-metadata="windowMetadata"
+    :parent-uuid="windowMetadata.uuid"
+    :container-manager="containerManager"
     :tabs-list="windowMetadata.tabsListParent"
     class="tab-window"
   />
@@ -38,7 +38,7 @@ export default defineComponent({
   },
 
   props: {
-    windowUuid: {
+    containerManager: {
       type: String,
       required: true
     },
@@ -46,10 +46,7 @@ export default defineComponent({
       type: Object,
       required: true
     }
-  },
-
-  setup() {
-
   }
+
 })
 </script>

--- a/src/views/ADempiere/WindowView/index.vue
+++ b/src/views/ADempiere/WindowView/index.vue
@@ -62,6 +62,7 @@ export default defineComponent({
   },
 
   setup(props, { root }) {
+    const containerType = 'window'
     const isLoaded = ref(false)
     const windowMetadata = ref({})
 
@@ -76,53 +77,24 @@ export default defineComponent({
       isLoaded.value = true
     }
 
-    const storedWindow = computed(() => {
-      return root.$store.getters.getWindow(windowUuid)
-    })
-
     // get window from vuex store or request from server
     const getWindow = () => {
-      const window = storedWindow.value
-      if (!root.isEmptyValue(window)) {
-        generateWindow(window)
-        return
-      }
-
       // metadata props use for test
       if (!root.isEmptyValue(props.metadata)) {
         return new Promise(resolve => {
-          const windowResponse = generateWindowRespose(props.metadata)
-          root.$store.commit('addWindow', windowResponse)
+          const windowResponse = generateWindowRespose({
+            ...props.metadata,
+            containerType
+          })
+
           generateWindow(windowResponse)
           resolve(windowResponse)
         })
       }
-
-      root.$store.dispatch('getWindowFromServer', {
-        windowUuid,
-        routeToDelete: root.$route
-      })
-        .then(windowResponse => {
-          generateWindow(windowResponse)
-        })
     }
 
-    const isDocumentTab = computed(() => {
-      const panel = root.$store.getters.getPanel(windowMetadata.value.currentTabUuid)
-      if (!root.isEmptyValue(panel)) {
-        return panel.isDocument
-      }
-
-      return windowMetadata.value.firstTab.isDocument
-    })
-
     const renderWindowComponent = computed(() => {
-      let windowComponent = () => import('@/views/ADempiere/WindowView/StandardWindow')
-
-      // documents have workflow
-      if (isDocumentTab.value) {
-        windowComponent = () => import('@/views/ADempiere/WindowView/DocumentWindow')
-      }
+      const windowComponent = () => import('@/views/ADempiere/WindowView/StandardWindow')
 
       return windowComponent
     })

--- a/src/views/ADempiere/WindowView/index.vue
+++ b/src/views/ADempiere/WindowView/index.vue
@@ -25,8 +25,8 @@
 
         <component
           :is="renderWindowComponent"
+          :container-manager="containerManager"
           :window-metadata="windowMetadata"
-          :window-uuid="windowUuid"
         />
       </el-aside>
     </el-container>
@@ -62,7 +62,8 @@ export default defineComponent({
   },
 
   setup(props, { root }) {
-    const containerType = 'window'
+    const containerManager = 'window'
+
     const isLoaded = ref(false)
     const windowMetadata = ref({})
 
@@ -82,10 +83,7 @@ export default defineComponent({
       // metadata props use for test
       if (!root.isEmptyValue(props.metadata)) {
         return new Promise(resolve => {
-          const windowResponse = generateWindowRespose({
-            ...props.metadata,
-            containerType
-          })
+          const windowResponse = generateWindowRespose(props.metadata)
 
           generateWindow(windowResponse)
           resolve(windowResponse)
@@ -104,6 +102,7 @@ export default defineComponent({
 
     return {
       windowUuid,
+      containerManager,
       windowMetadata,
       // computed
       renderWindowComponent,

--- a/src/views/ADempiere/WindowView/windowUtils.js
+++ b/src/views/ADempiere/WindowView/windowUtils.js
@@ -9,7 +9,7 @@ export function generateWindow(windowResponse) {
     firstTab, firstTabUuid
   } = generateTabs({
     tabs: responseWindow.tabs,
-    windowUuid: responseWindow.uuid
+    parentUuid: responseWindow.uuid
   })
 
   const newWindow = {
@@ -32,7 +32,8 @@ export function generateWindow(windowResponse) {
 
 export function generateTabs({
   tabs,
-  windowUuid
+  parentUuid,
+  containerType = 'window'
 }) {
   const firstTabTableName = tabs[0].tableName
   const firstTabUuid = tabs[0].uuid
@@ -50,9 +51,9 @@ export function generateTabs({
     // let tab = tabItem
     const tab = {
       ...tabItem,
+      parentUuid,
+      containerType,
       containerUuid: tabItem.uuid,
-      parentUuid: windowUuid,
-      windowUuid,
       tabGroup: tabItem.fieldGroup,
       firstTabUuid,
       // relations

--- a/src/views/ADempiere/WindowView/windowUtils.js
+++ b/src/views/ADempiere/WindowView/windowUtils.js
@@ -32,16 +32,12 @@ export function generateWindow(windowResponse) {
 
 export function generateTabs({
   tabs,
-  parentUuid,
-  containerType = 'window'
+  parentUuid
 }) {
   const firstTabTableName = tabs[0].tableName
   const firstTabUuid = tabs[0].uuid
-  const tabsListParent = []
 
   // indexes related to visualization
-  let tabParentIndex = 0
-
   const tabsList = tabs.filter((itemTab) => {
     return !(
       itemTab.isTranslationTab || itemTab.isSortTab ||
@@ -52,7 +48,6 @@ export function generateTabs({
     const tab = {
       ...tabItem,
       parentUuid,
-      containerType,
       containerUuid: tabItem.uuid,
       tabGroup: tabItem.fieldGroup,
       firstTabUuid,
@@ -64,13 +59,16 @@ export function generateTabs({
       index // this index is not related to the index in which the tabs are displayed
     }
 
-    if (tab.isParentTab) {
-      tab.tabParentIndex = tabParentIndex
-      tabParentIndex++
-      tabsListParent.push(tab)
-      return tab
-    }
     return tab
+  })
+
+  const tabsListParent = tabsList.filter(tabItem => {
+    return tabItem.isParentTab
+  }).map((itemTab, tabParentIndex) => {
+    return {
+      ...itemTab,
+      tabParentIndex
+    }
   })
 
   return {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
Logics related to the vuex store are eliminated in the new redefinition components, leaving metadata management only by properties.


#### Link to minimal reproduction
http://0.0.0.0:9527/#/test/window/standard?tab=0


#### Other relevant information
* Your OS: Linux Mint 19.1 Cinnamon x64. 
* Browser: Mozilla Firefox 88.0.1.
* Node.js version: 14.17.0.
* NPM version: 7.19.0.
* adempiere-vue version: 4.3.1.

