### PR TITLE
fix: Show records panel only in the corresponding tab.

### DIFF
--- a/src/components/ADempiere/AuxiliaryPanel/index.vue
+++ b/src/components/ADempiere/AuxiliaryPanel/index.vue
@@ -17,14 +17,24 @@
 -->
 
 <template>
-  <div class="container-main">
+  <el-main
+    v-shortkey="shorcutKeys"
+    class="container-main"
+    @shortkey.native="keyAction"
+  >
     <el-row :gutter="12" style="height: 100% !important;">
       <transition name="slide-fade" style="height: 100% !important;">
         <el-col :span="10" class="container-main" :style="fullscreen ? {width: 100 + '%'} : ''">
           <el-card class="table">
             <div slot="header">
               {{ label }}
-              <el-button type="text" icon="el-icon-close" style="float: right;padding: 3px 0px;font-size: 22px;padding-left: 5px;" @click="closeContainer" />
+
+              <el-button
+                type="text"
+                icon="el-icon-close"
+                style="float: right;padding: 3px 0px;font-size: 22px;padding-left: 5px;"
+                @click="closeContainer"
+              />
               <el-button
                 type="text"
                 style="float: right; font-size: 18px; padding: 3px 0"
@@ -33,20 +43,31 @@
                 <svg-icon :icon-class="!fullscreen ? 'fullscreen' : 'exit-fullscreen'" />
               </el-button>
             </div>
+
             <slot />
+
           </el-card>
         </el-col>
       </transition>
     </el-row>
-  </div>
+  </el-main>
 </template>
 
 <script>
-import { defineComponent, ref } from '@vue/composition-api'
+import { defineComponent, computed, ref } from '@vue/composition-api'
 
 export default defineComponent({
   name: 'AuxiliaryPanel',
+
   props: {
+    parentUuid: {
+      type: String,
+      default: undefined
+    },
+    containerUuid: {
+      type: String,
+      required: true
+    },
     // Container Title or Description
     label: {
       type: String,
@@ -61,9 +82,30 @@ export default defineComponent({
 
   setup(props, { root }) {
     const fullscreen = ref(false)
-    const closeContainer = () => {
-      root.$store.commit('setExternalContainer', false)
+
+    const shorcutKeys = computed(() => {
+      return {
+        closePanel: ['esc']
+      }
+    })
+
+    function keyAction(event) {
+      switch (event.srcKey) {
+        case 'closePanel':
+          closeContainer()
+          break
+      }
     }
+
+    function closeContainer() {
+      root.$store.dispatch('changeTabAttribute', {
+        parentUuid: props.parentUuid,
+        containerUuid: props.containerUuid,
+        attributeName: 'isShowedTableRecords',
+        attributeValue: false
+      })
+    }
+
     const percent = (position) => {
       if (position) {
         return '0%'
@@ -73,8 +115,11 @@ export default defineComponent({
 
     return {
       fullscreen,
-      // methodo
+      // computeds
+      shorcutKeys,
+      // methods
       closeContainer,
+      keyAction,
       percent
     }
   }

--- a/src/components/ADempiere/PanelDefinition/panelUtils.js
+++ b/src/components/ADempiere/PanelDefinition/panelUtils.js
@@ -80,6 +80,7 @@ export function generatePanelAndFields({
     fieldsList,
     // app attributes
     isLoadedFieldsList: true,
+    isShowedTableRecords: false,
     isShowedTotals: false
   }
 

--- a/src/components/ADempiere/TabManager/index.vue
+++ b/src/components/ADempiere/TabManager/index.vue
@@ -20,6 +20,8 @@
   <div style="height: 100% !important;">
     <auxiliary-panel
       v-if="isShowRecords"
+      :parent-uuid="parentUuid"
+      :container-uuid="tabUuid"
       :label="tabsList[currentTab].name"
     >
       <record-navigation
@@ -152,8 +154,14 @@ export default defineComponent({
       }
     })
 
+    // use getter to reactive properties
+    const currentTabMetadata = computed(() => {
+      // return props.tabsList[currentTab.value]
+      return root.$store.getters.getCurrentTab(props.parentUuid)
+    })
+
     const isShowRecords = computed(() => {
-      return root.$store.getters.getExternalContainer
+      return currentTabMetadata.value.isShowedTableRecords
     })
 
     const isShowMultiRecords = ref(true)
@@ -279,8 +287,12 @@ export default defineComponent({
 
     const openContainer = () => {
       if (props.isParentTabs) {
-        // TODO: Add tab manager store
-        root.$store.commit('setExternalContainer', true)
+        root.$store.dispatch('changeTabAttribute', {
+          parentUuid: props.parentUuid,
+          containerUuid: tabUuid.value,
+          attributeName: 'isShowedTableRecords',
+          attributeValue: true
+        })
         return
       }
       isShowMultiRecords.value = !isShowMultiRecords.value

--- a/src/components/ADempiere/TabManager/index.vue
+++ b/src/components/ADempiere/TabManager/index.vue
@@ -166,8 +166,12 @@ export default defineComponent({
       return key > 0 && isCreateNew.value
     }
 
-    const setCurrentTab = () => {
-      // TODO: Add store current tab
+    function setCurrentTab() {
+      console.info(props.tabsList[currentTab.value])
+      root.$store.commit('setCurrentTab', {
+        parentUuid: props.parentUuid,
+        tab: props.tabsList[currentTab.value]
+      })
     }
 
     const containerManagerTab = computed(() => {
@@ -192,11 +196,14 @@ export default defineComponent({
      */
     const handleClick = (tabHTML) => {
       const { tabuuid, tabindex } = tabHTML.$attrs
+
+      setTabNumber(tabindex)
+
+      // set metadata tab
       if (tabUuid.value !== tabuuid) {
         tabUuid.value = tabuuid
         setCurrentTab()
       }
-      setTabNumber(tabindex)
     }
 
     const setTabNumber = (tabNumber = '0') => {

--- a/src/store/modules/ADempiere/dictionary/window/actions.js
+++ b/src/store/modules/ADempiere/dictionary/window/actions.js
@@ -40,5 +40,37 @@ export default {
           resolve(window)
         })
     })
+  },
+
+  changeTabAttribute({ commit, getters }, {
+    parentUuid,
+    containerUuid,
+    attributeName,
+    attributeNameControl,
+    attributeValue
+  }) {
+    const tab = getters.getStoredTab(parentUuid, containerUuid)
+
+    commit('changeTabAttribute', {
+      tab,
+      attributeName,
+      attributeValue,
+      attributeNameControl
+    })
+
+    // set value into current tab
+    const currentTab = getters.getCurrentTab(parentUuid)
+    if (currentTab.uuid === containerUuid) {
+      // commit('changeTabAttribute', {
+      //   tab: currentTab,
+      //   attributeName,
+      //   attributeValue
+      // })
+      commit('changeWindowAttribute', {
+        uuid: parentUuid,
+        attributeName: 'currentTab',
+        attributeValue: tab
+      })
+    }
   }
 }

--- a/src/store/modules/ADempiere/dictionary/window/getters.js
+++ b/src/store/modules/ADempiere/dictionary/window/getters.js
@@ -44,5 +44,11 @@ export default {
       return tab.tableName
     }
     return undefined
+  },
+
+  getCurrentTab: (state, getters) => (windowUuid) => {
+    const window = getters.getStoredWindow(windowUuid)
+
+    return window.currentTab
   }
 }

--- a/src/store/modules/ADempiere/dictionary/window/mutations.js
+++ b/src/store/modules/ADempiere/dictionary/window/mutations.js
@@ -37,6 +37,17 @@ export default {
       value = state.storedWindows[uuid][attributeNameControl]
     }
 
-    state.storedWindows[uuid][attributeName] = value
+    Vue.set(state.storedWindows[uuid], attributeName, value)
+    // state.storedWindows[uuid][attributeName] = value
+  },
+
+  /**
+   *
+   * @param {*} state
+   * @param {string} parentUuid
+   * @param {object} tab
+   */
+  setCurrentTab(state, { parentUuid, tab }) {
+    Vue.set(state.storedWindows[parentUuid], 'currentTab', tab)
   }
 }

--- a/src/store/modules/ADempiere/dictionary/window/mutations.js
+++ b/src/store/modules/ADempiere/dictionary/window/mutations.js
@@ -41,6 +41,15 @@ export default {
     // state.storedWindows[uuid][attributeName] = value
   },
 
+  changeTabAttribute(state, payload) {
+    let value = payload.attributeValue
+    if (!isEmptyValue(payload.attributeNameControl)) {
+      value = payload.tab[payload.attributeNameControl]
+    }
+
+    payload.tab[payload.attributeName] = value
+  },
+
   /**
    *
    * @param {*} state

--- a/src/store/modules/ADempiere/utils.js
+++ b/src/store/modules/ADempiere/utils.js
@@ -32,9 +32,6 @@ const initStateUtils = {
   updatePayment: false,
   createBusinessPartner: false,
 
-  // TODO: Change to tab
-  showContainer: false,
-
   step: 0,
   updateCustomer: false,
   overdrawnInvoice: {
@@ -118,9 +115,7 @@ export default {
     popoverCreateBusinessPartner(state, createBusinessPartner) {
       state.createBusinessPartner = createBusinessPartner
     },
-    setExternalContainer(state, show) {
-      state.showContainer = show
-    },
+
     popoverOverdrawnInvoice(state, payload) {
       state.overdrawnInvoice = payload
     },
@@ -280,11 +275,6 @@ export default {
     },
     getPopoverCreateBusinessParnet: (state) => {
       return state.createBusinessPartner
-    },
-
-    // TODO: Change to tab
-    getExternalContainer: (state) => {
-      return state.showContainer
     },
 
     getStepCurrent: (state) => {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

Currently the record panel visibility is handled as a global property, it should be at panel level.


#### Steps to reproduce

1. Open multiple windows: `Relation Type`, ` Model Validator`, ` Setup Definition`, and ` Mail Template `
2. Show records in `Relation Type`.
3. Back to the window  `Mail Template`.

#### Screenshot or Gif

Before this pull request:

https://user-images.githubusercontent.com/20288327/134276778-83a9a6a8-a3d0-46af-a9dd-5a5ff12746fa.mp4

After this pull request:

https://user-images.githubusercontent.com/20288327/134276807-0340682e-93e2-4f05-9e7f-7487174f8b8f.mp4


#### Expected behavior

It is expected that if the log panel is displayed in a tab it will be kept open only in that tab. Note how it displays the records in the last tab (`Mail Template`) although it is never selected to display in that tab, erroneously sharing the visibility value with the window and tab `Relation Type`.

#### Other relevant information
* Your OS: Linux Mint 19.1 Cinnamon x64. 
* Browser: Mozilla Firefox 88.0.1.
* Node.js version: 14.17.0.
* NPM version: 7.19.0.
* adempiere-vue version: 4.3.1.

#### Additional context
mnemonic commands are added to close records with the escape key
