### PR TITLE
Improve when creating a business partner location from point of sale

### DIFF
--- a/src/components/ADempiere/Field/FieldLocation/index.vue
+++ b/src/components/ADempiere/Field/FieldLocation/index.vue
@@ -16,28 +16,26 @@
  along with this program.  If not, see <https:www.gnu.org/licenses/>.
 -->
 <template>
-  <div>
-    <el-popover
-      ref="locationAddress"
-      v-model="isShowedLocationForm"
-      :placement="popoverPlacement"
-      width="300"
-      trigger="manual"
-    >
-      <location-address-form
-        v-if="isShowedLocationForm"
-        :values="localValues"
-        :parent-metadata="metadata"
-      />
-    </el-popover>
-    <el-input
-      v-model="displayedValue"
-      readonly
-      @focus="setShowedLocationForm(true)"
-    >
-      <i slot="prefix" class="el-icon-location-information el-input__icon" />
-    </el-input>
-  </div>
+  <el-popover
+    ref="locationAddress"
+    v-model="isShowedLocationForm"
+    placement="left-end"
+    width="300"
+    trigger="manual"
+  >
+    <location-address-form
+      :values="localValues"
+      :parent-metadata="metadata"
+    />
+    <el-button slot="reference" type="text" style="width: -webkit-fill-available;" @click="setShowedLocationForm(true)">
+      <el-input
+        v-model="displayedValue"
+        readonly
+      >
+        <i slot="prefix" class="el-icon-location-information el-input__icon" />
+      </el-input>
+    </el-button>
+  </el-popover>
 </template>
 
 <script>

--- a/src/components/ADempiere/Field/FieldLocation/locationAddressForm.vue
+++ b/src/components/ADempiere/Field/FieldLocation/locationAddressForm.vue
@@ -42,8 +42,7 @@
           style="min-height: calc(50vh - 84px)"
           class="loading-panel"
         />
-
-        <el-col :span="24">
+        <el-col :span="24" style="padding-left: 12px;padding-right: 12px;padding-top: 3%;padding-bottom: 3%;">
           <samp style="float: right; padding-right: 10px;">
             <el-button
               :disabled="!isLoaded"

--- a/src/components/ADempiere/Form/VPOS/BusinessPartner/index.vue
+++ b/src/components/ADempiere/Form/VPOS/BusinessPartner/index.vue
@@ -24,6 +24,7 @@
         placement="right"
         width="400"
         trigger="click"
+        @hide="popoverClose"
       >
         <business-partner-create
           :parent-metadata="parentMetadata"
@@ -402,6 +403,9 @@ export default {
     },
     popoverOpen(value) {
       this.$store.dispatch('changePopover', true)
+    },
+    popoverClose(value) {
+      this.$store.commit('setShowedLocation', false)
     }
   }
 }


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report 
Adjust to the left the panel with the location fields for better visualization when recording the location to the business partner by the point of sale.

#### Steps to reproduce

1. Open the Create Business Partner panel.
2. Add Business Partner address

#### Screenshot or Gif
![gif2](https://user-images.githubusercontent.com/45974454/129226663-2cc76fe8-d3fa-4dfc-94d3-12f53abba225.gif)


#### Other relevant information
- Your OS: Debian 9
- Web Browser: Chrome, Safari, Opera
- Node.js version:  1. Open the Create Business Partner panel.
2. Add Business Partner address
- adempiere-vue version: 5.0

#### Issues
Fixes #1046 