### PR TITLE
Point of sale scale support

### DIFF
--- a/src/components/ADempiere/Form/VPOS/ConfirmDelivery/index.vue
+++ b/src/components/ADempiere/Form/VPOS/ConfirmDelivery/index.vue
@@ -29,7 +29,13 @@
       @submit.native.prevent="notSubmitForm"
     >
       <el-form-item label="Código Producto">
-        <el-input v-model="input" :placeholder="$t('quickAccess.searchWithEnter')" @input="searchProduct" />
+        <el-input
+          ref="inputFindProduct"
+          v-model="input"
+          :autofocus="true"
+          :placeholder="$t('quickAccess.searchWithEnter')"
+          @input="searchProduct"
+        />
       </el-form-item>
     </el-form>
     <el-table
@@ -215,6 +221,10 @@ export default {
     popoverName: {
       type: String,
       default: 'isShowPopoverField'
+    },
+    isVisible: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
@@ -295,6 +305,13 @@ export default {
       if (!this.isEmptyValue(this.$refs.open)) {
         this.$refs.open.showPopper = false
         this.$refs.open.destroyPopper()
+      }
+    },
+    isVisible(value) {
+      if (value) {
+        this.timeOut = setTimeout(() => {
+          this.$refs.inputFindProduct.focus()
+        }, 500)
       }
     }
   },

--- a/src/components/ADempiere/Form/VPOS/Options/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Options/index.vue
@@ -223,6 +223,7 @@
               >
                 <confirm-delivery
                   :is-selectable="false"
+                  :is-visible="popoverConfirmDelivery"
                   popover-name="isShowPopoverMenu"
                 />
                 <div

--- a/src/components/ADempiere/Form/VPOS/Order/orderLineMixin.js
+++ b/src/components/ADempiere/Form/VPOS/Order/orderLineMixin.js
@@ -162,10 +162,11 @@ export default {
       this.$store.dispatch('updateOrderLines', orderLine)
     },
     createOrderLine(orderUuid) {
-      const productUuid = this.product.uuid
+      const productUuid = this.product.product.uuid
       createOrderLine({
         orderUuid,
         productUuid,
+        quantity: this.product.weight,
         priceListUuid: this.currentPointOfSales.currentPriceList.uuid,
         warehouseUuid: this.currentPointOfSales.currentWarehouse.uuid
       })
@@ -275,7 +276,7 @@ export default {
       } else if (row.columnName === 'DisplayTaxAmount') {
         return this.currentPointOfSales.isDisplayTaxAmount
       } else if (row.columnName === 'GrandTotal') {
-        if (this.isDisplayIncludingTax) {
+        if (!this.isDisplayDiscount && !this.isDisplayTaxAmount) {
           this.orderLineDefinition.grandTotal.label = this.$t('form.productInfo.totalIncludingTax')
         }
         return true
@@ -303,12 +304,12 @@ export default {
       } else if (columnName === 'taxIndicator') {
         return this.formatQuantity(row.taxIndicator)
       } else if (columnName === 'GrandTotal') {
-        if (this.isDisplayIncludingTax) {
+        if (!this.isDisplayDiscount && !this.isDisplayTaxAmount) {
           return this.formatPrice((row.grandTotal * row.taxRate.rate / 100) + row.grandTotal, currency)
         }
         return this.formatPrice(row.grandTotal, currency)
       } else if (columnName === 'ConvertedAmount') {
-        if (this.isDisplayIncludingTax) {
+        if (!this.isDisplayDiscount && !this.isDisplayTaxAmount) {
           const price = ((row.grandTotal * row.taxRate.rate / 100) + row.grandTotal).toFixed(2)
           return this.formatPrice(price / this.totalAmountConverted, this.currentPointOfSales.displayCurrency.iso_code)
         }

--- a/src/components/ADempiere/Form/VPOS/posMixin.js
+++ b/src/components/ADempiere/Form/VPOS/posMixin.js
@@ -41,7 +41,10 @@ export default {
   },
   data() {
     return {
-      product: {},
+      product: {
+        product: '',
+        quantity: 0
+      },
       currentTable: 0,
       orderLines: [],
       products: {
@@ -486,12 +489,18 @@ export default {
         value: uuid
       })
     },
+    findScale(UPC) {
+      if (this.currentPointOfSales.scale && UPC.length <= 12) {
+        return this.checkDigitCalculation(UPC)
+      }
+      return UPC
+    },
     findProduct(searchValue) {
       if (this.withoutPOSTerminal()) {
         return
       }
-
-      const searchProduct = (typeof searchValue === 'object') ? searchValue.value : searchValue
+      this.product = this.findScale(searchValue)
+      const searchProduct = (typeof this.findScale(searchValue) === 'object') ? this.product.code : ((typeof searchValue === 'object') ? searchValue.value : searchValue)
       if (this.isEmptyValue(this.curretnPriceList)) {
         return
       }
@@ -502,7 +511,7 @@ export default {
         warehouseUuid: this.currentPointOfSales.currentWarehouse.uuid
       })
         .then(productPrice => {
-          this.product = productPrice.product
+          this.product.product = productPrice.product
           this.createOrder({ withLine: true })
         })
         .catch(error => {

--- a/src/utils/ADempiere/globalMethods.js
+++ b/src/utils/ADempiere/globalMethods.js
@@ -26,5 +26,6 @@ export {
   formatConversionCurrenty,
   round,
   convertValuesToSend,
-  typeValue
+  typeValue,
+  checkDigitCalculation
 } from '@/utils/ADempiere/valueUtils.js'

--- a/src/utils/ADempiere/valueUtils.js
+++ b/src/utils/ADempiere/valueUtils.js
@@ -552,6 +552,9 @@ export function convertValuesToSendListOrders(values) {
   })
   return valuesToSend
 }
+export function checkDigitCalculation(upc) {
+  return { code: upc.slice(1, 6), weight: upc.slice(6, 11) }
+}
 /**
  * Search in the currency lists for the current currency
  * @author Elsio Sanchez <elsiosanches@gmail.com>


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
Bar code holder for local use (store/warehouse) for the scale 

#### Expected behavior
When reading the barcode you must add the product and its quantity or weight according to the scanned UPC.

#### Other relevant information
- Your OS:  Debian 10
- Web Browser: Chrome
- Node.js version: 14.2.2

#### Additional context
Waiting for back-end support to select the scale to be used for the point of sale.