### PR TITLE
Display empty footer

### DIFF
--- a/src/components/ADempiere/Form/VPOS/Order/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Order/index.vue
@@ -311,23 +311,23 @@
               </p>
             </div>
             <span v-if="isMobile" style="float: right;padding-right: 3%;">
-              <p class="total">{{ $t('form.pos.order.order') }}: <b class="order-info">{{ currentOrder.documentNo }}</b></p>
+              <p class="total">{{ $t('form.pos.order.order') }}: <b v-show="!isEmptyValue(currentOrder.uuid)" class="order-info">{{ currentOrder.documentNo }}</b></p>
               <p class="total">
                 {{ $t('form.pos.order.date') }}:
-                <b class="order-info">
+                <b v-show="!isEmptyValue(currentOrder.uuid)" class="order-info">
                   {{ orderDate }}
                 </b>
               </p>
-              <p class="total">{{ $t('form.pos.order.type') }}:<b class="order-info">{{ currentOrder.documentType.name }}</b></p>
+              <p class="total">{{ $t('form.pos.order.type') }}:<b v-show="!isEmptyValue(currentOrder.uuid)" class="order-info">{{ currentOrder.documentType.name }}</b></p>
               <p class="total">
                 {{ $t('form.pos.order.itemQuantity') }}
-                <b class="order-info">
+                <b v-show="!isEmptyValue(currentOrder.uuid)" class="order-info">
                   {{ getItemQuantity }}
                 </b>
               </p>
               <p class="total">
                 {{ $t('form.pos.order.numberLines') }}
-                <b class="order-info">
+                <b v-show="!isEmptyValue(currentOrder.uuid)" class="order-info">
                   {{ numberOfLines }}
                 </b></p>
             </span>
@@ -335,14 +335,14 @@
               <p class="total">{{ $t('form.pos.order.seller') }}:<b style="float: right;">
                 {{ currentOrder.salesRepresentative.name }}
               </b></p>
-              <p class="total"> {{ $t('form.pos.order.subTotal') }}:<b class="order-info">{{ formatPrice(currentOrder.totalLines, pointOfSalesCurrency.iSOCode) }}</b></p>
-              <p class="total"> {{ $t('form.pos.order.discount') }}:<b class="order-info">{{ formatPrice(0, pointOfSalesCurrency.iSOCode) }}</b> </p>
-              <p class="total"> {{ $t('form.pos.order.tax') }}:<b style="float: right;">{{ getOrderTax(pointOfSalesCurrency.iSOCode) }}</b> </p>
+              <p class="total"> {{ $t('form.pos.order.subTotal') }}:<b v-show="!isEmptyValue(currentOrder.uuid)" class="order-info">{{ formatPrice(currentOrder.totalLines, pointOfSalesCurrency.iSOCode) }}</b></p>
+              <p class="total"> {{ $t('form.pos.order.discount') }}:<b v-show="!isEmptyValue(currentOrder.uuid)" class="order-info">{{ formatPrice(0, pointOfSalesCurrency.iSOCode) }}</b> </p>
+              <p class="total"> {{ $t('form.pos.order.tax') }}:<b v-show="!isEmptyValue(currentOrder.uuid)" style="float: right;">{{ getOrderTax(pointOfSalesCurrency.iSOCode) }}</b> </p>
               <p class="total">
                 <b>
                   {{ $t('form.pos.order.total') }}:
                 </b>
-                <b style="float: right;">
+                <b v-show="!isEmptyValue(currentOrder.uuid)" style="float: right;">
                   <el-popover
                     :v-model="seeConversion"
                     placement="top-start"
@@ -364,23 +364,23 @@
               </p>
             </span>
             <span v-if="!isMobile" style="float: right;padding-right: 3%;">
-              <p class="total">{{ $t('form.pos.order.order') }}: <b class="order-info">{{ currentOrder.documentNo }}</b></p>
+              <p class="total">{{ $t('form.pos.order.order') }}: <b v-show="!isEmptyValue(currentOrder.uuid)" class="order-info">{{ currentOrder.documentNo }}</b></p>
               <p class="total">
                 {{ $t('form.pos.order.date') }}:
-                <b class="order-info">
+                <b v-show="!isEmptyValue(currentOrder.uuid)" class="order-info">
                   {{ orderDate }}
                 </b>
               </p>
               <p class="total">{{ $t('form.pos.order.type') }}:<b class="order-info">{{ currentOrder.documentType.name }}</b></p>
               <p class="total">
                 {{ $t('form.pos.order.itemQuantity') }}
-                <b class="order-info">
+                <b v-show="!isEmptyValue(currentOrder.uuid)" class="order-info">
                   {{ getItemQuantity }}
                 </b>
               </p>
               <p class="total">
                 {{ $t('form.pos.order.numberLines') }}
-                <b class="order-info">
+                <b v-show="!isEmptyValue(currentOrder.uuid)" class="order-info">
                   {{ numberOfLines }}
                 </b></p>
             </span>


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report 
Display order footer do not display data if no order is mounted

#### Screenshot or Gif

![Peek 22-07-2021 09-55](https://user-images.githubusercontent.com/45974454/129245887-2da0ca0e-bba0-40f7-95fa-6bfb15d9e3d1.gif)


#### Expected behavior
When you do not see any sales order mounted the footer of the point of sale is empty when loading an order without lines the quantities and price shows 0.

#### Other relevant information
- Your OS: Debian 9
- Web Browser: Chrome, Safari, Opera
- Node.js version: 10.4.0
- adempiere-vue version: 5.0

#### Additional context

Fixes #1038 
