### PR TITLE
fix: Multiple requests private access.

### DIFF
--- a/src/components/ADempiere/TabManager/index.vue
+++ b/src/components/ADempiere/TabManager/index.vue
@@ -52,6 +52,7 @@
       >
         <lock-record
           slot="label"
+          :is-active-tab="tabAttributes.uuid === tabUuid"
           :tab-position="isParentTabs ? key : 1"
           :tab-uuid="tabAttributes.uuid"
           :table-name="tabAttributes.tableName"
@@ -100,11 +101,12 @@
 <script>
 import { defineComponent, computed, ref } from '@vue/composition-api'
 
-import AuxiliaryPanel from '@/components/ADempiere/AuxiliaryPanel'
-import DefaultTable from '@/components/ADempiere/DefaultTable'
-import LockRecord from '@/components/ADempiere/ContainerOptions/LockRecord'
-import PanelDefinition from '@/components/ADempiere/PanelDefinition'
-import RecordNavigation from '@/components/ADempiere/RecordNavigation'
+// components
+import AuxiliaryPanel from '@/components/ADempiere/AuxiliaryPanel/index.vue'
+import DefaultTable from '@/components/ADempiere/DefaultTable/index.vue'
+import LockRecord from '@/components/ADempiere/ContainerOptions/LockRecord/index.vue'
+import PanelDefinition from '@/components/ADempiere/PanelDefinition/index.vue'
+import RecordNavigation from '@/components/ADempiere/RecordNavigation/index.vue'
 
 export default defineComponent({
   name: 'TabManager',


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open any window with multiple tabs.
2. Open web browser dev tools, in network request.

#### Screenshot or Gif
Before this change:

https://user-images.githubusercontent.com/20288327/138994963-6b802682-9c9a-49b9-8c1a-b3c4fd93e539.mp4

After this change:

https://user-images.githubusercontent.com/20288327/138994974-21b877c5-5b12-49ce-9055-46d71084d112.mp4

#### Expected behavior
It is expected that only requests for displayed or active tabs will be executed, however, all tab requests are executed even if they are not active.

#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

