### PR TITLE
Remove ID column from the business partner table

### DIFF
--- a/src/components/ADempiere/Form/VPOS/BusinessPartner/businessPartnersList.vue
+++ b/src/components/ADempiere/Form/VPOS/BusinessPartner/businessPartnersList.vue
@@ -60,11 +60,6 @@
         width="100"
       />
       <el-table-column
-        :label="$t('form.productInfo.id')"
-        prop="id"
-        width="90"
-      />
-      <el-table-column
         prop="name"
         :label="$t('form.productInfo.name')"
       />

--- a/src/components/ADempiere/Form/VPOS/BusinessPartner/businessPartnersList.vue
+++ b/src/components/ADempiere/Form/VPOS/BusinessPartner/businessPartnersList.vue
@@ -191,7 +191,10 @@ export default {
             containerUuid: mutation.payload.containerUuid,
             format: 'object'
           })
-          this.searchBPartnerList(values)
+          clearTimeout(this.timeOut)
+          this.timeOut = setTimeout(() => {
+            this.searchBPartnerList(values)
+          }, 1000)
         }
       })
     },


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
Remove the ID column from the business partner table and add a timeout when searching for a business partner.

#### Screenshot or Gif
![Screenshot_20210916_154310](https://user-images.githubusercontent.com/45974454/133675905-c561a5ee-aed9-4b36-aab1-b5c7cf694456.png)
