### PR TITLE
fix: References loading indefinitely.

### DIFF
--- a/src/components/ADempiere/ActionMenu/References.vue
+++ b/src/components/ADempiere/ActionMenu/References.vue
@@ -95,7 +95,7 @@ export default defineComponent({
       parentUuid
     } = parent._props
     const {
-      tableName
+      getTableName
     } = props.referencesManager
 
     const isLoadedReferences = ref(false)
@@ -111,6 +111,7 @@ export default defineComponent({
         recordUuid.value !== 'create-new'
     })
 
+    // is container manage references
     const isReferecesContent = computed(() => {
       if (!root.isEmptyValue(props.referencesManager) && isWithRecord.value) {
         return true
@@ -127,6 +128,7 @@ export default defineComponent({
       if (isReferecesContent.value) {
         return root.$store.getters.getStoredReferences({
           windowUuid: parentUuid,
+          tableName: getTableName(),
           recordUuid: recordUuid.value
         })
       }
@@ -154,10 +156,6 @@ export default defineComponent({
     }
 
     const getReferences = () => {
-      if (!isReferecesContent.value) {
-        return
-      }
-
       const references = getterReferences.value
       if (!root.isEmptyValue(references)) {
         referencesList.value = references.referencesList
@@ -167,24 +165,28 @@ export default defineComponent({
 
         root.$store.dispatch('getReferencesFromServer', {
           parentUuid,
-          tableName,
+          tableName: getTableName(),
           recordUuid: recordUuid.value
         })
           .then(responseReferences => {
             referencesList.value = responseReferences.referencesList
           })
+          // handle error in store
+          .catch(() => {})
           .finally(() => {
             isLoadedReferences.value = true
           })
       }
     }
 
-    // when change record uuid loaded references
-    watch(recordUuid, () => {
-      getReferences()
-    })
+    if (isReferecesContent.value) {
+      // when change record uuid loaded references
+      watch(recordUuid, () => {
+        getReferences()
+      })
 
-    getReferences()
+      getReferences()
+    }
 
     return {
       referencesList,

--- a/src/store/modules/ADempiere/dictionary/window/getters.js
+++ b/src/store/modules/ADempiere/dictionary/window/getters.js
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
+
 /**
  * Dictionary Window Getters
  */
@@ -34,5 +36,13 @@ export default {
     return state.storedWindows[windowUuid].tabsList.find(tab => {
       return tab.uuid === tabUuid
     })
+  },
+
+  getTableName: (state, getters) => (windowUuid, tabUuid) => {
+    const tab = getters.getStoredTab(windowUuid, tabUuid)
+    if (!isEmptyValue(tab)) {
+      return tab.tableName
+    }
+    return undefined
   }
 }

--- a/src/store/modules/ADempiere/references.js
+++ b/src/store/modules/ADempiere/references.js
@@ -14,16 +14,20 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import Vue from 'vue'
 import { requestReferencesList } from '@/api/ADempiere/window'
 
 const references = {
   state: {
-    storedReferences: []
+    storedReferences: {}
   },
 
   mutations: {
     addReferencesList(state, payload) {
-      state.storedReferences.push(payload)
+      const { windowUuid, tableName, recordUuid } = payload
+      const key = windowUuid + '_' + tableName + '_' + recordUuid
+
+      Vue.set(state.storedReferences, key, payload)
     }
   },
 
@@ -39,7 +43,7 @@ const references = {
       tableName,
       recordUuid
     }) {
-      return new Promise(resolve => {
+      return new Promise((resolve, reject) => {
         requestReferencesList({
           windowUuid: parentUuid,
           tableName,
@@ -59,6 +63,7 @@ const references = {
           })
           .catch(error => {
             console.warn(`References Load Error ${error.code}: ${error.message}.`)
+            reject(error)
           })
       })
     }
@@ -70,11 +75,9 @@ const references = {
       tableName,
       recordUuid
     }) => {
-      return state.storedReferences.find(item => {
-        return item.windowUuid === windowUuid &&
-          item.tableName === tableName &&
-          item.recordUuid === recordUuid
-      })
+      const key = windowUuid + '_' + tableName + '_' + recordUuid
+
+      return state.storedReferences[key]
     }
   }
 }

--- a/src/views/ADempiere/Window/MultiTabWindow.vue
+++ b/src/views/ADempiere/Window/MultiTabWindow.vue
@@ -137,8 +137,11 @@ export default defineComponent({
     })
 
     const referencesManager = ref({
-      tableName: (tableName) => {
-        return tableName
+      getTableName: () => {
+        const tabUuid = props.windowMetadata.currentTabUuid
+        const windowUuid = props.windowMetadata.uuid
+
+        return root.$store.getters.getTableName(windowUuid, tabUuid)
       }
     })
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Login.
2. Open any window.

#### Screenshot or Gif
Before this pull request:

https://user-images.githubusercontent.com/20288327/133542245-9bc12a12-2ed3-4169-a674-d84aefdf00fa.mp4

After this pull request:

https://user-images.githubusercontent.com/20288327/133542303-dbf46c77-357c-44c7-82fe-9e22e0d70643.mp4

#### Expected behavior
It is expected that once the record is set in the window and the load request is made for the references, and regardless of whether or not there are references in the result, the loading icon on the references will stop.

#### Other relevant information
* Your OS: Linux Mint 19.1 Cinnamon x64. 
* Browser: Mozilla Firefox 88.0.1.
* Node.js version: 14.17.0.
* NPM version: 7.19.0.
* adempiere-vue version: 4.3.1.

#### Additional context
If it is a new record, the references menu remains disabled. 
