### PR TITLE
fix: NPM CI install packages.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@toast-ui/vue-editor": "2.5.1",
-    "@vue/composition-api": "1.1.3",
+    "@vue/composition-api": "1.1.4",
     "axios": "0.21.1",
     "babel-plugin-require-context-hook": "^1.0.0",
     "clipboard": "2.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1967,10 +1967,10 @@
   optionalDependencies:
     prettier "^1.18.2"
 
-"@vue/composition-api@1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-1.1.3.tgz#8fa528c5f68fec47363340fdae7c7fe047ba5e10"
-  integrity sha512-gFcLkHD7SkaoE+i4OhMtv6c/gQeSYxEDDGk4yzF4tZ8h8+7oFNBX8lPUWf9McHGBTcztZNzsIZuwkDVmc0WZlQ==
+"@vue/composition-api@1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-1.1.4.tgz#b4cd566e575350b86c22fa02632e4a356ac2e26e"
+  integrity sha512-f618a79X0VepQUoZofaAYzaherBuzfIIYah4gQPcwmXgN3oeuGdhO7DY2s3Rjcw7r9yTEh5sQIowbNWy6INGjg==
   dependencies:
     tslib "^2.3.0"
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

Inconsistency in checksum of package file after mixing branches


#### Screenshot or Gif
![action-npm-ci](https://user-images.githubusercontent.com/20288327/131602642-5acf83a2-b4ce-4c06-a977-7884c9fe711c.png)


#### Link to minimal reproduction

https://github.com/adempiere/adempiere-vue/runs/3462575342?check_suite_focus=true

#### Other relevant information
* Your OS: Linux Mint 19.1 Cinnamon x64. 
* Browser: Mozilla Firefox 88.0.1.
* Node.js version: 14.17.0.
* NPM version: 7.19.0.
* adempiere-vue version: 4.3.1.

