### PR TITLE
when consulting product information when applying discount

### DIFF
--- a/src/components/ADempiere/Form/VPOS/Order/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Order/index.vue
@@ -185,7 +185,7 @@
                             <b>{{ scope.row.taxRate.name }}</b>
                             <br>
                             {{ $t('form.productInfo.grandTotal') }}:
-                            <b>{{ formatPrice((scope.row.priceActual * scope.row.taxRate.rate / 100) + scope.row.priceList, pointOfSalesCurrency.iSOCode) }}</b>
+                            <b>{{ formatPrice((scope.row.priceList * scope.row.taxRate.rate / 100) + scope.row.priceList * scope.row.quantityOrdered, pointOfSalesCurrency.iSOCode) }}</b>
                             <br>
                             {{ $t('form.pos.tableProduct.quantity') }}:
                             <b>{{ formatQuantity(scope.row.quantityOrdered) }}</b>


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

When a discount is applied to a product and when consulting the product information, there is a difference in the overall total, since the amount of the product (which does not have a discount) and the VAT (which was generated with the discount percentage) are added together.
#### Screenshot or Gif

![image](https://user-images.githubusercontent.com/45974454/136093796-d67dff54-19c5-486a-aa5f-e456b8ba2fda.png)
