### PR TITLE
After Running Cache Reset, Focus always goes to Dashboard, instead of last Tab or (ideally) last active Tab

### DIFF
--- a/src/components/ADempiere/DropdownMenu/menuCard.vue
+++ b/src/components/ADempiere/DropdownMenu/menuCard.vue
@@ -45,7 +45,6 @@ export default {
   },
   methods: {
     redirect(item) {
-      console.log(item)
       this.openItemMenu(item)
 
       let tabParent

--- a/src/store/modules/ADempiere/process/actions.js
+++ b/src/store/modules/ADempiere/process/actions.js
@@ -164,6 +164,9 @@ export default {
         }
       }
       commit('addInExecution', processResult)
+      let oldRouter = {
+        path: ''
+      }
       if (panelType === 'window') {
         reportType = 'pdf'
       } else if (panelType === 'browser') {
@@ -179,9 +182,12 @@ export default {
           })
         }
       } else {
+        const tabViewsVisited = getters.visitedViews
+        dispatch('tagsView/delView', routeToDelete)
+        oldRouter = tabViewsVisited[tabViewsVisited.length - 1]
         // close view if is process, report.
         router.push({
-          path: '/dashboard'
+          path: oldRouter.path
         }, () => {})
         dispatch('tagsView/delView', routeToDelete)
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
After Running Cache Reset, Focus always goes to Dashboard, instead of last Tab or (ideally) last active Tab

### Screenshot or Gif

![Peek 28-09-2021 09-05](https://user-images.githubusercontent.com/45974454/136579407-74ecb102-5cd7-4045-9553-30a1777063ee.gif)
### Issues
Fixes #1042 