### PR TITLE
Amount of tax per line

### DIFF
--- a/src/components/ADempiere/Form/VPOS/Order/orderLineMixin.js
+++ b/src/components/ADempiere/Form/VPOS/Order/orderLineMixin.js
@@ -276,9 +276,9 @@ export default {
       } else if (columnName === 'ConvertedAmount') {
         return this.formatPrice(row.grandTotal / this.totalAmountConverted, this.currentPointOfSales.displayCurrency.iso_code)
       } else if (columnName === 'DiscountTotal') {
-        return this.formatPrice(row.priceList * (row.discountRate / 100), currency)
+        return this.formatPrice((row.priceList * row.quantityOrdered) * (row.discountRate / 100), currency)
       } else if (columnName === 'DisplayTaxAmount') {
-        return this.formatPrice((row.priceActual * row.taxRate.rate / 100), currency)
+        return this.formatPrice((row.grandTotal * row.taxRate.rate / 100), currency)
       }
     },
     productPrice(price, discount) {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
Amount of tax per line
#### Steps to reproduce

1. Go to POS Order
2. Select a product that has tax
3. Modify the quantity

#### Screenshot or Gif
![Peek 21-09-2021 14-20](https://user-images.githubusercontent.com/45974454/134239346-7c7e7098-d5f2-4d29-aaf0-806875d053b0.gif)
