### PR TITLE
fix: This is undefined in utils methods.

### DIFF
--- a/src/utils/ADempiere/valueFormat.js
+++ b/src/utils/ADempiere/valueFormat.js
@@ -163,10 +163,10 @@ export function formatDate(date, isTime = false) {
 
 //  Get Formatted Price
 export function formatPrice(number, currency) {
-  if (this.isEmptyValue(number)) {
+  if (isEmptyValue(number)) {
     return undefined
   }
-  if (this.isEmptyValue(currency)) {
+  if (isEmptyValue(currency)) {
     currency = getCurrency()
   }
   //  Get formatted number
@@ -178,7 +178,7 @@ export function formatPrice(number, currency) {
 
 //  Format Quantity
 export function formatQuantity(number) {
-  if (this.isEmptyValue(number)) {
+  if (isEmptyValue(number)) {
     return undefined
   }
   if (!Number.isInteger(number)) {
@@ -190,7 +190,7 @@ export function formatQuantity(number) {
 
 // Format percentage based on Intl library
 export function formatPercent(number) {
-  if (this.isEmptyValue(number)) {
+  if (isEmptyValue(number)) {
     return undefined
   }
   //  Get formatted number


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

The scope of this is not available in the help methods of formatQuantity, formatPercent and formatPrice.

#### Screenshot or Gif

https://user-images.githubusercontent.com/20288327/124845664-304d5f00-df65-11eb-91b9-c4c3f5152312.mp4



#### Other relevant information
* Your OS: Linux Mint 19.1 Cinnamon x64. 
* Browser: Mozilla Firefox 88.0.1.
* Node.js version: 14.17.0.
* NPM version: 7.19.0.
* adempiere-vue version: 4.3.1.

#### Additional context
Output: 
```
The scope of this is not available in the help methods of formatQuantity, formatPercent and formatPrice.
```
