### PR TITLE
feat: Push docker image with commit.

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -7,9 +7,7 @@ on:
   # Triggers the workflow on push events but only for the develop branch
   push:
     branches:
-      - master
       - develop
-      - window-redefinition
 
 jobs:
 

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -1,0 +1,152 @@
+# This workflow will run tests using node and then publish a package to GitHub Container Registry and Docker Hub Regitry when a pushed into main branches
+# This file was contributed by Edwin Betancourt from ERP Consultores y Asociados, C.A
+
+name: Push Main Branches
+
+on:
+  # Triggers the workflow on push events but only for the develop branch
+  push:
+    branches:
+      - master
+      - develop
+      - window-redefinition
+
+jobs:
+
+  # Build dist application ADempiere-Vue
+  build-app:
+    name: Build dist ADempiere-Vue
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Node configuration
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Set tag version into config file
+        run: sed -i "s|releaseNoForDocumentation|${{ github.event.release.tag_name }}|g" config/default.json
+      - name: Install packages
+        run: npm ci
+      - name: Run test
+        run: npm test
+      - name: Compile dist
+        run: npm run build:prod --if-present
+
+      - name: Upload dist app
+        uses: actions/upload-artifact@v2
+        with:
+          name: adempiere-vue
+          path: dist
+
+  # Publish docker image in Github Container Registry to application
+  push-imame-ghcr:
+    name: Push Docker image to GitHub Container
+    needs:
+      - build-app
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Download build dist app
+        uses: actions/download-artifact@v2
+        with:
+          name: adempiere-vue
+          path: dist
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set Lower Case to owner and repository
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >> ${GITHUB_ENV}
+          echo "REPO_LC=${NAME,,}" >> ${GITHUB_ENV}
+        env:
+          OWNER: '${{ github.repository_owner }}'
+          NAME: '${{ github.event.repository.name }}'
+
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-names@v4.8
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build/Dockerfile.prod
+          push: true
+          tags: |
+            ghcr.io/${{ env.OWNER_LC }}/${{ env.REPO_LC }}:${{ steps.branch-name.outputs.current_branch }}
+            ghcr.io/${{ env.OWNER_LC }}/${{ env.REPO_LC }}:${{ github.sha }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
+
+  # Publish docker image in Docker Hub registry to application
+  push-imame-dhr:
+    name: Push Docker image to Docker Hub
+    needs:
+      - build-app
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Download build dist app
+        uses: actions/download-artifact@v2
+        with:
+          name: adempiere-vue
+          path: dist
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          # CONFIGURE DOCKER SECRETS INTO REPOSITORY
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set Lower Case to owner and repository
+        run: |
+          ORG=$OWNER
+          if [ -n "${{ secrets.DOCKERHUB_ORG }}" ]; then
+            echo "Set secret DOCKERHUB_ORG as namespace"
+            ORG=${{ secrets.DOCKERHUB_ORG }}
+          else
+            echo "Set OWNER ($OWNER) as namespace "
+          fi
+          echo "ORG_LC=${ORG,,}" >> ${GITHUB_ENV}
+          echo "OWNER_LC=${OWNER,,}" >> ${GITHUB_ENV}
+          echo "REPO_LC=${NAME,,}" >> ${GITHUB_ENV}
+        env:
+          # to docker image namespace
+          OWNER: '${{ github.repository_owner }}'
+          NAME: '${{ github.event.repository.name }}'
+
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-names@v4.8
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build/Dockerfile.prod
+          push: true
+          tags: |
+            ${{ env.ORG_LC }}/${{ env.REPO_LC }}:${{ steps.branch-name.outputs.current_branch }}
+            ${{ env.ORG_LC }}/${{ env.REPO_LC }}:${{ github.sha }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17884,15 +17884,9 @@
       }
     },
     "vue-loader-v16": {
-<<<<<<< HEAD
-      "version": "npm:vue-loader@16.4.1",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.4.1.tgz",
-      "integrity": "sha512-nL1bDhfMAZgTVmVkOXQaK/WJa9zFDLM9vKHbh5uGv6HeH1TmZrXMWUEVhUrACT38XPhXM4Awtjj25EvhChEgXw==",
-=======
       "version": "npm:vue-loader@16.5.0",
       "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.5.0.tgz",
       "integrity": "sha512-WXh+7AgFxGTgb5QAkQtFeUcHNIEq3PGVQ8WskY5ZiFbWBkOwcCPRs4w/2tVyTbh2q6TVRlO3xfvIukUtjsu62A==",
->>>>>>> develop
       "dev": true,
       "optional": true,
       "requires": {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Push commit into main branches (`master`, `develop`, `window-redefinition`)

When pushing a commit on the main branches a docker image of adempiere-vue is created with the branch tag, in the case of pushing on the develop branch the image with the current changes of that branch would be `adempiere-vue:develop`.

This way you will have docker container images updated with the main branches, without affecting the `latest` one created with the releases.


![docker-develop-gh](https://user-images.githubusercontent.com/20288327/129649901-51aedbc6-9f86-4193-a78f-7b02b8ee218d.png)

![docker-develop-dh](https://user-images.githubusercontent.com/20288327/129650029-19d37a85-85d7-4692-86f8-5ac56dc96694.png)


#### Other relevant information
* Your OS: Linux Mint 19.1 Cinnamon x64. 
* Browser: Mozilla Firefox 88.0.1.
* Node.js version: 14.17.0.
* NPM version: 7.19.0.
* adempiere-vue version: 4.3.1.

#### Additional context
See action https://github.com/EdwinBetanc0urt/adempiere-vue/actions/runs/1137591515

![docker-develop](https://user-images.githubusercontent.com/20288327/129649867-30817853-8e2f-46dc-9297-f3ab4de28730.png)
