### PR TITLE
feat: Improve documentation deploy.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,18 +1,18 @@
 # This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
 # For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
-# This file was contributed by Carlos Parada and Yamel Senih from ERP Consultores y Asociados, C.A
+# This file was contributed by Carlos Parada, Edwin Betancourt and Yamel Senih from ERP Consultores y Asociados, C.A
 
-name: Build Project
+name: Deploy on Github Pages
 
 # Controls when the action will run. 
 on:
   push:
-    branches: [ master, develop ]
-  release:
-    types: [created]
-
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+    branches: 
+      # Push events on master and develop branchs
+      - master
+      - develop
+    paths:
+      - 'docs/**'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -20,33 +20,39 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+
     strategy:
       matrix:
         node-version: [14.x]
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: set -e
-      - run: |
-             cd docs
-             npm i
-             npm run build
-      - run: |
-            cd docs
-            git clone https://github.com/adempiere/adempiere-vue.git --branch gh-pages --single-branch gh-pages
-            cp -r .vuepress/dist/* gh-pages/
-            cd gh-pages
-            touch .nojekyll 
-            git init 
-            git config --local user.email "action@github.com"
-            git config --local user.name "GitHub Action"
-            git add .
-            git commit -m "Update documentation" -a || true
-      - uses: ad-m/github-push-action@master
+
+      - name: Generate static vuepress files
+        run: |
+          cd docs
+          npm i
+          npm run build
+
+      - name: Init new repo in dist folder and commit generated files
+        run: |
+          cd docs/.vuepress/dist
+          touch .nojekyll
+          git init
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add -A
+          git commit -m "docs: ${{ github.event.head_commit.message }}" -a || true
+
+      - name: Force push to destination branch
+        uses: ad-m/github-push-action@v0.6.0
         with:
           branch: gh-pages
-          directory: docs/gh-pages
+          force: true
+          directory: docs/.vuepress/dist
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,6 @@
 # This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
 # For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
-# This file was contributed by Carlos Parada, Edwin Betancourt and Yamel Senih from ERP Consultores y Asociados, C.A
+# This file was contributed by Carlos Parada and Yamel Senih from ERP Consultores y Asociados, C.A
 
 name: Deploy on Github Pages
 
@@ -11,6 +11,7 @@ on:
       # Push events on master and develop branchs
       - master
       - develop
+    # takes only the directory changes
     paths:
       - 'docs/**'
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,11 +20,18 @@ features:
 footer: GNU/GPL v3 Licensed | Copyright © 2019-present ADempiere
 ---
 
+<p align="center">
+  <img width="320" src="https://upload.wikimedia.org/wikipedia/commons/b/b1/Adempiere-logo.png">
+</p>
+
 ## Getting Started
 
 ```bash
 # clone the project
 git clone https://github.com/adempiere/adempiere-vue.git
+
+# be located on the path
+cd adempiere-vue/docs/
 
 # install dependency
 yarn install
@@ -33,6 +40,8 @@ yarn install
 yarn dev
 ```
 
-## Demo
+## Live Preview
 
 [ADempiere UI Demo](https://demo-ui.erpya.com/)
+
+[ADempiere UI Documentation](https://adempiere.github.io/adempiere-vue/)


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

### This change has the following improvements:

- The action name is changed from `Build Project` to `Deploy on Github Pages`.

- Only deploy to the `gh-pages` branch when there is a change inside the `g` directory.

- Removes the section that clones the repository unnecessarily.

- When committing to deploy the documentation place the `docs:` prefix followed by the last commit message.

- Link (https://adempiere.github.io/adempiere-vue/) of the live preview is added in the readme of the documentation.

#### Other relevant information
* Your OS: Linux Mint 19.1 Cinnamon x64. 
* Browser: Mozilla Firefox 88.0.1.
* Node.js version: 14.17.0.
* NPM version: 7.19.0.
* adempiere-vue version: 4.3.1.

#### Additional context
See: https://github.com/EdwinBetanc0urt/adempiere-vue/actions/runs/1058405396

![gh-actions](https://user-images.githubusercontent.com/20288327/126737883-ed452215-7465-4502-bafb-b8af6959ef7c.png)

