### PR TITLE
commercial people

### DIFF
--- a/src/components/ADempiere/Form/VPOS/Options/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Options/index.vue
@@ -511,7 +511,6 @@ export default {
       createOrder({
         posUuid,
         customerUuid: this.currentOrder.businessPartner.uuid,
-        salesRepresentativeUuid: this.currentOrder.salesRepresentative.uuid,
         warehouseUuid: this.$store.getters.currentWarehouse.uuid
       })
         .then(order => {

--- a/src/store/modules/ADempiere/pointOfSales/order/actions.js
+++ b/src/store/modules/ADempiere/pointOfSales/order/actions.js
@@ -37,13 +37,11 @@ export default {
   createOrder({ commit, dispatch, rootGetters }, {
     posUuid,
     customerUuid,
-    salesRepresentativeUuid,
     documentTypeUuid
   }) {
     return createOrder({
       posUuid,
       customerUuid,
-      salesRepresentativeUuid,
       warehouseUuid: rootGetters.currentWarehouse.uuid,
       documentTypeUuid
     })


### PR DESCRIPTION
When creating a sales order for the point of sale it should take as commercial people who have the user with which you log in.

#### Gif
![cal](https://user-images.githubusercontent.com/45974454/124011835-70817000-d9ae-11eb-9639-4b9270e6a6c9.gif)
