### PR TITLE
feat: Add window zoom in smart browser.

### DIFF
--- a/src/lang/ADempiere/en/actionMenu.js
+++ b/src/lang/ADempiere/en/actionMenu.js
@@ -21,6 +21,7 @@ const actionMenu = {
   createNewRecord: 'New Record',
   shareLink: 'Share Link',
   withoutActions: 'Without Actions',
+  zoomWindow: 'Zoom Window',
   // relations
   relations: 'Relations',
   withoutRelations: 'Without Relations',

--- a/src/lang/ADempiere/es/actionMenu.js
+++ b/src/lang/ADempiere/es/actionMenu.js
@@ -21,10 +21,11 @@ const actionMenu = {
   createNewRecord: 'Nuevo Registro',
   shareLink: 'Compartir Enlace',
   withoutActions: 'Sin Actiones',
+  zoomWindow: 'Acercar Ventana',
   // relations
   relations: 'Relaciones',
   withoutRelations: 'Sin Relaciones',
-  // refeerences
+  // references
   references: 'Referencias',
   withoutReferences: 'Sin referencias para el registro'
 }

--- a/src/utils/ADempiere/constants/actionsMenuList.js
+++ b/src/utils/ADempiere/constants/actionsMenuList.js
@@ -16,7 +16,7 @@
 
 import language from '@/lang'
 import { showMessage } from '@/utils/ADempiere/notification.js'
-import { copyToClipboard } from '@/utils/ADempiere/coreUtils'
+import { copyToClipboard, zoomIn } from '@/utils/ADempiere/coreUtils.js'
 
 /**
  * Create new record
@@ -117,6 +117,23 @@ export const deleteRecord = {
         })
         console.warn(`Delete Entity - Error ${error.message}, Code: ${error.code}.`)
       })
+  }
+}
+
+/**
+ * Delete record (entity) with record
+ */
+export const zoomWindow = {
+  name: language.t('actionMenu.zoomWindow'),
+  enabled: true,
+  svg: false,
+  icon: 'el-icon-zoom-in',
+  type: 'zoom',
+  actionName: 'zoomWindow',
+  zoomWindow: ({ uuid }) => {
+    zoomIn({
+      uuid
+    })
   }
 }
 

--- a/src/utils/ADempiere/constants/actionsMenuList.js
+++ b/src/utils/ADempiere/constants/actionsMenuList.js
@@ -121,7 +121,8 @@ export const deleteRecord = {
 }
 
 /**
- * Delete record (entity) with record
+ * Zoom in on the window associated with the smart browser
+ * @param {string} uuid of window
  */
 export const zoomWindow = {
   name: language.t('actionMenu.zoomWindow'),

--- a/src/utils/ADempiere/coreUtils.js
+++ b/src/utils/ADempiere/coreUtils.js
@@ -14,17 +14,27 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { isEmptyValue, recursiveTreeSearch } from '@/utils/ADempiere/valueUtils.js'
-import { showMessage } from '@/utils/ADempiere/notification'
 import router from '@/router'
 import language from '@/lang'
 import store from '@/store'
+
+import { showMessage } from '@/utils/ADempiere/notification'
+import { isEmptyValue, recursiveTreeSearch } from '@/utils/ADempiere/valueUtils.js'
 
 export function zoomIn({
   uuid,
   params = {},
   query = {}
 }) {
+  if (isEmptyValue(uuid)) {
+    showMessage({
+      type: 'error',
+      showClose: true,
+      message: language.t('notifications.emptyValues')
+    })
+    return
+  }
+
   const menuTree = store.getters.permission_routes
 
   const viewSearch = recursiveTreeSearch({

--- a/src/views/ADempiere/Browser/index.vue
+++ b/src/views/ADempiere/Browser/index.vue
@@ -82,16 +82,19 @@ import LoadingView from '@/components/ADempiere/LoadingView/index.vue'
 import TitleAndHelp from '@/components/ADempiere/TitleAndHelp'
 import PanelDefinition from '@/components/ADempiere/PanelDefinition/index.vue'
 
-// utils and helpers methods
-import {
-  refreshBrowserSearh,
-  sharedLink
-} from '@/utils/ADempiere/constants/actionsMenuList'
+// utils and helper methods
 import {
   isDisplayedField, isDisplayedColumn,
   isMandatoryField, isMandatoryColumn,
   isReadOnlyField, isReadOnlyColumn
 } from '@/utils/ADempiere/dictionary/browser.js'
+
+// constants
+import {
+  refreshBrowserSearh,
+  sharedLink,
+  zoomWindow
+} from '@/utils/ADempiere/constants/actionsMenuList'
 
 export default defineComponent({
   name: 'BrowserView',
@@ -268,6 +271,13 @@ export default defineComponent({
 
       getActionList: () => [
         refreshBrowserSearh,
+        {
+          ...zoomWindow,
+          uuid: root.isEmptyValue(storedBrowser.value)
+            ? null
+            : storedBrowser.value.window.uuid
+        },
+
         sharedLink
       ]
     })


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open smart browser User Browser
2. Displayed actions and select Zoom Window.

#### Screenshot or Gif

https://user-images.githubusercontent.com/20288327/138998494-64ba1ea0-ac78-4dd8-96e9-62ea195ca02a.mp4


#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
fixes https://github.com/adempiere/adempiere-vue/issues/133
