### PR TITLE
Intuitive output on the point-of-sale product search panel

### DIFF
--- a/src/components/ADempiere/Form/VPOS/ProductInfo/index.vue
+++ b/src/components/ADempiere/Form/VPOS/ProductInfo/index.vue
@@ -213,8 +213,7 @@ export default {
       // call callback function to return suggestions
       callBack(results)
     },
-    close(a) {
-      console.log('alo', a)
+    close() {
       this.visible = false
     },
     handleSelect(elementSelected) {

--- a/src/components/ADempiere/Form/VPOS/ProductInfo/index.vue
+++ b/src/components/ADempiere/Form/VPOS/ProductInfo/index.vue
@@ -21,10 +21,15 @@
       <template slot="label">
         {{ $t('form.productInfo.codeProduct') }}
         <el-popover
+          v-model="visible"
+          v-shortkey="keyShortcuts"
           placement="right"
           trigger="click"
           width="800"
+          @shortkey.native="close"
         >
+          <el-button icon="el-icon-close" type="text" style="float: right;padding: 1% 1% 0px 0px;font-size: 20px;" @click="close" />
+          <br>
           <product-info-list />
           <el-button
             slot="reference"
@@ -106,6 +111,7 @@ export default {
   },
   data() {
     return {
+      visible: false,
       timeOut: null
     }
   },
@@ -206,6 +212,10 @@ export default {
 
       // call callback function to return suggestions
       callBack(results)
+    },
+    close(a) {
+      console.log('alo', a)
+      this.visible = false
     },
     handleSelect(elementSelected) {
       const valueProduct = this.isEmptyValue(elementSelected.product) ? elementSelected.value : elementSelected.product.value

--- a/src/components/ADempiere/Form/VPOS/ProductInfo/productList.vue
+++ b/src/components/ADempiere/Form/VPOS/ProductInfo/productList.vue
@@ -18,6 +18,7 @@
 <template>
   <el-main
     v-shortkey="shortsKey"
+    style="padding-top: 0px;"
     @shortkey.native="keyAction"
   >
     <el-form


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
Close point-of-sale product search panel
Add an exit button to the point-of-sale product search panel

#### Screenshot or Gif

![Peek 22-07-2021 09-55](https://user-images.githubusercontent.com/45974454/128559329-d4889e53-370a-48a1-bd6b-56c47b4f2a92.gif)


#### Other relevant information
- Your OS: Debian 9
- Web Browser: Chrome
- Node.js version: 18.1.2


#### Additional context
Added a button to exit the point of sale product search panel. 

You can also close the point of sale product search panel by pressing the ( ESC ) key.

#### Issues
FIxes #1022 