### PR TITLE
fix: Click item menu without relation.

### DIFF
--- a/src/components/ADempiere/ActionMenu/Relations.vue
+++ b/src/components/ADempiere/ActionMenu/Relations.vue
@@ -128,6 +128,11 @@ export default defineComponent({
     }
 
     const clickRelation = (item) => {
+      if (root.isEmptyValue(item)) {
+        // whitout relations
+        return
+      }
+
       let tabParent
       if (item.meta && item.meta.type === 'window') {
         tabParent = 0


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `/test/window/multitab`
2. Show relations.
3. Click in without relations.

#### Screenshot or Gif

Before this PR:
https://user-images.githubusercontent.com/20288327/130000858-52d1cadf-1db4-4ff7-a5ca-4da22910cedf.mp4

After this PR:
https://user-images.githubusercontent.com/20288327/130000758-12d7a3a0-2930-48fa-b741-84128ad1b6d0.mp4


#### Other relevant information
* Your OS: Linux Mint 19.1 Cinnamon x64. 
* Browser: Mozilla Firefox 88.0.1.
* Node.js version: 14.17.0.
* NPM version: 7.19.0.
* adempiere-vue version: 4.3.1.


#### Additional context
Browser console 
```
TypeError: Cannot read property 'meta' of undefined
    at VueComponent.clickRelation (Relations.vue?1c46:132)
    at invokeWithErrorHandling (vue.runtime.esm.js?2b0e:1863)
    at VueComponent.invoker (vue.runtime.esm.js?2b0e:2188)
    at invokeWithErrorHandling (vue.runtime.esm.js?2b0e:1863)
    at VueComponent.Vue.$emit (vue.runtime.esm.js?2b0e:3903)
    at VueComponent.handleMenuItemClick (element-ui.common.js?5c96:2487)
    at invokeWithErrorHandling (vue.runtime.esm.js?2b0e:1863)
    at VueComponent.Vue.$emit (vue.runtime.esm.js?2b0e:3903)
    at VueComponent.dispatch (emitter.js?d010:29)
    at VueComponent.handleClick (element-ui.common.js?5c96:2774)
```
