### PR TITLE
Validate that a Business Partner cannot be modified after collections have been recorded

### DIFF
--- a/src/components/ADempiere/Form/VPOS/BusinessPartner/businessPartnerUpdate.vue
+++ b/src/components/ADempiere/Form/VPOS/BusinessPartner/businessPartnerUpdate.vue
@@ -132,7 +132,11 @@ export default {
       return this.$store.getters.posAttributes.currentPointOfSales.currentOrder.businessPartner
     },
     isTemplateOfCustomer() {
-      return this.$store.getters.posAttributes.currentPointOfSales.currentOrder.businessPartner.id === this.$store.getters.posAttributes.currentPointOfSales.templateBusinessPartner.id
+      const currentOrder = this.$store.getters.posAttributes.currentPointOfSales.currentOrder
+      if (!this.isEmptyValue(currentOrder.listPayments.payments)) {
+        return !this.isEmptyValue(currentOrder.listPayments.payments)
+      }
+      return currentOrder.businessPartner.id === this.$store.getters.posAttributes.currentPointOfSales.templateBusinessPartner.id
     },
     showCustomer() {
       return this.$store.getters.getShowUpdateCustomer


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
It is required that the business partners cannot be modified after having registered the collections.

It is required that the business partner field be set as not updateable after recording the collections, if it is necessary to change business partners, the first payment records must be deleted, the business partner must be changed and then the collections must be recorded again.

#### Screenshot or Gif
![Peek 13-09-2021 14-18](https://user-images.githubusercontent.com/45974454/133136140-2ee20893-e4f1-45c1-89e5-f00dd1f53761.gif)
