### PR TITLE
Current payment currency

### DIFF
--- a/src/components/ADempiere/Form/VPOS/Collection/typeCollection.vue
+++ b/src/components/ADempiere/Form/VPOS/Collection/typeCollection.vue
@@ -281,11 +281,11 @@ export default {
       return ''
     },
     iSOCode(value) {
-      const currencyPay = this.convertionsList.find(currency => !this.isEmptyValue(currency.currencyTo) && currency.currencyTo.uuid === value.currencyUuid)
+      const currencyPay = this.listCurrency.find(currency => currency.uuid === value.currencyUuid)
       if (!currencyPay) {
         return ''
       }
-      return currencyPay.currencyTo.iSOCode
+      return currencyPay.iso_code
     },
     amountConvertion(value) {
       const currencyPay = this.convertionsList.find(currency => !this.isEmptyValue(currency.currencyTo) && currency.currencyTo.uuid === value.currencyUuid)


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Feature
Current payment currency
#### Steps to reproduce

1. Go to POS Order
2. Select a product that has tax
3. Modify the quantity
4. Look at the error: You will see that in the tax column you keep the tax of 1 unit.

#### Screenshot or Gif
![Screenshot_20210920_171808](https://user-images.githubusercontent.com/45974454/134235915-33f5fe16-33ae-4219-9529-e73623234432.png)
