### PR TITLE
Filter fields styling fix

### DIFF
--- a/src/components/ADempiere/Field/index.vue
+++ b/src/components/ADempiere/Field/index.vue
@@ -349,13 +349,6 @@ export default {
   }
 
   /**
-   * Maximum height to avoid distorting the field list
-   */
-  .el-form-item__content {
-    max-height: 36px !important;
-  }
-
-  /**
    * Reduce the spacing between the form element and its label
    */
   .el-form--label-top .el-form-item__label {

--- a/src/components/ADempiere/FilterFields/index.vue
+++ b/src/components/ADempiere/FilterFields/index.vue
@@ -17,7 +17,7 @@
 -->
 
 <template>
-  <el-form :class="cssClass" style="float: right;">
+  <el-form :class="cssClass" :style="styles.form">
     <el-form-item>
       <template v-if="!isEmptyValue(groupField)" slot="label">
         {{ groupField }}
@@ -32,6 +32,7 @@
         value-key="key"
         :size="size"
         :popper-append-to-body="true"
+        :style="styles.select"
       >
         <el-option
           v-for="(item, key) in fieldsListAvailable"
@@ -86,6 +87,16 @@ export default defineComponent({
     const showedAttibute = props.inTable
       ? 'isShowedTableFromUser'
       : 'isShowedFromUser'
+
+    const styles = screen.width < 450
+     ? {
+          form: 'float: right; width: 100%;',
+          select: 'display: block'
+        }
+      :
+       {
+        form: 'float: right;',
+      } 
 
     const isMobile = computed(() => {
       root.$store.state.app.device === 'mobile'
@@ -166,6 +177,7 @@ export default defineComponent({
       size,
       fieldsListShowed,
       fieldsListAvailable,
+      styles,
       // methods
       changeShowed
     }

--- a/src/components/ADempiere/FilterFields/index.vue
+++ b/src/components/ADempiere/FilterFields/index.vue
@@ -187,47 +187,10 @@ export default defineComponent({
 }
 </style>
 <style lang="scss">
-/*
-.form-filter-fields {
-  .el-tag--small {
-    max-width: 132px !important;
+  .el-select-dropdown.is-multiple .el-select-dropdown__item.selected::after {
+    position: static;
+    float: right;
+    margin-left: 5px;
   }
 
-  // text tag
-  .el-tag {
-    &.el-tag--info {
-      &.el-tag--small {
-        &.el-tag--light  {
-          // max-width: calc(100% - 10px);
-          &:first-child {
-            .el-select__tags-text {
-              max-width: calc(100% - 15px);
-            }
-          }
-        }
-      }
-    }
-  }
-  .el-select__tags-text {
-    width: 100%;
-    overflow: hidden !important;
-    white-space: nowrap;
-    text-overflow: ellipsis !important; // ... end text
-    display: inline-block;
-  }
-
-  // icon X close tag
-  .el-select i.el-tag__close {
-    &.el-tag__close {
-      // left: 58%;
-      // margin-top: 0px !important;
-      // top: 0 !important;
-      color: #FFF !important;
-      // position: absolute !important;
-      position: relative !important;
-      top: -7 !important;
-    }
-  }
-}
-*/
 </style>

--- a/src/components/ADempiere/FilterFields/index.vue
+++ b/src/components/ADempiere/FilterFields/index.vue
@@ -89,14 +89,13 @@ export default defineComponent({
       : 'isShowedFromUser'
 
     const styles = screen.width < 450
-     ? {
-          form: 'float: right; width: 100%;',
-          select: 'display: block'
-        }
-      :
-       {
-        form: 'float: right;',
-      } 
+      ? {
+        form: 'float: right; width: 100%;',
+        select: 'display: block'
+      }
+      : {
+        form: 'float: right;'
+      }
 
     const isMobile = computed(() => {
       root.$store.state.app.device === 'mobile'

--- a/src/components/ADempiere/Panel/index.vue
+++ b/src/components/ADempiere/Panel/index.vue
@@ -80,11 +80,6 @@ export default {
 </script>
 
 <style>
-  .select-filter {
-    width: 280px !important;
-    float: right;
-    top: 0;
-  }
   .select-filter-header {
     width: 60% !important;
     float: right;


### PR DESCRIPTION
## Minor style fixes for filter fields select box
#### Steps to reproduce

1. Login
2. Navigate to "Quote to Quote Invoice" -> Sales Orders
3. Click on "Sales Order' menu card
4. See filter field select box on top right corner
   -> Select box is not positioned correctly
   -> Check box on option list layered on top of long names

Behaviour is the same for mobile and desktop

#### Screenshot

- Desktop
<img width="789" alt="Screen Shot 2021-07-01 at 3 52 03 pm" src="https://user-images.githubusercontent.com/54033498/124073126-10a9c880-da85-11eb-8c17-c855e850a9ed.png">

- Mobile
<img width="447" alt="Screen Shot 2021-07-01 at 3 59 22 pm" src="https://user-images.githubusercontent.com/54033498/124073392-5a92ae80-da85-11eb-9e87-748ff5cdd23b.png">

#### Expected behavior
Correct formatting of both issues

- Desktop
<img width="709" alt="Screen Shot 2021-07-01 at 3 52 45 pm" src="https://user-images.githubusercontent.com/54033498/124073174-23bc9880-da85-11eb-9458-0a2d85b7f418.png">

- Mobile
<img width="419" alt="Screen Shot 2021-07-01 at 3 59 32 pm" src="https://user-images.githubusercontent.com/54033498/124073524-62eae980-da85-11eb-823a-64e15f322872.png">

#### Other relevant information
- Your OS: macOS Big Sur 11.4
- Web Browser: Chrome 91.0.4472.114
- Node.js version: 7.14.0
- adempiere-vue version: 4.3.1.

#### Additional context
Add any other context about the problem here.
