### PR TITLE
fix: Tab name style.

### DIFF
--- a/src/components/ADempiere/ContainerOptions/LockRecord/index.vue
+++ b/src/components/ADempiere/ContainerOptions/LockRecord/index.vue
@@ -20,24 +20,32 @@
   <span v-if="isFirstTab" key="withTooltip">
     <el-tooltip
       v-if="isFirstTab"
-      :content="isLocked ? $t('data.lockRecord') : $t('data.unlockRecord')"
+      :content="tooltipText"
       placement="top"
     >
       <el-button type="text" @click="lockRecord()">
         <i
-          :class="isLocked ? 'el-icon-lock' : 'el-icon-unlock'"
+          :class="{ 'el-icon-lock': isLocked, 'el-icon-unlock': !isLocked }"
           style="font-size: 15px; color: black;"
         />
       </el-button>
     </el-tooltip>
 
-    <span :style="isLocked ? 'color: red;' :'color: #1890ff;'">
+    <slot name="prefix" />
+
+    <span :class="{ 'locked-record': isLocked }">
       {{ tabName }}
     </span>
+
+    <slot name="sufix" />
   </span>
 
   <span v-else key="onlyName">
+    <slot name="prefix" />
+
     {{ tabName }}
+
+    <slot name="sufix" />
   </span>
 </template>
 
@@ -79,6 +87,13 @@ export default defineComponent({
     const isValidUuid = (recordUuid) => {
       return !root.isEmptyValue(recordUuid) && recordUuid !== 'create-new'
     }
+
+    const tooltipText = computed(() => {
+      if (isLocked.value) {
+        return root.$t('data.lockRecord')
+      }
+      return root.$t('data.unlockRecord')
+    })
 
     const lockRecord = () => {
       const action = isLocked.value ? 'unlockRecord' : 'lockRecord'
@@ -168,9 +183,16 @@ export default defineComponent({
       isLocked,
       // computed
       isFirstTab,
+      tooltipText,
       // methods
       lockRecord
     }
   }
 })
 </script>
+
+<style lang="scss">
+.locked-record {
+  color: red !important;
+}
+</style>

--- a/src/components/ADempiere/ContainerOptions/LockRecord/index.vue
+++ b/src/components/ADempiere/ContainerOptions/LockRecord/index.vue
@@ -90,9 +90,9 @@ export default defineComponent({
 
     const tooltipText = computed(() => {
       if (isLocked.value) {
-        return root.$t('data.lockRecord')
+        return root.$t('data.unlockRecord')
       }
-      return root.$t('data.unlockRecord')
+      return root.$t('data.lockRecord')
     })
 
     const lockRecord = () => {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open **Business Partner** window.
2. Select **Vendor** tab.

#### Screenshot or Gif

Before this PR:
![tab-style](https://user-images.githubusercontent.com/20288327/126432621-ee04a095-36fd-4a46-b512-a41a88fa4d3b.png)

After this PR:
![tab-style-fix](https://user-images.githubusercontent.com/20288327/126432642-9b112118-f2ec-4de3-bbf1-2ecdb7e5af2f.png)


#### Expected behavior
You can notice how the first tab, **Business Partner**, is still in blue color implying that it is selected when it is not.

#### Other relevant information
* Your OS: Linux Mint 19.1 Cinnamon x64. 
* Browser: Mozilla Firefox 88.0.1.
* Node.js version: 14.17.0.
* NPM version: 7.19.0.
* adempiere-vue version: 4.3.1.

