### PR TITLE
Clear POS cache

### DIFF
--- a/src/layout/components/Navbar.vue
+++ b/src/layout/components/Navbar.vue
@@ -171,6 +171,7 @@ export default {
       this.$store.dispatch('app/toggleSideBar')
     },
     async logout() {
+      this.clearStoreTagsView()
       await this.$store.dispatch('user/logout')
       this.$router.push({
         path: '/login'
@@ -225,6 +226,9 @@ export default {
           break
       }
       return field
+    },
+    clearStoreTagsView() {
+      this.$store.dispatch('clearStorePointOfSales')
     }
   }
 }

--- a/src/layout/components/TagsView/index.vue
+++ b/src/layout/components/TagsView/index.vue
@@ -175,6 +175,7 @@ export default {
       })
     },
     refreshSelectedTag(view) {
+      this.clearStoreTagsView()
       this.$store.dispatch('tagsView/delCachedView', view).then(() => {
         const { fullPath } = view
         this.$nextTick(() => {
@@ -212,6 +213,7 @@ export default {
             })
           }
         }
+        this.clearStoreTagsView()
       })
     },
     closeOthersTags() {
@@ -272,6 +274,9 @@ export default {
     },
     handleScroll() {
       this.closeMenu()
+    },
+    clearStoreTagsView() {
+      this.$store.dispatch('clearStorePointOfSales')
     }
   }
 }

--- a/src/store/modules/ADempiere/pointOfSales/point/actions.js
+++ b/src/store/modules/ADempiere/pointOfSales/point/actions.js
@@ -127,6 +127,10 @@ export default {
         })
       })
   },
+  clearStorePointOfSales({ state }) {
+    console.log(state)
+    state.pointOfSalesList = []
+  },
   listTenderTypesFromServer({ commit }, posUuid) {
     listTenderTypes({
       posUuid


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
The POS form cache will be cleared when you give the option to refresh the tab or close the tab.
#### Screenshot or Gif
![Peek 22-07-2021 09-55](https://user-images.githubusercontent.com/45974454/130150509-3b5b27e1-72e6-41bf-8499-1b78be9eb6ee.gif)

#### Other relevant information
- Your OS: Debian 9
- Web Browser: Chrome
- Node.js version: 10.4.0
- adempiere-vue version: 5.0
