### PR TITLE
Process order without completing the return process

### DIFF
--- a/src/components/ADempiere/Form/VPOS/Collection/overdrawnInvoice/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Collection/overdrawnInvoice/index.vue
@@ -708,9 +708,10 @@ export default {
           } else {
             this.$store.dispatch('sendCreateCustomerAccount', this.$store.getters.getAddRefund)
               .then(response => {
-                this.completePreparedOrder(posUuid, orderUuid, payments)
+                if (response.type === 'success') {
+                  this.completePreparedOrder(posUuid, orderUuid, payments)
+                }
               })
-            this.completePreparedOrder(posUuid, orderUuid, payments)
             this.$store.commit('dialogoInvoce', { show: false, success: true })
           }
           break

--- a/src/components/ADempiere/Form/VPOS/posMixin.js
+++ b/src/components/ADempiere/Form/VPOS/posMixin.js
@@ -331,7 +331,9 @@ export default {
               case 1:
                 this.$store.dispatch('sendCreateCustomerAccount', this.$store.getters.getAddRefund)
                   .then(response => {
-                    this.refundAllowed(action.posUuid, action.orderUuid, action.payments)
+                    if (response.type === 'success') {
+                      this.refundAllowed(action.posUuid, action.orderUuid, action.payments)
+                    }
                   })
                 break
               case 3:

--- a/src/store/modules/ADempiere/pointOfSales/payments/actions.js
+++ b/src/store/modules/ADempiere/pointOfSales/payments/actions.js
@@ -400,7 +400,10 @@ export default {
       .then(response => {
         const orderUuid = response.orderUuid
         dispatch('listPayments', { orderUuid })
-        return response
+        return {
+          ...response,
+          type: 'success'
+        }
       })
       .catch(error => {
         console.warn(`ListPaymentsFromServer: ${error.message}. Code: ${error.code}.`)
@@ -409,7 +412,7 @@ export default {
           message: error.message,
           showClose: true
         })
-        return
+        return { type: 'error' }
       })
   },
   /**


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
validate that you first add the return and then process the order

#### Screenshot or Gif
#### Before Pull Request
![Peek 15-09-2021 16-22](https://user-images.githubusercontent.com/45974454/133504985-aa204417-0e45-4dd5-aa6c-020a5a6993ee.gif)
#### After Pull Request
![ssucces](https://user-images.githubusercontent.com/45974454/133505098-e443528a-393a-4c79-a607-2855c77d0328.gif)

#### Issues

Fixes #1172 
