### PR TITLE
fix: Windows set default values.

### DIFF
--- a/src/components/ADempiere/Panel/mainPanelMixin.js
+++ b/src/components/ADempiere/Panel/mainPanelMixin.js
@@ -19,7 +19,7 @@ import FilterFields from '@/components/ADempiere/FilterFields'
 import { fieldIsDisplayed } from '@/utils/ADempiere/dictionaryUtils.js'
 import { parsedValueComponent } from '@/utils/ADempiere/valueUtils.js'
 import { convertObjectToKeyValue } from '@/utils/ADempiere/valueFormat.js'
-import { LOG_COLUMNS_NAME_LIST } from '@/utils/ADempiere/dataUtils.js'
+import { LOG_COLUMNS_NAME_LIST } from '@/utils/ADempiere/constants/systemColumns'
 
 export default {
   name: 'MainPanelMixin',

--- a/src/components/ADempiere/PanelDefinition/index.vue
+++ b/src/components/ADempiere/PanelDefinition/index.vue
@@ -27,7 +27,6 @@
 
 <script>
 import { defineComponent, computed, ref } from '@vue/composition-api'
-import { generatePanelAndFields } from './panelUtils'
 
 export default defineComponent({
   name: 'PanelDefinition',
@@ -64,14 +63,8 @@ export default defineComponent({
      */
     const getPanel = () => {
       // generated panel properties
-      const panel = generatePanelAndFields({
-        parentUuid: props.parentUuid,
-        containerUuid: props.containerUuid,
-        panelMetadata: props.panelMetadata
-      })
-
       // set panel genereated
-      metadata.value = panel
+      metadata.value = props.panelMetadata
     }
 
     getPanel()

--- a/src/components/ADempiere/PanelDefinition/panelUtils.js
+++ b/src/components/ADempiere/PanelDefinition/panelUtils.js
@@ -1,3 +1,18 @@
+// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { generateField } from '@/utils/ADempiere/dictionaryUtils'
 import { getFieldTemplate } from '@/utils/ADempiere/lookupFactory'
@@ -5,22 +20,20 @@ import { getFieldTemplate } from '@/utils/ADempiere/lookupFactory'
 export function generatePanelAndFields({
   parentUuid,
   containerUuid,
-  panelMetadata: tabMetadata = {}
+  panelMetadata = {}
 }) {
   const fieldAdditionalAttributes = {
     parentUuid,
     containerUuid,
     // tab attributes
-    tabTableName: tabMetadata.tableName,
-    tabQuery: tabMetadata.query,
-    tabWhereClause: tabMetadata.whereClause,
+    tabTableName: panelMetadata.tableName,
     // app attributes
     isShowedFromUser: true,
     isReadOnlyFromForm: false
   }
 
   // convert fields and add app attributes
-  const fieldsList = tabMetadata.fields.map((fieldItem, index) => {
+  const fieldsList = panelMetadata.fields.map((fieldItem, index) => {
     fieldItem = generateField({
       fieldToGenerate: fieldItem,
       moreAttributes: {
@@ -60,7 +73,8 @@ export function generatePanelAndFields({
 
   // panel for save on store
   const panel = {
-    ...tabMetadata,
+    ...panelMetadata,
+    parentUuid,
     containerUuid,
     fieldLinkColumnName,
     fieldsList,

--- a/src/components/ADempiere/RecordNavigation/index.vue
+++ b/src/components/ADempiere/RecordNavigation/index.vue
@@ -33,7 +33,6 @@
 <script>
 import { defineComponent, computed, ref } from '@vue/composition-api'
 
-import { generatePanelAndFields } from '@/components/ADempiere/PanelDefinition/panelUtils'
 import DefaultTable from '@/components/ADempiere/DefaultTable'
 import PanelDefinition from '@/components/ADempiere/PanelDefinition'
 
@@ -87,11 +86,7 @@ export default defineComponent({
     })
 
     const panelMetadata = computed(() => {
-      return generatePanelAndFields({
-        parentUuid: props.parentUuid,
-        containerUuid: props.containerUuid,
-        panelMetadata: props.currentTab
-      })
+      return props.currentTab
     })
     // create the table header
     const tableheaders = computed(() => {

--- a/src/components/ADempiere/TabManager/index.vue
+++ b/src/components/ADempiere/TabManager/index.vue
@@ -66,7 +66,6 @@
         </lock-record>
 
         <!-- records in table to multi records -->
-        <!-- // TODO: remove generatePanelAndFields metho with store -->
         <default-table
           v-if="!isParentTabs"
           v-show="!isParentTabs && isShowMultiRecords"
@@ -76,11 +75,7 @@
           :container-manager="containerManagerTab"
           :header="tableHeaders"
           :data-table="recordsList"
-          :panel-metadata="generatePanelAndFields({
-            parentUuid: parentUuid,
-            containerUuid: tabAttributes.uuid,
-            panelMetadata: tabAttributes
-          })"
+          :panel-metadata="tabAttributes"
         />
         <!-- fields in panel to single record -->
         <panel-definition
@@ -101,7 +96,6 @@
 <script>
 import { defineComponent, computed, ref } from '@vue/composition-api'
 
-import { generatePanelAndFields } from '@/components/ADempiere/PanelDefinition/panelUtils'
 import AuxiliaryPanel from '@/components/ADempiere/AuxiliaryPanel'
 import DefaultTable from '@/components/ADempiere/DefaultTable'
 import LockRecord from '@/components/ADempiere/ContainerOptions/LockRecord'
@@ -187,15 +181,8 @@ export default defineComponent({
     // create the table header
     const tableHeaders = computed(() => {
       const panel = props.tabsList[tabNo]
-      if (panel && panel.fields) {
-        // TODO: Change to stored generated panel
-        const panelGenerated = generatePanelAndFields({
-          parentUuid: props.parentUuid,
-          containerUuid: panel.uuid,
-          panelMetadata: panel
-        })
-        return panelGenerated.fieldsList
-        // panel.fields
+      if (panel && panel.fieldsList) {
+        return panel.fieldsList
       }
       return []
     })
@@ -307,7 +294,6 @@ export default defineComponent({
       isShowRecords,
       tabStyle,
       // methods
-      generatePanelAndFields,
       handleClick,
       openContainer,
       isDisabledTab

--- a/src/store/modules/ADempiere/dataManager.js
+++ b/src/store/modules/ADempiere/dataManager.js
@@ -21,7 +21,6 @@ import {
   createEntity,
   deleteEntity
 } from '@/api/ADempiere/common/persistence'
-import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
 import router from '@/router'
 
 const dataManager = {
@@ -59,12 +58,20 @@ const dataManager = {
     }) {
       return new Promise(resolve => {
         const tab = rootGetters.getStoredTab(parentUuid, containerUuid)
-        if (isEmptyValue(tab)) {
-          resolve()
-          return
-        }
 
         const currentRoute = router.app._route
+        // set action
+        router.push({
+          name: currentRoute.name,
+          params: {
+            ...currentRoute.params
+          },
+          query: {
+            ...currentRoute.query,
+            action: 'create-new'
+          }
+        }, () => {})
+
         const defaultAttributes = rootGetters.getParsedDefaultValues({
           parentUuid,
           containerUuid,
@@ -76,6 +83,8 @@ const dataManager = {
           commit('addChangeToPersistenceQueue', {
             ...attribute,
             containerUuid
+          }, {
+            root: true
           })
         })
 
@@ -84,6 +93,8 @@ const dataManager = {
           containerUuid,
           isOverWriteParent,
           attributes: defaultAttributes
+        }, {
+          root: true
         })
 
         resolve(defaultAttributes)
@@ -91,7 +102,6 @@ const dataManager = {
     },
 
     createEntity({
-      dispatch,
       rootGetters
     }, {
       parentUuid,

--- a/src/store/modules/ADempiere/dictionary/window/actions.js
+++ b/src/store/modules/ADempiere/dictionary/window/actions.js
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { requestWindowMetadata } from '@/api/ADempiere/dictionary/window'
+import { generateWindow } from '@/views/ADempiere/Window/windowUtils'
 
 export default {
   addWindow({ commit }, windowResponse) {
@@ -33,9 +34,10 @@ export default {
         uuid
       })
         .then(async windowResponse => {
-          dispatch('addWindow', windowResponse)
+          const window = generateWindow(windowResponse)
+          dispatch('addWindow', window)
 
-          resolve(windowResponse)
+          resolve(window)
         })
     })
   }

--- a/src/store/modules/ADempiere/dictionary/window/getters.js
+++ b/src/store/modules/ADempiere/dictionary/window/getters.js
@@ -27,11 +27,11 @@ export default {
   },
 
   getStoredTabs: (state) => (windowUuid) => {
-    return state.storedWindows[windowUuid].tabs
+    return state.storedWindows[windowUuid].tabsList
   },
 
   getStoredTab: (state) => (windowUuid, tabUuid) => {
-    return state.storedWindows[windowUuid].tabs.find(tab => {
+    return state.storedWindows[windowUuid].tabsList.find(tab => {
       return tab.uuid === tabUuid
     })
   }

--- a/src/store/modules/ADempiere/panel/getters.js
+++ b/src/store/modules/ADempiere/panel/getters.js
@@ -18,12 +18,14 @@ import {
   isEmptyValue,
   parsedValueComponent
 } from '@/utils/ADempiere/valueUtils.js'
-import { ACCOUNTING_COLUMNS } from '@/utils/ADempiere/constants/systemColumns'
+import {
+  ACCOUNTING_COLUMNS,
+  LOG_COLUMNS_NAME_LIST
+} from '@/utils/ADempiere/constants/systemColumns'
 import {
   fieldIsDisplayed,
   getDefaultValue
 } from '@/utils/ADempiere/dictionaryUtils.js'
-import { LOG_COLUMNS_NAME_LIST } from '@/utils/ADempiere/dataUtils.js'
 
 const getters = {
   getPanel: (state) => (containerUuid) => {

--- a/src/store/modules/ADempiere/persistence.js
+++ b/src/store/modules/ADempiere/persistence.js
@@ -3,7 +3,7 @@ import {
   updateEntity
 } from '@/api/ADempiere/common/persistence.js'
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
-import { LOG_COLUMNS_NAME_LIST } from '@/utils/ADempiere/dataUtils.js'
+import { LOG_COLUMNS_NAME_LIST } from '@/utils/ADempiere/constants/systemColumns'
 import language from '@/lang'
 import { showMessage } from '@/utils/ADempiere/notification.js'
 

--- a/src/utils/ADempiere/constants/systemColumns.js
+++ b/src/utils/ADempiere/constants/systemColumns.js
@@ -24,6 +24,45 @@ export const PROCESSING = 'Processing'
 
 export const PROCESSED = 'Processed'
 
+/**
+ * Log columns list into table
+ * Manages with user session
+ */
+export const LOG_COLUMNS_NAME_LIST = [
+  'Created',
+  'CreatedBy',
+  'Updated',
+  'UpdatedBy'
+]
+
+/**
+ * Columns list into standard table
+ */
+export const STANDARD_COLUMNS_NAME_LIST = [
+  ...LOG_COLUMNS_NAME_LIST,
+  // Table Name '_ID'
+  CLIENT,
+  ORGANIZATION,
+  ACTIVE,
+  'UUID'
+]
+
+/**
+ * Columns list into document table
+ */
+export const DOCUMENT_COLUMNS_NAME_LIST = [
+  ...STANDARD_COLUMNS_NAME_LIST,
+  'C_DocType_ID',
+  'DateDoc',
+  'Description',
+  'DocAction',
+  'DocStatus',
+  'DocumentNo',
+  'IsApproved',
+  PROCESSED,
+  PROCESSING
+]
+
 export const ACCOUNTING_COLUMNS = [
   'C_AcctSchema_ID',
   'C_Currency_ID',

--- a/src/utils/ADempiere/dataUtils.js
+++ b/src/utils/ADempiere/dataUtils.js
@@ -1,6 +1,6 @@
 // ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
 // Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
-// Contributor(s): Edwin Betancourt edwinBetanc0urt@hotmail.com www.erpya.com
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
@@ -206,43 +206,4 @@ export const FIELD_OPERATORS_LIST = [
   OPERATORS_FIELD_TEXT_LONG,
   OPERATORS_FIELD_TIME,
   OPERATORS_FIELD_YES_NO
-]
-
-/**
- * Log columns list into table
- * Manages with user session
- */
-export const LOG_COLUMNS_NAME_LIST = [
-  'Created',
-  'CreatedBy',
-  'Updated',
-  'UpdatedBy'
-]
-
-/**
- * Columns list into standard table
- */
-export const STANDARD_COLUMNS_NAME_LIST = [
-  ...LOG_COLUMNS_NAME_LIST,
-  // Table Name '_ID'
-  'AD_Client_ID',
-  'AD_Org_ID',
-  'IsActive',
-  'UUID'
-]
-
-/**
- * Columns list into document table
- */
-export const DOCUMENT_COLUMNS_NAME_LIST = [
-  ...STANDARD_COLUMNS_NAME_LIST,
-  'C_DocType_ID',
-  'DateDoc',
-  'Description',
-  'DocAction',
-  'DocStatus',
-  'DocumentNo',
-  'IsApproved',
-  'Processed',
-  'Processing'
 ]

--- a/src/views/ADempiere/Window/index.vue
+++ b/src/views/ADempiere/Window/index.vue
@@ -41,7 +41,7 @@ import { defineComponent, computed, ref } from '@vue/composition-api'
 import LoadingView from '@/components/ADempiere/LoadingView'
 
 import { convertWindow } from '@/utils/ADempiere/apiConverts/dictionary.js'
-import { generateWindow as generateWindowDictionary } from './windowUtils'
+import { generateWindow } from './windowUtils'
 import { BUTTON } from '@/utils/ADempiere/references'
 
 export default defineComponent({
@@ -169,16 +169,16 @@ export default defineComponent({
       return root.$store.getters.getStoredWindow(windowUuid)
     })
 
-    const generateWindow = (window) => {
+    function setLoadWindow(window) {
       windowMetadata.value = window
       isLoaded.value = true
     }
 
     // get window from vuex store or request from server
-    const getWindow = () => {
+    function getWindow() {
       let window = storedWindow.value
       if (!root.isEmptyValue(window)) {
-        generateWindow(window)
+        setLoadWindow(window)
         return
       }
       // metadata props use for test
@@ -186,13 +186,13 @@ export default defineComponent({
         // from server response
         window = convertWindow(props.metadata)
         // add apps properties
-        window = generateWindowDictionary(window)
+        window = generateWindow(window)
         // add into store
         return root.$store.dispatch('addWindow', window)
           .then(windowResponse => {
             // to obtain the load effect
             setTimeout(() => {
-              generateWindow(windowResponse)
+              setLoadWindow(windowResponse)
             }, 1000)
           })
       }
@@ -201,8 +201,7 @@ export default defineComponent({
       })
         .then(windowResponse => {
           // add apps properties
-          window = generateWindowDictionary(windowResponse)
-          generateWindow(window)
+          setLoadWindow(windowResponse)
         })
     }
 

--- a/src/views/ADempiere/Window/windowUtils.js
+++ b/src/views/ADempiere/Window/windowUtils.js
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import { generatePanelAndFields } from '@/components/ADempiere/PanelDefinition/panelUtils'
+
 export function generateWindow(responseWindow) {
   const {
     tabsList, tabsListParent, tabsListChild,
@@ -70,10 +72,14 @@ export function generateTabs({
       isParentTab: Boolean(firstTabTableName === tabItem.tableName),
       // app properties
       isShowedRecordNavigation: !(tabItem.isSingleRow),
-      isLoadFieldsList: false,
       index // this index is not related to the index in which the tabs are displayed
     }
-    return tab
+
+    return generatePanelAndFields({
+      parentUuid,
+      containerUuid: tabItem.uuid,
+      panelMetadata: tab
+    })
   })
 
   const tabsListParent = tabsList.filter(tabItem => {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open any window.
2. Select in menu action `New Record`.

#### Screenshot or Gif

Before this PR:

https://user-images.githubusercontent.com/20288327/133007287-5cdcc296-be09-462a-8ed9-ce28451143ba.mp4

After this PR:

https://user-images.githubusercontent.com/20288327/133007313-8cd9249e-7172-443c-80f7-66851c3a139c.mp4


#### Expected behavior

Clicking on new record is expected to set the default values in the fields, however it keeps the old values.

#### Other relevant information
* Your OS: Linux Mint 19.1 Cinnamon x64. 
* Browser: Mozilla Firefox 88.0.1.
* Node.js version: 14.17.0.
* NPM version: 7.19.0.
* adempiere-vue version: 4.3.1.

#### Additional context
The service to obtain entities does not return the display value in the lookup type fields.

