### PR TITLE
fix: References send request without record.

### DIFF
--- a/src/components/ADempiere/ActionMenu/References.vue
+++ b/src/components/ADempiere/ActionMenu/References.vue
@@ -112,6 +112,7 @@ export default defineComponent({
     })
 
     const isWithRecord = computed(() => {
+      // TODO: Add validate uuid record with route
       return !root.isEmptyValue(recordUuid.value) &&
         recordUuid.value !== 'create-new'
     })
@@ -186,14 +187,15 @@ export default defineComponent({
 
     if (isReferecesContent.value) {
       // when change record uuid loaded references
-      watch(recordUuid, (newValue) => {
-        // TODO: Add validate uuid record with route
-        if (newValue !== 'create-new' && !root.isEmptyValue(newValue)) {
+      watch(recordUuid, (newValue, oldValue) => {
+        if (isWithRecord.value && newValue !== oldValue) {
           getReferences()
         }
       })
 
-      getReferences()
+      if (isWithRecord.value) {
+        getReferences()
+      }
     }
 
     return {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open any window (Relation Type for this case).
2. Show web browser console.

#### Screenshot or Gif

Before this pull request:

https://user-images.githubusercontent.com/20288327/136732065-cbdefdc7-2236-4338-a5b6-9367d757a05a.mp4

After this pull request:

https://user-images.githubusercontent.com/20288327/136732150-0044f441-11d4-4dc4-bbac-4b94d01d32b7.mp4

#### Expected behavior
An unnecessary request is sent for the references without having the record identifier, so it generates a warning in the console.
It should not generate warnings or send unnecessary requests that do not have the minimum parameters for a successful response.

#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
Web browser console warning:
```
References Load Error undefined: ID de Registro * No encontrado *
ID de Registro * No encontrado *.
```

