### PR TITLE
fix: Create record request with empty mandatory.

### DIFF
--- a/src/store/modules/ADempiere/dictionary/window/getters.js
+++ b/src/store/modules/ADempiere/dictionary/window/getters.js
@@ -46,6 +46,14 @@ export default {
     return undefined
   },
 
+  getStoredFieldsFromTab: (state, getters) => (windowUuid, tabUuid) => {
+    const tab = getters.getStoredTab(windowUuid, tabUuid)
+    if (!isEmptyValue(tab)) {
+      return tab.fieldsList
+    }
+    return undefined
+  },
+
   getCurrentTab: (state, getters) => (windowUuid) => {
     const window = getters.getStoredWindow(windowUuid)
 

--- a/src/store/modules/ADempiere/persistence.js
+++ b/src/store/modules/ADempiere/persistence.js
@@ -44,16 +44,20 @@ const persistence = {
       value
     }) {
       return new Promise((resolve, reject) => {
+        const { parentUuid, containerUuid } = field
         commit('addChangeToPersistenceQueue', {
-          containerUuid: field.containerUuid,
+          containerUuid,
           columnName: field.columnName,
           value
         })
 
         // TODO: Add dictonary getter
+        const fieldsList = getters.getStoredFieldsFromTab(parentUuid, containerUuid)
+
         const emptyFields = getters.getFieldsListEmptyMandatory({
-          containerUuid: field.containerUuid,
-          formatReturn: false
+          containerUuid,
+          formatReturn: false,
+          fieldsList
         }).filter(itemField => {
           return !LOG_COLUMNS_NAME_LIST.includes(itemField.columnName)
         }).map(itemField => {
@@ -68,9 +72,12 @@ const persistence = {
           return
         }
         const route = router.app._route
-        recordUuid = route.query.action === 'create-new' ? getters.getUuidOfContainer(field.containerUuid) : route.query.action
+        recordUuid = route.query.action === 'create-new'
+          ? getters.getUuidOfContainer(field.containerUuid)
+          : route.query.action
+
         dispatch('flushPersistenceQueue', {
-          containerUuid: field.containerUuid,
+          containerUuid,
           tableName: field.tabTableName,
           recordUuid
         })


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open any window with mandatory fields.
2. Change value of optional fields
3. Show console in web browser.

#### Screenshot or Gif

Before this PR:

https://user-images.githubusercontent.com/20288327/135934243-5815c11f-0e66-4f79-bef4-b4bea3a60898.mp4

After this PR:

https://user-images.githubusercontent.com/20288327/135934193-e650d5d2-5689-42d6-83d3-b9f401360f7b.mp4

#### Expected behavior
It is expected that if there are mandatory fields with empty value, the request will not be sent to the create entity server.

#### Other relevant information
- Your OS: Linux Mint 20.2,
- Web Browser: Firefox 92.0.1
- Node.js version: 14.18.0
- NPM version: 6.14.15
- adempiere-vue version: 4.4.0.

