### PR TITLE
fix: Releases documentation tag view not fixed.

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -92,13 +92,21 @@ export const constantRoutes = [
     path: '/documentation',
     component: Layout,
     redirect: '/documentation/index',
-    meta: { title: 'documentation', icon: 'documentation', affix: true, breadcrumb: false },
+    meta: {
+      title: 'documentation',
+      icon: 'documentation',
+      breadcrumb: false
+    },
     children: [
       {
         path: 'index',
         component: () => import('@/views/documentation/index'),
         name: 'Documentation',
-        meta: { title: language.t('documentation.releaseNotes'), icon: 'documentation', affix: true, isIndex: true }
+        meta: {
+          title: language.t('documentation.releaseNotes'),
+          icon: 'documentation',
+          isIndex: true
+        }
       }
     ]
   },


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Login.
2. Open Releases Notes in sidebar menu.
3. Close Documentation tag view.

#### Screenshot or Gif

https://user-images.githubusercontent.com/20288327/128945133-f45e72a9-af9d-491f-b94f-518a64c265e8.mp4


#### Other relevant information
* Your OS: Linux Mint 19.1 Cinnamon x64. 
* Browser: Mozilla Firefox 88.0.1.
* Node.js version: 14.17.0.
* NPM version: 7.19.0.
* adempiere-vue version: 4.3.1.

#### Additional context
fixes https://github.com/adempiere/adempiere-vue/issues/1032
