### PR TITLE
fix: Field style label and content.

### DIFF
--- a/src/components/ADempiere/Field/FieldOptions/LabelField.vue
+++ b/src/components/ADempiere/Field/FieldOptions/LabelField.vue
@@ -1,10 +1,10 @@
 <template>
-  <div :style="labelStyle">
+  <div :style="labelStyle" class="label-field">
     <span>
       {{ label }}
     </span>
 
-    <span v-if="isMandatory" :style="'color: #f34b4b'">*</span>
+    <span v-if="isMandatory" :style="'color: #f34b4b'"> * </span>
 
     <i class="el-icon-info" :style="iconStyle" />
   </div>
@@ -53,9 +53,11 @@ export default defineComponent({
 })
 </script>
 
-<style scoped>
-.el-icon-info {
+<style lang="scss" scoped>
+.label-field {
+  .el-icon-info {
     font-size: 11px;
     color: #008fd3;
+  }
 }
 </style>

--- a/src/components/ADempiere/Field/FieldOptions/index.vue
+++ b/src/components/ADempiere/Field/FieldOptions/index.vue
@@ -17,7 +17,7 @@
 -->
 
 <template>
-  <div>
+  <div class="field-options">
     <el-dropdown
       v-if="isMobile"
       key="options-mobile"
@@ -28,7 +28,8 @@
       @command="handleCommand"
       @click="false"
     >
-      <label-field :is-mandatory="metadata.required && isEmptyValue(valueField)" :label="metadata.name" :is-mobile="true" />
+      <label-field :is-mandatory="metadata.required" :label="metadata.name" :is-mobile="true" />
+
       <el-dropdown-menu slot="dropdown">
         <template
           v-for="(option, key) in optionsList"
@@ -45,10 +46,10 @@
       </el-dropdown-menu>
     </el-dropdown>
 
+    <!-- Desktop menu -->
     <el-menu
       v-else-if="!isMobile && metadata.panelType !== 'form'"
       key="options-desktop"
-      class="el-menu-demo"
       mode="horizontal"
       unique-opened
       style="z-index: 0"
@@ -59,8 +60,9 @@
     >
       <el-submenu index="menu">
         <template slot="title">
-          <label-field :is-mandatory="metadata.required && isEmptyValue(valueField)" :label="metadata.name" />
+          <label-field :is-mandatory="metadata.required" :label="metadata.name" />
         </template>
+
         <el-menu-item
           v-for="(option, key) in optionsList"
           :key="key"
@@ -97,13 +99,15 @@
 
 <script>
 import { defineComponent, computed, ref, watch } from '@vue/composition-api'
+
+import LabelField from './LabelField.vue'
+import LabelPopoverOption from './LabelPopoverOption.vue'
+
 import {
   optionsListStandad, optionsListAdvancedQuery,
   documentStatusOptionItem, translateOptionItem,
   zoomInOptionItem, calculatorOptionItem
 } from '@/components/ADempiere/Field/FieldOptions/fieldOptionsList.js'
-import LabelField from './LabelField.vue'
-import LabelPopoverOption from './LabelPopoverOption.vue'
 import { recursiveTreeSearch } from '@/utils/ADempiere/valueUtils.js'
 
 export default defineComponent({
@@ -390,7 +394,44 @@ export default defineComponent({
 })
 </script>
 
+<style lang="scss">
+.field-options {
+  .el-menu--horizontal {
+    // transparent background color of the field label
+    &.el-menu {
+      background: #FFF0;
+    }
+    &.el-menu:hover {
+      background: #FFF0;
+    }
+
+    // height of the field label
+    .el-submenu .el-submenu__title {
+      height: 30px;
+      line-height: 30px;
+    }
+    .el-submenu__title {
+      height: 30px;
+      line-height: 30px;
+      // left spacing of field name
+      padding: 0px;
+    }
+  }
+
+  // hidde arrow icon
+  .el-submenu .el-submenu__icon-arrow  {
+    visibility: hidden;
+  }
+
+  // hide bottom line in label
+  .el-menu.el-menu--horizontal {
+    border-bottom: solid 0px #E6E6E6;
+  }
+}
+</style>
+
 <style>
+/*
 .el-popover {
   position: fixed;
   padding: 0px;
@@ -408,8 +449,10 @@ export default defineComponent({
   border-bottom: 2px solid transparent;
   color: #535457e3;
 }
+*/
 </style>
-<style scoped>
+<style lang="scss" scoped>
+/*
 .el-form--label-top .el-form-item__label {
   padding-bottom: 0px !important;
   display: block;
@@ -454,7 +497,7 @@ export default defineComponent({
 }
 .el-dropdown-menu__item--divided {
   position: relative;
-  /* margin-top: 6px; */
+  // margin-top: 6px;
   border-top: 1px solid #e6ebf5;
 }
 .label {
@@ -471,4 +514,5 @@ export default defineComponent({
 .contents {
   display: inline-flex;
 }
+*/
 </style>

--- a/src/components/ADempiere/Field/FieldText.vue
+++ b/src/components/ADempiere/Field/FieldText.vue
@@ -69,9 +69,20 @@ export default {
   },
   computed: {
     cssClassStyle() {
-      let styleClass = ' custom-field-text '
-      if (!this.isEmptyValue(this.metadata.cssClassName)) {
-        styleClass += this.metadata.cssClassName
+      const { cssClassName, displayType, inTable } = this.metadata
+      let styleClass = ''
+      if (!this.isEmptyValue(cssClassName)) {
+        styleClass += cssClassName
+      }
+
+      if (displayType === TEXT.id) {
+        styleClass += ' custom-field-textarea '
+      } else {
+        styleClass += ' custom-field-text '
+      }
+
+      if (inTable) {
+        styleClass += ' field-in-table '
       }
       return styleClass
     },
@@ -110,11 +121,15 @@ export default {
 }
 </script>
 
-<style>
+<style lang="scss">
   .custom-field-text {
     max-height: 36px;
   }
+
+  // indicates if the textarea is adjustable
   .el-textarea__inner {
-    resize: none !important;
+    &.field-in-table {
+      resize: none !important;
+    }
   }
 </style>

--- a/src/components/ADempiere/Field/index.vue
+++ b/src/components/ADempiere/Field/index.vue
@@ -15,10 +15,11 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https:www.gnu.org/licenses/>.
 -->
+
 <template>
-  <div v-if="!inTable">
+  <div v-if="isDisplayedField" class="field-definition">
     <el-col
-      v-if="isDisplayedField"
+      v-if="!inTable"
       key="is-panel-template"
       :xs="sizeField.xs"
       :sm="sizeField.sm"
@@ -47,29 +48,32 @@
         />
       </el-form-item>
     </el-col>
+
+    <component
+      :is="componentRender"
+      v-else
+      :id="field.panelType !== 'form' ? field.columnName : ''"
+      key="is-table-template"
+      :class="classField"
+      :parent-uuid="parentUuid"
+      :container-uuid="containerUuid"
+      :container-manager="containerManager"
+      :field-metadata="fieldAttributes"
+      :metadata="fieldAttributes"
+      :value-model="recordDataFields"
+      :in-table="true"
+    />
   </div>
-  <component
-    :is="componentRender"
-    v-else
-    :id="field.panelType !== 'form' ? field.columnName : ''"
-    key="is-table-template"
-    :class="classField"
-    :parent-uuid="parentUuid"
-    :container-uuid="containerUuid"
-    :container-manager="containerManager"
-    :field-metadata="fieldAttributes"
-    :metadata="fieldAttributes"
-    :value-model="recordDataFields"
-    :in-table="true"
-  />
 </template>
 
 <script>
+import FieldOptions from '@/components/ADempiere/Field/FieldOptions/index.vue'
+
 import { evalutateTypeField, fieldIsDisplayed } from '@/utils/ADempiere/dictionaryUtils'
+import { TEXT } from '@/utils/ADempiere/references'
 import {
   ACTIVE, CLIENT, PROCESSING, PROCESSED
 } from '@/utils/ADempiere/constants/systemColumns'
-import FieldOptions from '@/components/ADempiere/Field/FieldOptions'
 
 /**
  * This is the base component for linking the components according to the
@@ -131,10 +135,13 @@ export default {
       return this.$store.state.app.device === 'mobile'
     },
     classFrom() {
-      if (this.field.componentPath === 'FieldTextLong' || this.field.componentPath === 'FieldImage') {
-        return 'from-text-long'
+      if (['FieldTextLong', 'FieldImage'].includes(this.field.componentPath)) {
+        return 'field-text-long'
       }
-      return 'from-field'
+      if ([TEXT.id].includes(this.field.displayType)) {
+        return 'field-text-area'
+      }
+      return 'field-standard'
     },
     sizeField() {
       if (this.field.isShowedRecordNavigation) {
@@ -426,66 +433,61 @@ export default {
 </script>
 
 <style lang="scss">
+.field-definition {
   /**
    * Separation between elements (item) of the form
    */
-  .from-text-long {
-    max-height: 300px;
-    min-height: 250px;
-  }
-  .from-field {
-    max-height: 65px;
-  }
   .el-form-item {
-    margin-bottom: 10px !important;
+    margin-bottom: 12px !important;
     margin-left: 10px;
     margin-right: 10px;
+  }
+  .field-text-long {
+    max-height: 300px;
+    min-height: 250px;
   }
 
   /**
    * Maximum height to avoid distorting the field list
    */
-  .el-form-item__content {
-    max-height: 36px !important;
+  .field-standard {
+    &:not(.in-table) {
+      max-height: 79px;
+    }
+
+    .el-form-item__content {
+      max-height: 36px !important;
+    }
   }
 
-  /**
-   * Reduce the spacing between the form element and its label
-   */
-  .el-form--label-top .el-form-item__label {
-    padding-bottom: 0px !important;
-  }
-
+  /*
   .in-table {
     margin-bottom: 0px !important;
     margin-left: 0px;
     margin-right: 0px;
   }
+  */
 
   /**
    * Min height all text area, not into table
    */
   .el-textarea__inner:not(.in-table) {
     min-height: 36px !important;
-    /*
-    height: 36px auto !important;
-    max-height: 54.2333px !important;
-    */
+    // height: 36px auto !important;
+    // max-height: 54.2333px !important;
   }
 
   /**
    * Reduce the spacing between the form element and its label
    */
-  .el-form--label-top .el-form-item__label {
-    padding-bottom: 0px !important;
+  .el-form-item__label {
+    padding-bottom: 0px;
   }
+
+  /*
   .pre-formatted {
     white-space: pre;
   }
-  .el-submenu__title {
-    padding: 0;
-  }
-  .el-submenu .el-submenu__icon-arrow  {
-    visibility: hidden;
-  }
+  */
+}
 </style>


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open any window with multiple fields.

#### Screenshot or Gif
Before this changes:

https://user-images.githubusercontent.com/20288327/137167624-72f85acd-66b2-4740-ba47-e755e8e22b94.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/137166313-59ab596a-e0ef-403f-9a4d-3ea43d26f278.mp4


#### Expected behavior
The label of the fields are overlapped with the content, and the content of the textarea fields are overlapped with the other fields.


#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

