### PR TITLE
feat: Remove deprecated attribure displayColumn.

### DIFF
--- a/src/components/ADempiere/DataTable/index.vue
+++ b/src/components/ADempiere/DataTable/index.vue
@@ -193,7 +193,6 @@
                       :in-table="true"
                       :metadata-field="{
                         ...fieldAttributes,
-                        displayColumn: scope.row[fieldAttributes.displayColumnName],
                         tableIndex: scope.$index,
                         rowKey: scope.row[panelMetadata.keyColumn],
                         keyColumn: panelMetadata.keyColumn,

--- a/src/components/ADempiere/Field/FieldAutocomplete.vue
+++ b/src/components/ADempiere/Field/FieldAutocomplete.vue
@@ -53,12 +53,19 @@
 </template>
 
 <script>
+// mixins
 import fieldMixin from '@/components/ADempiere/Field/mixin/mixinField.js'
-import { convertBooleanToString } from '@/utils/ADempiere/valueFormat.js'
+
+// utils and helper methods
+import { convertBooleanToString } from '@/utils/ADempiere/formatValue/booleanFormat.js'
 
 export default {
   name: 'FieldAutocomplete',
-  mixins: [fieldMixin],
+
+  mixins: [
+    fieldMixin
+  ],
+
   data() {
     // label with '' value is assumed to be undefined non-existent
     const label = ' '
@@ -79,6 +86,7 @@ export default {
       timeOut: null
     }
   },
+
   computed: {
     isPanelWindow() {
       return this.metadata.panelType === 'window'
@@ -185,9 +193,11 @@ export default {
       }
     }
   },
+
   created() {
     this.changeBlankOption()
   },
+
   methods: {
     parseValue(value) {
       if (typeof value === 'boolean') {

--- a/src/components/ADempiere/Field/FieldLocation/index.vue
+++ b/src/components/ADempiere/Field/FieldLocation/index.vue
@@ -39,29 +39,36 @@
 </template>
 
 <script>
+// mixins
 import fieldMixin from '@/components/ADempiere/Field/mixin/mixinField.js'
 import mixinLocation from './mixinLocation.js'
+
+// components
 import LocationAddressForm from './locationAddressForm'
 
 export default {
   name: 'FieldLocation',
+
   components: {
     LocationAddressForm
   },
+
   mixins: [
     fieldMixin,
     mixinLocation
   ],
+
   data() {
     return {
       localValues: {}
     }
   },
+
   computed: {
     displayedValue: {
       get() {
         /**
-         * TODO: Add DisplayColumn (to locator's and location's fields) in entities
+         * TODO: Add DisplayColumnName (to locator's and location's fields) in entities
          * list response, to set value or empty value in fieldValue state when
          * change records with dataTable.
          */
@@ -90,11 +97,13 @@ export default {
       return this.metadata.popoverPlacement || 'top'
     }
   },
+
   mounted() {
     if (!this.metadata.isAdvancedQuery) {
       this.getLocation()
     }
   },
+
   methods: {
     getLocation() {
       if (!this.isEmptyValue(this.displayedValue)) {

--- a/src/components/ADempiere/Field/FieldOptions/documentStatus/index.vue
+++ b/src/components/ADempiere/Field/FieldOptions/documentStatus/index.vue
@@ -39,7 +39,7 @@
       v-if="isEmptyValue(valueActionDocument)"
       :type="tagStatus(fieldAttributes.value)"
     >
-      {{ fieldAttributes.displayColumn }}
+      {{ fieldAttributes.displayColumnName }}
     </el-tag>
     <el-tag
       v-else
@@ -73,6 +73,7 @@ export default {
       valueActionDocument: ''
     }
   },
+
   computed: {
     withoutRecord() {
       // TODO: Validate with record attribute
@@ -114,6 +115,7 @@ export default {
       return this.$store.getters.getOrders
     }
   },
+
   methods: {
     listActionDocument(isShowList) {
       if (isShowList) {

--- a/src/components/ADempiere/Field/FieldSelect.vue
+++ b/src/components/ADempiere/Field/FieldSelect.vue
@@ -283,17 +283,18 @@ export default {
           this.displayedValue = option.label
           this.uuidValue = option.uuid
         } else {
-          if (!this.isEmptyValue(this.metadata.displayColumnName)) {
+          if (!this.isEmptyValue(this.displayedValue)) {
             // verify if exists to add
             this.optionsList.push({
               id: value,
               // TODO: Add uuid
-              label: this.metadata.displayColumnName
+              label: this.displayedValue
             })
           } else {
             if (!this.isPanelWindow || (this.isPanelWindow &&
               !this.isEmptyValue(this.$route.query) &&
               this.$route.query.action === 'create-new')) {
+              // request lookup
               this.getDataLookupItem()
             }
           }

--- a/src/components/ADempiere/Field/FieldSelect.vue
+++ b/src/components/ADempiere/Field/FieldSelect.vue
@@ -48,6 +48,7 @@ import fieldMixin from '@/components/ADempiere/Field/mixin/mixinField.js'
 
 // utils and helper methods
 import { convertBooleanToString } from '@/utils/ADempiere/formatValue/booleanFormat.js'
+import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 
 /**
  * This component is a lookup type field, use as a replacement for fields:
@@ -149,26 +150,6 @@ export default {
           })
         }
 
-        if (this.isEmptyValue(value)) {
-          /* eslint-disable */
-          this.displayedValue = undefined
-          this.uuidValue = undefined
-          /* eslint-disable */
-          return value
-        }
-
-        const option = this.findOption(value)
-        if (!option.label) {
-          const label = this.displayedValue
-          /* eslint-disable */
-          this.optionsList.push({
-            // TODO: Add uuid
-            id: value,
-            label
-          })
-          /* eslint-disable */
-        }
-
         return value
       },
       set(value) {
@@ -193,7 +174,7 @@ export default {
           parentUuid: this.metadata.parentUuid,
           containerUuid: this.metadata.containerUuid,
           // 'ColumnName'_UUID
-          columnName: this.metadata.columnName + '_UUID',
+          columnName: this.metadata.columnName + '_UUID'
         })
       },
       set(value) {
@@ -265,6 +246,27 @@ export default {
       if (value) {
         // if is field showed, search into store all options to list
         this.optionsList = this.getterLookupAll
+      }
+    },
+    value(newValue) {
+      if (isEmptyValue(newValue)) {
+        this.displayedValue = undefined
+        this.uuidValue = undefined
+      } else {
+        const option = this.findOption(newValue)
+        if (!option.label) {
+          const label = this.displayedValue
+          if (!isEmptyValue(label)) {
+            this.optionsList.push({
+              // TODO: Add uuid
+              id: newValue,
+              label
+            })
+          } else {
+            // request lookup
+            this.getDataLookupItem()
+          }
+        }
       }
     }
   },

--- a/src/components/ADempiere/Field/FieldSelect.vue
+++ b/src/components/ADempiere/Field/FieldSelect.vue
@@ -43,8 +43,11 @@
 </template>
 
 <script>
+// mixins
 import fieldMixin from '@/components/ADempiere/Field/mixin/mixinField.js'
-import { convertBooleanToString } from '@/utils/ADempiere/valueFormat.js'
+
+// utils and helper methods
+import { convertBooleanToString } from '@/utils/ADempiere/formatValue/booleanFormat.js'
 
 /**
  * This component is a lookup type field, use as a replacement for fields:
@@ -58,7 +61,11 @@ import { convertBooleanToString } from '@/utils/ADempiere/valueFormat.js'
  */
 export default {
   name: 'FieldSelect',
-  mixins: [fieldMixin],
+
+  mixins: [
+    fieldMixin
+  ],
+
   data() {
     // label with '' value is assumed to be undefined non-existent
     const label = ' '
@@ -75,6 +82,7 @@ export default {
       blankOption
     }
   },
+
   computed: {
     isPanelWindow() {
       return this.metadata.panelType === 'window'
@@ -231,6 +239,7 @@ export default {
       }
     }
   },
+
   watch: {
     isSelectMultiple(isMultiple) {
       let value = this.value
@@ -259,9 +268,11 @@ export default {
       }
     }
   },
+
   created() {
     this.changeBlankOption()
   },
+
   beforeMount() {
     if (this.metadata.displayed) {
       this.optionsList = this.getterLookupAll
@@ -272,13 +283,12 @@ export default {
           this.displayedValue = option.label
           this.uuidValue = option.uuid
         } else {
-          // TODO: Property displayColumn is @deprecated
-          if (!this.isEmptyValue(this.metadata.displayColumn)) {
+          if (!this.isEmptyValue(this.metadata.displayColumnName)) {
             // verify if exists to add
             this.optionsList.push({
               id: value,
               // TODO: Add uuid
-              label: this.metadata.displayColumn
+              label: this.metadata.displayColumnName
             })
           } else {
             if (!this.isPanelWindow || (this.isPanelWindow &&
@@ -291,6 +301,7 @@ export default {
       }
     }
   },
+
   methods: {
     parseValue(value) {
       if (typeof value === 'boolean') {

--- a/src/components/ADempiere/Field/FieldSelect.vue
+++ b/src/components/ADempiere/Field/FieldSelect.vue
@@ -134,23 +134,19 @@ export default {
     value: {
       get() {
         const { columnName, containerUuid } = this.metadata
-        let value
         // table records values
         if (this.metadata.inTable) {
           const row = this.$store.getters.getRowData({
             containerUuid,
             index: this.metadata.tableIndex
           })
-          value = row[columnName]
-        } else {
-          value = this.$store.getters.getValueOfField({
-            parentUuid: this.metadata.parentUuid,
-            containerUuid,
-            columnName
-          })
+          return row[columnName]
         }
-
-        return value
+        return this.$store.getters.getValueOfField({
+          parentUuid: this.metadata.parentUuid,
+          containerUuid,
+          columnName
+        })
       },
       set(value) {
         const option = this.findOption(value)
@@ -192,6 +188,7 @@ export default {
     },
     displayedValue: {
       get() {
+        // DisplayColumn_'ColumnName'
         const { displayColumnName: columnName, containerUuid } = this.metadata
         // table records values
         if (this.metadata.inTable) {
@@ -199,13 +196,11 @@ export default {
             containerUuid,
             index: this.metadata.tableIndex
           })
-          // DisplayColumn_'ColumnName'
           return row[columnName]
         }
         return this.$store.getters.getValueOfField({
           parentUuid: this.metadata.parentUuid,
           containerUuid,
-          // DisplayColumn_'ColumnName'
           columnName
         })
       },
@@ -252,20 +247,21 @@ export default {
       if (isEmptyValue(newValue)) {
         this.displayedValue = undefined
         this.uuidValue = undefined
-      } else {
-        const option = this.findOption(newValue)
-        if (!option.label) {
-          const label = this.displayedValue
-          if (!isEmptyValue(label)) {
-            this.optionsList.push({
-              // TODO: Add uuid
-              id: newValue,
-              label
-            })
-          } else {
-            // request lookup
-            this.getDataLookupItem()
-          }
+        return
+      }
+
+      const option = this.findOption(newValue)
+      if (!option.label) {
+        const label = this.displayedValue
+        if (!isEmptyValue(label)) {
+          this.optionsList.push({
+            // TODO: Add uuid
+            id: newValue,
+            label
+          })
+        } else {
+          // request lookup
+          this.getDataLookupItem()
         }
       }
     }

--- a/src/components/ADempiere/Field/mixin/mixinField.js
+++ b/src/components/ADempiere/Field/mixin/mixinField.js
@@ -186,7 +186,7 @@ export default {
     /**
      * @param {mixed} value, main value in component
      * @param {mixed} valueTo, used in end value in range
-     * @param {string} label, or displayColumn to show in select
+     * @param {string} label, or displayColumnName to show in select
      */
     handleFieldChange({
       value,

--- a/src/store/modules/ADempiere/data/actions.js
+++ b/src/store/modules/ADempiere/data/actions.js
@@ -1,4 +1,25 @@
+// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import language from '@/lang'
+
+// constants
+import { TABLE, TABLE_DIRECT } from '@/utils/ADempiere/references'
+
+// api request methods
 import {
   getEntity
 } from '@/api/ADempiere/common/persistence.js'
@@ -11,6 +32,8 @@ import {
   lockPrivateAccess,
   unlockPrivateAccess
 } from '@/api/ADempiere/actions/private-access'
+
+// utils and helper methods
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 import { convertArrayKeyValueToObject } from '@/utils/ADempiere/valueFormat.js'
 import { typeValue } from '@/utils/ADempiere/valueUtils.js'
@@ -19,8 +42,6 @@ import {
   getPreference
 } from '@/utils/ADempiere/contextUtils'
 import { showMessage } from '@/utils/ADempiere/notification'
-import { TABLE, TABLE_DIRECT } from '@/utils/ADempiere/references'
-import language from '@/lang'
 
 const actions = {
   /**
@@ -490,7 +511,7 @@ const actions = {
     isSendToServer = true,
     isSendCallout = true,
     newValue,
-    displayColumn,
+    displayColumnName,
     withOutColumnNames = []
   }) {
     // dispatch('setPreferenceContext', {
@@ -519,7 +540,7 @@ const actions = {
       row,
       value: newValue,
       columnName,
-      displayColumn
+      displayColumnName
     })
 
     if (panelType === 'browser') {
@@ -530,7 +551,7 @@ const actions = {
         row: rowSelection,
         value: newValue,
         columnName,
-        displayColumn
+        displayColumnName
       })
     } else if (panelType === 'window') {
       // request callouts

--- a/src/store/modules/ADempiere/data/mutations.js
+++ b/src/store/modules/ADempiere/data/mutations.js
@@ -1,3 +1,18 @@
+// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 const mutations = {
   addRecordSelection(state, payload) {
@@ -20,17 +35,17 @@ const mutations = {
   },
   notifyCellTableChange: (state, payload) => {
     payload.row[payload.columnName] = payload.value
-    if (payload.displayColumn !== undefined) {
+    if (payload.displayColumnName !== undefined) {
       const key = `DisplayColumn_${payload.columnName}`
-      payload.row[key] = payload.displayColumn
+      payload.row[key] = payload.displayColumnName
     }
   },
   notifyCellSelectionChange: (state, payload) => {
     if (payload.row !== undefined) {
       payload.row[payload.columnName] = payload.value
-      if (payload.displayColumn !== undefined) {
+      if (payload.displayColumnName !== undefined) {
         const key = `DisplayColumn_${payload.columnName}`
-        payload.row[key] = payload.displayColumn
+        payload.row[key] = payload.displayColumnName
       }
     }
   },

--- a/src/store/modules/ADempiere/panel/getters.js
+++ b/src/store/modules/ADempiere/panel/getters.js
@@ -252,7 +252,7 @@ const getters = {
     return attributesList
   },
 
-  getParsedDefaultValues: (state, getters) => ({
+  getParsedDefaultValues: (state, getters, rootState, rootGetters) => ({
     parentUuid,
     containerUuid,
     isGetServer = true,
@@ -264,6 +264,7 @@ const getters = {
       fieldsList = getters.getFieldsListFromPanel(containerUuid)
     }
     const attributesRangue = []
+    const attributesDisplayColumn = []
     const attributesObject = {}
     let attributesList = fieldsList
       .map(fieldItem => {
@@ -312,9 +313,33 @@ const getters = {
         }
 
         // add display column to default
-        if (fieldItem.componentPath === 'FieldSelect' && fieldItem.value === parsedDefaultValue) {
-          // TODO: Verify displayColumnName attribute, or get dispay column to fieldValue store
-          attributesObject[fieldItem.displayColumnName] = fieldItem.displayColumnName
+        if (fieldItem.componentPath === 'FieldSelect') {
+          const { displayColumnName } = fieldItem
+          let displayedValue
+          if (!isEmptyValue(parsedDefaultValue)) {
+            const { tableName, directQuery, query } = fieldItem.reference
+            const optionsList = rootGetters.getLookupAll({
+              parentUuid,
+              containerUuid,
+              directQuery,
+              tableName,
+              query,
+              value: parsedDefaultValue
+            })
+            if (!isEmptyValue(optionsList)) {
+              const option = optionsList.find(item => item.id === parsedDefaultValue)
+              if (!isEmptyValue(option)) {
+                displayedValue = option.label
+              }
+            }
+          }
+
+          attributesObject[displayColumnName] = displayedValue
+          attributesDisplayColumn.push({
+            columnName: displayColumnName,
+            value: displayedValue,
+            isSQL
+          })
         }
 
         return {
@@ -325,7 +350,7 @@ const getters = {
         }
       })
     if (formatToReturn === 'array') {
-      attributesList = attributesList.concat(attributesRangue)
+      attributesList = attributesList.concat(attributesRangue, attributesDisplayColumn)
       return attributesList
     }
     return attributesObject

--- a/src/store/modules/ADempiere/panel/getters.js
+++ b/src/store/modules/ADempiere/panel/getters.js
@@ -216,12 +216,12 @@ const getters = {
         attributesObject[fieldItem.columnName] = valueToReturn
 
         // Add display columns if field has value
-        if (fieldItem[propertyName] && fieldItem.displayColumn) {
-          // TODO: Verify displayColumn attribute, or get dispay column to fieldValue store
-          attributesObject[fieldItem.displayColumnName] = fieldItem.displayColumn
+        if (fieldItem[propertyName] && fieldItem.displayColumnName) {
+          // TODO: Verify displayColumnName attribute, or get dispay column to fieldValue store
+          attributesObject[fieldItem.displayColumnName] = fieldItem.displayColumnName
           displayColumnsList.push({
             columnName: fieldItem.displayColumnName,
-            value: fieldItem.displayColumn
+            value: fieldItem.displayColumnName
           })
         }
 
@@ -313,8 +313,8 @@ const getters = {
 
         // add display column to default
         if (fieldItem.componentPath === 'FieldSelect' && fieldItem.value === parsedDefaultValue) {
-          // TODO: Verify displayColumn attribute, or get dispay column to fieldValue store
-          attributesObject[fieldItem.displayColumnName] = fieldItem.displayColumn
+          // TODO: Verify displayColumnName attribute, or get dispay column to fieldValue store
+          attributesObject[fieldItem.displayColumnName] = fieldItem.displayColumnName
         }
 
         return {

--- a/src/utils/ADempiere/contextUtils.js
+++ b/src/utils/ADempiere/contextUtils.js
@@ -1,6 +1,6 @@
 // ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
 // Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
-// Contributor(s): Edwin Betancourt edwinBetanc0urt@hotmail.com www.erpya.com
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
@@ -14,11 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
-import { convertBooleanToString } from '@/utils/ADempiere/valueFormat.js'
-import { ACCOUNTING_COLUMNS } from '@/utils/ADempiere/constants/systemColumns.js'
-import evaluator from '@/utils/ADempiere/evaluator'
 import store from '@/store'
+
+// constants
+import { ACCOUNTING_COLUMNS } from '@/utils/ADempiere/constants/systemColumns.js'
+
+// utils and helper methods
+import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
+import { convertBooleanToString } from '@/utils/ADempiere/formatValue/booleanFormat.js'
+import evaluator from '@/utils/ADempiere/evaluator'
 
 export default evaluator
 

--- a/src/utils/ADempiere/dictionaryUtils.js
+++ b/src/utils/ADempiere/dictionaryUtils.js
@@ -133,8 +133,6 @@ export function generateField({
     componentPath: componentReference.componentPath,
     isSupported: componentReference.isSupported,
     size: componentReference.size || DEFAULT_SIZE,
-    // TODO: Property 'displayColumn' is @depecated
-    displayColumn: undefined, // link to value from selects and table
     displayColumnName: `DisplayColumn_${fieldToGenerate.columnName}`, // key to display column
     // value attributes
     value: String(parsedDefaultValue).trim() === '' ? undefined : parsedDefaultValue,

--- a/src/utils/ADempiere/formatValue/booleanFormat.js
+++ b/src/utils/ADempiere/formatValue/booleanFormat.js
@@ -28,3 +28,16 @@ export const convertBooleanToTranslationLang = (booleanValue) => {
 
   return language.t('components.switchInactiveText')
 }
+
+/**
+ * Convert boolean value to string value
+ * @param {boolean} booleanValue
+ * @returns {strin}
+ */
+export const convertBooleanToString = (booleanValue) => {
+  if (booleanValue === true || booleanValue === 'true' || booleanValue === 'Y') {
+    return 'Y'
+  }
+
+  return 'N'
+}

--- a/src/utils/ADempiere/lookupFactory.js
+++ b/src/utils/ADempiere/lookupFactory.js
@@ -60,14 +60,18 @@
 // - query
 // - directQuery
 // - tableName
-// - displayColumn
+// - displayColumnName
 // - defaultValue
 
+import store from '@/store'
+
+// constants
 import { CHAR, DEFAULT_SIZE, TABLE_DIRECT } from '@/utils/ADempiere/references.js'
 import { evalutateTypeField, getDefaultValue, getEvaluatedLogics } from '@/utils/ADempiere/dictionaryUtils.js'
+
+// utils and helper methods
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 import { getParentFields } from '@/utils/ADempiere/contextUtils.js'
-import store from '@/store'
 
 // Create a Field from UUID based on server meta-data
 export function createFieldFromDictionary({

--- a/src/utils/ADempiere/valueFormat.js
+++ b/src/utils/ADempiere/valueFormat.js
@@ -49,13 +49,6 @@ export const convertStringToBoolean = (valueToParsed) => {
   return valReturn
 }
 
-export const convertBooleanToString = (booleanValue) => {
-  if (booleanValue || booleanValue === 'true') {
-    return 'Y'
-  }
-  return 'N'
-}
-
 /**
  * Convert a object to array pairs
  * @param {object} object, object to convert

--- a/src/utils/ADempiere/valueUtils.js
+++ b/src/utils/ADempiere/valueUtils.js
@@ -14,9 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { convertStringToBoolean, convertBooleanToString } from '@/utils/ADempiere/valueFormat.js'
-import { TABLE, TABLE_DIRECT } from '@/utils/ADempiere/references.js'
 import language from '@/lang'
+
+// constants
+import { TABLE, TABLE_DIRECT } from '@/utils/ADempiere/references.js'
+
+// utils and helper methods
+import { convertStringToBoolean } from '@/utils/ADempiere/valueFormat.js'
+import { convertBooleanToString } from '@/utils/ADempiere/formatValue/booleanFormat.js'
 
 /**
  * Checks if value is empty. Deep-checks arrays and objects


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Description
The use of the depreciated `displayColumn` attribute is eliminated by using the `displayColumnName`

#### Screenshot or Gif
Before this changes:

https://user-images.githubusercontent.com/20288327/139169108-ab461f37-9a76-4666-a192-d01d2038f2cc.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/139169047-32cb7017-555a-447c-bdb3-f99bfe2f38d7.mp4


#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

