### PR TITLE
Indicate when you are loading the order history

### DIFF
--- a/src/components/ADempiere/Form/VPOS/OrderList/index.vue
+++ b/src/components/ADempiere/Form/VPOS/OrderList/index.vue
@@ -296,6 +296,7 @@ export default {
           clearTimeout(this.timeOut)
           this.isLoadRecord = true
           this.timeOut = setTimeout(() => {
+            this.$store.dispatch('setOrdersListPageNumber', 1)
             this.loadOrdersList()
           }, 2000)
         }

--- a/src/components/ADempiere/Form/VPOS/OrderList/index.vue
+++ b/src/components/ADempiere/Form/VPOS/OrderList/index.vue
@@ -55,7 +55,7 @@
     <el-table
       ref="orderTable"
       v-shortkey="shortsKey"
-      v-loading="!ordersList.isLoaded"
+      v-loading="!ordersList.isLoaded || isLoadRecord"
       :data="sortTableOrderList"
       border
       fit
@@ -168,6 +168,7 @@ export default {
       defaultMaxPagination: 50,
       fieldsList: fieldsListOrders,
       metadataList: [],
+      isLoadRecord: false,
       isCustomForm: true,
       activeAccordion: 'query-criteria',
       timeOut: null
@@ -221,6 +222,9 @@ export default {
       if (value && this.isEmptyValue(this.metadataList)) {
         this.setFieldsList()
       }
+    },
+    sortTableOrderList(value) {
+      this.isLoadRecord = false
     }
   },
   created() {
@@ -248,6 +252,7 @@ export default {
       }
     },
     loadOrdersList() {
+      this.isLoadRecord = true
       const point = this.$store.getters.posAttributes.currentPointOfSales.uuid
       if (!this.isEmptyValue(point)) {
         this.$store.dispatch('listOrdersFromServer', {
@@ -289,6 +294,7 @@ export default {
           !mutation.payload.columnName.includes('_UUID') &&
           mutation.payload.containerUuid === this.metadata.containerUuid) {
           clearTimeout(this.timeOut)
+          this.isLoadRecord = true
           this.timeOut = setTimeout(() => {
             this.loadOrdersList()
           }, 2000)

--- a/src/store/modules/ADempiere/pointOfSales/order/actions.js
+++ b/src/store/modules/ADempiere/pointOfSales/order/actions.js
@@ -259,11 +259,11 @@ export default {
       })
       .catch(error => {
         console.warn(`listOrdersFromServer: ${error.message}. Code: ${error.code}.`)
-        // showMessage({
-        //   type: 'info',
-        //   message: error.message,
-        //   showClose: true
-        // })
+        showMessage({
+          type: 'info',
+          message: error.message,
+          showClose: true
+        })
       })
   },
   setOrder({ commit, dispatch }, order) {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
Indicate when the order history is loaded and when changing parameters search from page 0

#### Screenshot or Gif
![history](https://user-images.githubusercontent.com/45974454/133508588-027c0b3f-124a-4acb-b124-a3f71e0e0622.gif)
