### PR TITLE
fix: Records current tab.

### DIFF
--- a/src/components/ADempiere/TabManager/index.vue
+++ b/src/components/ADempiere/TabManager/index.vue
@@ -156,8 +156,10 @@ export default defineComponent({
 
     // use getter to reactive properties
     const currentTabMetadata = computed(() => {
-      // return props.tabsList[currentTab.value]
-      return root.$store.getters.getCurrentTab(props.parentUuid)
+      if (props.isParentTabs) {
+        return root.$store.getters.getCurrentTab(props.parentUuid)
+      }
+      return root.$store.getters.getCurrentTabChild(props.parentUuid)
     })
 
     const isShowRecords = computed(() => {
@@ -175,8 +177,11 @@ export default defineComponent({
     }
 
     function setCurrentTab() {
-      console.info(props.tabsList[currentTab.value])
-      root.$store.commit('setCurrentTab', {
+      let tabMutation = 'setCurrentTab'
+      if (!props.isParentTabs) {
+        tabMutation = 'setCurrentTabChild'
+      }
+      root.$store.commit(tabMutation, {
         parentUuid: props.parentUuid,
         tab: props.tabsList[currentTab.value]
       })

--- a/src/store/modules/ADempiere/dictionary/window/getters.js
+++ b/src/store/modules/ADempiere/dictionary/window/getters.js
@@ -58,5 +58,11 @@ export default {
     const window = getters.getStoredWindow(windowUuid)
 
     return window.currentTab
+  },
+
+  getCurrentTabChild: (state, getters) => (windowUuid) => {
+    const window = getters.getStoredWindow(windowUuid)
+
+    return window.currentTabChild
   }
 }

--- a/src/store/modules/ADempiere/dictionary/window/mutations.js
+++ b/src/store/modules/ADempiere/dictionary/window/mutations.js
@@ -58,5 +58,14 @@ export default {
    */
   setCurrentTab(state, { parentUuid, tab }) {
     Vue.set(state.storedWindows[parentUuid], 'currentTab', tab)
+  },
+
+  /**
+   * @param {*} state
+   * @param {string} parentUuid
+   * @param {object} tab
+   */
+  setCurrentTabChild(state, { parentUuid, tab }) {
+    Vue.set(state.storedWindows[parentUuid], 'currentTabChild', tab)
   }
 }

--- a/src/views/ADempiere/Window/windowUtils.js
+++ b/src/views/ADempiere/Window/windowUtils.js
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { generatePanelAndFields } from '@/components/ADempiere/PanelDefinition/panelUtils'
+import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
 
 export function generateWindow(responseWindow) {
   const {
@@ -25,10 +26,16 @@ export function generateWindow(responseWindow) {
     parentUuid: responseWindow.uuid
   })
 
+  let currentTabChild = {}
+  if (!isEmptyValue(tabsListChild)) {
+    currentTabChild = tabsListChild[0]
+  }
+
   const newWindow = {
     ...responseWindow,
     tabsList,
     currentTab: tabsListParent[0],
+    currentTabChild,
     tabsListChild,
     tabsListParent,
     // app attributes


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open any window with multiple tabs.
2. Open records in parent tab.
3. Close records.

#### Screenshot or Gif
Before this changes:

https://user-images.githubusercontent.com/20288327/137030721-12bf7f5b-3d1c-4078-8e59-13b2692aa4ed.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/137030734-183b7d75-cd86-4a73-9da2-12f67821ee58.mp4


#### Expected behavior
It is expected that the records of the current tab will be displayed, but the child tab is displayed, and it does not allow to close the registry list.

#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

