### PR TITLE
feat: Add docker image to main branches.

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -1,5 +1,5 @@
 # This workflow will run tests using node and then publish a package to GitHub Container Registry and Docker Hub Regitry when a pushed into main branches
-# This file was contributed by Edwin Betancourt from ERP Consultores y Asociados, C.A
+# This file was contributed by EdwinBetanc0urt@outlook.com from ERP Consultores y Asociados, C.A
 
 name: Push Main Branches
 
@@ -8,6 +8,10 @@ on:
   push:
     branches:
       - develop
+      - master
+      - window-redefinition
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

Generate the docker image of the main branches of the repository by pushing a commit on these branches, ignoring the changes in the documentation folder.

#### Screenshot or Gif

See Docker Hub Registry:

![ad-vue-docker](https://user-images.githubusercontent.com/20288327/129979839-7311ffea-d9b4-4e42-90da-235b74856e63.png)

See GitHub Container Registry:

![gh-docker](https://user-images.githubusercontent.com/20288327/129979961-07fcbb37-1f48-4fc9-844e-74e81c27e914.png)



#### Other relevant information

* Your OS: Linux Mint 19.1 Cinnamon x64. 
* Browser: Mozilla Firefox 88.0.1.
* Node.js version: 14.17.0.
* NPM version: 7.19.0.
* adempiere-vue version: 4.3.1.

