### PR TITLE
Clear Point of Sale Store

### DIFF
--- a/src/components/ADempiere/Form/index.vue
+++ b/src/components/ADempiere/Form/index.vue
@@ -90,6 +90,9 @@ export default {
         })
       }
     }
+  },
+  created() {
+    this.$store.dispatch('clearStorePointOfSales')
   }
 }
 </script>

--- a/src/store/modules/ADempiere/pointOfSales/point/actions.js
+++ b/src/store/modules/ADempiere/pointOfSales/point/actions.js
@@ -127,6 +127,10 @@ export default {
         })
       })
   },
+  clearStorePointOfSales({ state, dispatch }) {
+    state.pointOfSalesList = []
+    dispatch('listPointOfSalesFromServer')
+  },
   listTenderTypesFromServer({ commit }, posUuid) {
     listTenderTypes({
       posUuid


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
Clear Point of Sale Store store when opening or reloading tabs

#### Screenshot or Gif

![Peek 22-07-2021 09-55](https://user-images.githubusercontent.com/45974454/130150509-3b5b27e1-72e6-41bf-8499-1b78be9eb6ee.gif)

#### Expected behavior
The POS form cache will be cleared when you give the option to refresh the tab or close the tab.

#### Other relevant information
- Your OS: Debian 9
- Web Browser: Chrome
- Node.js version: 10.4.0
- adempiere-vue version: 5.0
