### PR TITLE
Click incremented POS line quantities

### DIFF
--- a/src/components/ADempiere/Field/FieldNumber.vue
+++ b/src/components/ADempiere/Field/FieldNumber.vue
@@ -39,7 +39,6 @@
       :class="cssClassStyle"
       autofocus
       @change="preHandleChange"
-      @blur="customFocusLost"
       @focus="focusGained"
       @keydown.native="keyPressed"
       @keyup.native="keyReleased"

--- a/src/components/ADempiere/Form/VPOS/Order/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Order/index.vue
@@ -62,7 +62,7 @@
                   @command="changeDocumentType"
                 >
                   <span>
-                    <icon class="el-icon-document" />
+                    <el-icon class="el-icon-document" />
                     <b style="cursor: pointer"> {{ currentDocumentType.name }} </b>
                   </span>
                   <el-dropdown-menu slot="dropdown">

--- a/src/components/ADempiere/Form/VPOS/Order/line/fieldsListLine.js
+++ b/src/components/ADempiere/Form/VPOS/Order/line/fieldsListLine.js
@@ -22,6 +22,7 @@ export default [
     overwriteDefinition: {
       size: 24,
       sequence: 8,
+      valueMin: 0,
       handleActionPerformed: true,
       handleContentSelection: true,
       handleFocusGained: true,
@@ -35,6 +36,7 @@ export default [
     overwriteDefinition: {
       size: 24,
       sequence: 9,
+      valueMin: 0,
       handleActionPerformed: true,
       handleContentSelection: true,
       handleActionKeyPerformed: true
@@ -46,6 +48,7 @@ export default [
     isFromDictionary: true,
     overwriteDefinition: {
       size: 24,
+      valueMin: 0,
       sequence: 10,
       handleActionPerformed: true,
       handleContentSelection: true,


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report 
Add functionality to the quantity increment and decrement button
#### Steps to reproduce

1. Open POS, add a product.
2. At the end of the line, click on the Edit button (the green one).
3. Then click this time on the quantity field.
4. Try to increase or decrease the quantity by clicking on the side arrows.

#### Screenshot or Gif

![gif](https://user-images.githubusercontent.com/45974454/129208155-5e0c5d42-9d3e-4685-b47c-65951436566c.gif)

#### Expected behavior
Add functionality to the quantity increment and decrement button and It was also validated that it did not allow to add quantities of products in negatives. 

#### Other relevant information
- Your OS: Debian 9
- Web Browser: Chrome, Safari, Opera
- Node.js version: v10.19.0
- adempiere-vue version: 5.0

#### Issues

Fixes #1035 