### PR TITLE
fix: Fields options popover style.

### DIFF
--- a/src/components/ADempiere/Field/FieldOptions/CalculatorField/index.vue
+++ b/src/components/ADempiere/Field/FieldOptions/CalculatorField/index.vue
@@ -17,8 +17,8 @@
 -->
 
 <template>
-  <el-card class="box-card calculator-option">
-    <div slot="header" class="clearfix">
+  <el-card class="field-option-card calculator-option">
+    <div slot="header">
       <span>
         {{ $t('fieldOptions.field') }}:
         <b> {{ fieldAttributes.name }} </b>
@@ -379,6 +379,8 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../common-style.scss">
+</style>
 <style lang="scss">
 .calculator-option {
   .el-card__header {

--- a/src/components/ADempiere/Field/FieldOptions/ChangeLogs/index.vue
+++ b/src/components/ADempiere/Field/FieldOptions/ChangeLogs/index.vue
@@ -81,7 +81,8 @@
 <script>
 
 export default {
-  name: 'FieldChangeLogs',
+  name: 'ChangeLogsField',
+
   props: {
     fieldAttributes: {
       type: Object,
@@ -92,6 +93,7 @@ export default {
       default: undefined
     }
   },
+
   data() {
     return {
       isLoading: false,
@@ -99,6 +101,7 @@ export default {
       typeAction: 0
     }
   },
+
   computed: {
     language() {
       return this.$store.getters.language
@@ -135,6 +138,7 @@ export default {
       return 'scroll-child'
     }
   },
+
   methods: {
     sortSequence(itemA, itemB) {
       return new Date().setTime(new Date(itemB.logDate).getTime()) - new Date().setTime(new Date(itemA.logDate).getTime())
@@ -151,6 +155,7 @@ export default {
       }
     }
   }
+
 }
 </script>
 

--- a/src/components/ADempiere/Field/FieldOptions/ContextInfo/index.vue
+++ b/src/components/ADempiere/Field/FieldOptions/ContextInfo/index.vue
@@ -17,52 +17,65 @@
 -->
 
 <template>
-  <div>
-    <el-card class="box-card" style="padding: 1%;">
-      <div slot="header" class="clearfix">
-        <span>
-          {{ $t('field.field') }}
-          <b> {{ fieldAttributes.name }} </b>
-        </span>
-      </div>
-      <el-scrollbar wrap-class="scroll-child">
-        <el-form
-          ref="form"
-          label-position="top"
-          label-width="120px"
-          style="overflow: auto;"
-          @submit.native.prevent="notSubmitForm"
+  <el-card class="field-option-card context-info">
+    <div slot="header">
+      <span>
+        {{ $t('field.field') }}
+        <b> {{ fieldAttributes.name }} </b>
+      </span>
+    </div>
+
+    <el-scrollbar wrap-class="scroll-child">
+      <el-form
+        ref="form"
+        class="form-context-info"
+        label-position="top"
+        label-width="120px"
+        style="overflow: auto;"
+        @submit.native.prevent="notSubmitForm"
+      >
+        <el-form-item
+          v-if="!isEmptyValue(messageText)"
+          :label="$t('field.contextInfo')"
+          class="justify-text"
         >
-          <el-form-item v-if="!isEmptyValue(messageText)" :label="$t('field.contextInfo')">
-            {{ messageText }}
-          </el-form-item>
+          {{ messageText }}
+        </el-form-item>
 
-          <el-form-item :label="$t('field.container.description')">
-            {{ fieldAttributes.description }}
-          </el-form-item>
-
-          <el-form-item :label="$t('field.container.help')" style="word-break: normal">
-            {{ fieldAttributes.help }}
-          </el-form-item>
-        </el-form>
-      </el-scrollbar>
-
-      <template v-for="(zoomItem, index) in fieldAttributes.reference.zoomWindows">
-        <el-button
-          :key="index"
-          type="text"
-          @click="redirect({ window: zoomItem })"
+        <el-form-item
+          :label="$t('field.container.description')"
+          class="justify-text"
         >
-          {{ $t('table.ProcessActivity.zoomIn') }}
-          {{ zoomItem.name }}
-        </el-button>
-      </template>
-    </el-card>
-  </div>
+          {{ fieldAttributes.description }}
+        </el-form-item>
+
+        <el-form-item
+          v-if="!isEmptyValue(fieldAttributes.help)"
+          :label="$t('field.container.help')"
+          class="justify-text"
+        >
+          {{ fieldAttributes.help }}
+        </el-form-item>
+      </el-form>
+    </el-scrollbar>
+
+    <template v-for="(zoomItem, index) in fieldAttributes.reference.zoomWindows">
+      <el-button
+        :key="index"
+        type="text"
+        @click="redirect({ window: zoomItem })"
+      >
+        {{ $t('table.ProcessActivity.zoomIn') }}
+        {{ zoomItem.name }}
+      </el-button>
+    </template>
+  </el-card>
 </template>
 
 <script>
 import { defineComponent, computed } from '@vue/composition-api'
+
+// utils and helper methods
 import { zoomIn } from '@/utils/ADempiere/coreUtils.js'
 import { parseContext } from '@/utils/ADempiere/contextUtils'
 
@@ -95,11 +108,6 @@ export default defineComponent({
       }
       return ''
     })
-
-    function notSubmitForm(event) {
-      event.preventDefault()
-      return false
-    }
 
     function redirect({ window }) {
       const { columnName } = props.fieldAttributes
@@ -147,9 +155,30 @@ export default defineComponent({
       // computeds
       messageText,
       // methods
-      notSubmitForm,
       redirect
     }
   }
 })
 </script>
+
+<style lang="scss" src="../common-style.scss">
+</style>
+<style lang="scss">
+.context-info {
+  &.el-card {
+    max-width: 300px;
+
+    .form-context-info {
+      .el-form-item {
+        // spacing between form items
+        padding-bottom: 10px;
+
+        .el-form-item__content {
+          // text content interline
+          line-height: 20px;
+        }
+      }
+    }
+  }
+}
+</style>

--- a/src/components/ADempiere/Field/FieldOptions/DocumentStatus/index.vue
+++ b/src/components/ADempiere/Field/FieldOptions/DocumentStatus/index.vue
@@ -15,6 +15,7 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https:www.gnu.org/licenses/>.
 -->
+
 <template>
   <el-popover
     v-if="(fieldAttributes.columnName === 'DocStatus') && (!isEmptyValue(processOrderUuid))"
@@ -59,7 +60,7 @@
 
 <script>
 export default {
-  name: 'FieldDocumentStatus',
+  name: 'DocumentStatusField',
 
   props: {
     fieldAttributes: {
@@ -159,5 +160,6 @@ export default {
       this.valueActionDocument = ''
     }
   }
+
 }
 </script>

--- a/src/components/ADempiere/Field/FieldOptions/LabelField.vue
+++ b/src/components/ADempiere/Field/FieldOptions/LabelField.vue
@@ -24,22 +24,25 @@ export default defineComponent({
     label: {
       type: String,
       default: ''
-    },
-    isMobile: {
-      type: Boolean,
-      default: false
     }
   },
 
-  setup(props) {
+  setup(props, { root }) {
+    const isMobile = computed(() => {
+      return root.$store.state.app.device === 'mobile'
+    })
+
     const labelStyle = computed(() => {
-      let displayStyle
-      props.isMobile ? displayStyle = 'display: flex; width: auto;' : 'display: block;'
+      let displayStyle = 'display: block;'
+      if (isMobile.value) {
+        displayStyle = 'display: flex; width: auto;'
+      }
+
       return displayStyle + ' margin-left: 3px;'
     })
 
     const iconStyle = computed(() => {
-      if (props.isMobile) {
+      if (isMobile.value) {
         return 'margin-left: 5px; margin-top: 7px;'
       }
       return 'margin-left: -5px; padding-bottom: 6px;'

--- a/src/components/ADempiere/Field/FieldOptions/LabelPopoverOption.vue
+++ b/src/components/ADempiere/Field/FieldOptions/LabelPopoverOption.vue
@@ -1,7 +1,16 @@
 <template>
-  <div :style="textStyle">
-    <i v-if="!option.svg" :class="option.icon" style="font-weight: bolder;" />
-    <svg-icon v-else :icon-class="option.icon" :style="iconWrapperStyle" />
+  <div class="label-popover-option" :style="textStyle">
+    <i
+      v-if="!option.svg"
+      :class="option.icon"
+      style="font-weight: bolder;"
+    />
+    <svg-icon
+      v-else
+      :icon-class="option.icon"
+      :style="iconWrapperStyle"
+    />
+
     <span>
       <b class="label">
         {{ option.name }}
@@ -11,7 +20,11 @@
 </template>
 
 <script>
-export default {
+import { defineComponent, computed } from '@vue/composition-api'
+
+export default defineComponent({
+  name: 'LabelPopoverOption',
+
   props: {
     option: {
       type: Object,
@@ -22,29 +35,44 @@ export default {
       default: false
     }
   },
-  computed: {
-    iconWrapperStyle() {
-      if (this.isMobile) {
-        return { 'margin-right': '6px' }
+
+  setup(props) {
+    const iconWrapperStyle = computed(() => {
+      if (props.isMobile) {
+        return {
+          'margin-right': '6px'
+        }
       }
       return {
         'margin-left': '5px',
         'margin-right': '13px'
       }
-    },
-    textStyle() {
-      if (!this.isMobile) {
-        return ''
+    })
+
+    const textStyle = computed(() => {
+      if (props.isMobile) {
+        return {
+          'font-size': '130%',
+          'margin': '7px'
+        }
       }
-      return { 'font-size': '130%', 'margin': '7px' }
+      return ''
+    })
+
+    return {
+      iconWrapperStyle,
+      textStyle
     }
   }
-}
+
+})
 </script>
 
-<style >
-.svg-icon-wrapper {
+<style lang="scss">
+.label-popover-option {
+  .svg-icon-wrapper {
     margin-left: 5px;
     margin-right: 13px;
+  }
 }
 </style>

--- a/src/components/ADempiere/Field/FieldOptions/OperatorComparison/index.vue
+++ b/src/components/ADempiere/Field/FieldOptions/OperatorComparison/index.vue
@@ -40,7 +40,7 @@
 import { computed, defineComponent, ref } from '@vue/composition-api'
 
 export default defineComponent({
-  name: 'FieldOperatorComparison',
+  name: 'OperatorComparisonField',
 
   props: {
     fieldAttributes: {

--- a/src/components/ADempiere/Field/FieldOptions/PreferenceValue/index.vue
+++ b/src/components/ADempiere/Field/FieldOptions/PreferenceValue/index.vue
@@ -19,55 +19,68 @@
 <template>
   <el-card
     v-if="!isEmptyValue(metadataList)"
-    class="box-card"
-    style="padding: 1%;"
+    class="field-option-card preference-value"
+    style="min-width: 430px;"
   >
-    <div slot="header" class="clearfix">
+    <div slot="header">
       <span>
-        {{ $t('components.preference.title') }}
+        {{ $t('components.preference.title') }}:
         <b>
           {{ fieldAttributes.name }}
-          {{ fieldValue }}
         </b>
       </span>
     </div>
-    <div class="text item">
+    <div class="justify-text">
       {{ getDescriptionOfPreference }}
     </div>
-    <br>
 
-    <div class="text item">
-      <el-form
-        :inline="true"
-      >
-        <el-form-item>
-          <p slot="label">
-            {{ fieldAttributes.name }}: {{ fieldValue }}
-          </p>
-        </el-form-item>
-      </el-form>
+    <div style="margin-top: 10px;">
+      <ul>
+        <li>
+          {{ $t('fieldOptions.currentValue') }}:
+          <b>
+            <!-- TODO: Add parsed value to boolean and date -->
+            <template v-if="!isEmptyValue(displayedValue)">
+              {{ value }} - {{ displayedValue }}
+            </template>
+            <template v-else>
+              {{ value }}
+            </template>
+          </b>
+        </li>
+      </ul>
+
+      <hr>
       <el-form
         label-position="top"
         :inline="true"
-        class="demo-form-inline"
+        class="form-values"
         size="medium"
       >
-        <el-form-item
-          v-for="(field) in metadataList"
-          :key="field.sequence"
-        >
-          <p slot="label">
-            {{ field.name }}
-          </p>
-          <el-switch
-            v-model="field.value"
-          />
-        </el-form-item>
+        <el-row>
+          <el-col
+            v-for="(field) in metadataList"
+            :key="field.sequence"
+            :xs="6"
+            :sm="6"
+            :md="6"
+            :lg="6"
+            :xl="6"
+          >
+            <el-form-item>
+              <p slot="label" style="margin-bottom: 0px;margin-top: 0px;">
+                {{ field.name }}
+              </p>
+              <el-switch
+                v-model="field.value"
+              />
+            </el-form-item>
+          </el-col>
+        </el-row>
       </el-form>
     </div>
-    <br>
 
-    <el-row>
+    <el-row class="footer">
       <el-col :span="24">
         <samp style="float: left; padding-right: 10px;">
           <el-button
@@ -114,21 +127,19 @@ import { setPreference, deletePreference } from '@/api/ADempiere/field/preferenc
 
 export default {
   name: 'PreferenceValue',
+
   mixins: [
     formMixin
   ],
+
   props: {
     fieldAttributes: {
       type: [Object],
       required: true,
       default: null
-    },
-    fieldValue: {
-      type: [String, Number, Boolean, Date, Array, Object],
-      required: true,
-      default: ''
     }
   },
+
   data() {
     return {
       preferenceFields,
@@ -138,6 +149,7 @@ export default {
       isActive: false
     }
   },
+
   computed: {
     fieldsListPreference() {
       return this.metadataList.map(item => {
@@ -147,6 +159,39 @@ export default {
           columnName: item.columnName,
           sequence: item.sequence
         }
+      })
+    },
+    value() {
+      const { columnName, containerUuid, inTable } = this.fieldAttributes
+      // table records values
+      if (inTable) {
+        const row = this.$store.getters.getRowData({
+          containerUuid,
+          index: this.fieldAttributes.tableIndex
+        })
+        return row[columnName]
+      }
+      return this.$store.getters.getValueOfField({
+        parentUuid: this.fieldAttributes.parentUuid,
+        containerUuid,
+        columnName
+      })
+    },
+    displayedValue() {
+      // DisplayColumn_'ColumnName'
+      const { displayColumnName: columnName, containerUuid, inTable } = this.fieldAttributes
+      // table records values
+      if (inTable) {
+        const row = this.$store.getters.getRowData({
+          containerUuid,
+          index: this.fieldAttributes.tableIndex
+        })
+        return row[columnName]
+      }
+      return this.$store.getters.getValueOfField({
+        parentUuid: this.fieldAttributes.parentUuid,
+        containerUuid,
+        columnName
       })
     },
 
@@ -209,10 +254,11 @@ export default {
       return expl
     }
   },
+
   watch: {
-    isActive(value) {
-      const preferenceValue = this.fieldValue
-      if (value && this.isEmptyValue(this.metadataList)) {
+    isActive(newValue) {
+      const preferenceValue = this.value
+      if (newValue && this.isEmptyValue(this.metadataList)) {
         this.setFieldsList()
       }
       if (!this.isEmptyValue(preferenceValue)) {
@@ -224,14 +270,17 @@ export default {
       }
     }
   },
+
   beforeMount() {
     if (this.isEmptyValue(this.metadataList)) {
       this.setFieldsList()
     }
   },
+
   methods: {
     close() {
       if (!this.isEmptyValue(this.$route.query.fieldColumnName)) {
+        /*
         this.$router.push({
           name: this.$route.name,
           query: {
@@ -240,6 +289,7 @@ export default {
             fieldColumnName: ''
           }
         }, () => {})
+        */
         this.$children[0].visible = false
         this.$store.commit('changeShowRigthPanel', false)
         this.$store.commit('changeShowOptionField', false)
@@ -278,8 +328,9 @@ export default {
             const data = metadata
             fieldsList.push({
               ...data,
-              containerUuid: 'field-reference'
+              containerUuid: `field-preference`
             })
+
             if (data.value) {
               this.description.push(data.name)
             }
@@ -294,7 +345,7 @@ export default {
       setPreference({
         parentUuid: this.fieldAttributes.parentUuid,
         attribute: this.fieldAttributes.columnName,
-        value: this.fieldValue,
+        value: this.value,
         isForCurrentClient: this.clientField.value,
         isForCurrentOrganization: this.organizationField.value,
         isForCurrentUser: this.userField.value,
@@ -316,5 +367,30 @@ export default {
         })
     }
   }
+
 }
 </script>
+
+<style lang="scss" src="../common-style.scss">
+</style>
+<style lang="scss">
+.preference-value {
+  >.el-card__body {
+    padding-top: 5px !important;
+
+    .el-form-item {
+      margin-bottom: 0px !important;
+    }
+
+    .form-values {
+      padding-bottom: 10px;
+    }
+
+    .footer {
+      // line footer
+      border-top: 1px solid #e6ebf5 !important;
+      padding-top: 10px;
+    }
+  }
+}
+</style>

--- a/src/components/ADempiere/Field/FieldOptions/PreferenceValue/index.vue
+++ b/src/components/ADempiere/Field/FieldOptions/PreferenceValue/index.vue
@@ -24,7 +24,7 @@
   >
     <div slot="header">
       <span>
-        {{ $t('components.preference.title') }}:
+        {{ $t('fieldOptions.preference.title') }}:
         <b>
           {{ fieldAttributes.name }}
         </b>
@@ -121,9 +121,13 @@
 
 <script>
 import formMixin from '@/components/ADempiere/Form/formMixin'
+
 import preferenceFields from './preferenceValueFieldsList.js'
 import { CLIENT, ORGANIZATION } from '@/utils/ADempiere/constants/systemColumns'
+
 import { setPreference, deletePreference } from '@/api/ADempiere/field/preference.js'
+
+const containerUuid = `field-preference`
 
 export default {
   name: 'PreferenceValue',
@@ -144,9 +148,9 @@ export default {
     return {
       preferenceFields,
       metadataList: [],
-      code: '',
       description: [],
-      isActive: false
+      isCustomForm: true,
+      containerUuid
     }
   },
 
@@ -217,57 +221,39 @@ export default {
     },
 
     getDescriptionOfPreference() {
-      if (this.isEmptyValue(this.metadataList)) {
-        return ''
-      }
-      if (!this.clientField) {
+      if (this.isEmptyValue(this.metadataList) || !this.clientField) {
         return ''
       }
 
       // Create Message
-      let expl = this.$t('components.preference.for')
-      if (this.clientField && this.organizationField) {
-        if (this.clientField.value && this.organizationField.value) {
-          expl = expl.concat(this.$t('components.preference.clientAndOrganization'))
-        } else if (this.clientField.value && !this.organizationField.value) {
-          expl = expl.concat(this.$t('components.preference.allOrganizationOfClient'))
-        } else if (!this.clientField.value && this.organizationField.value) {
-          expl = expl.concat(this.$t('components.preference.entireSystem'))
+      let expl = this.$t('fieldOptions.preference.for')
+      if (this.organizationField) {
+        if (this.clientField.value) {
+          if (this.organizationField.value) {
+            expl += this.$t('fieldOptions.preference.clientAndOrganization')
+          } else {
+            expl += this.$t('fieldOptions.preference.allOrganizationOfClient')
+          }
         } else {
-          expl = expl.concat(this.$t('components.preference.entireSystem'))
+          expl += this.$t('fieldOptions.preference.entireSystem')
         }
       }
 
       if (this.userField && this.containerField) {
         if (this.userField.value) {
-          expl = expl.concat(this.$t('components.preference.thisUser'))
+          expl += this.$t('fieldOptions.preference.thisUser')
         } else {
-          expl = expl.concat(this.$t('components.preference.allUsers'))
+          expl += this.$t('fieldOptions.preference.allUsers')
         }
 
         if (this.containerField.value) {
-          expl = expl.concat(this.$t('components.preference.thisWindow'))
+          expl += this.$t('fieldOptions.preference.thisWindow')
         } else {
-          expl = expl.concat(this.$t('components.preference.allWindows'))
+          expl += this.$t('fieldOptions.preference.allWindows')
         }
       }
-      return expl
-    }
-  },
 
-  watch: {
-    isActive(newValue) {
-      const preferenceValue = this.value
-      if (newValue && this.isEmptyValue(this.metadataList)) {
-        this.setFieldsList()
-      }
-      if (!this.isEmptyValue(preferenceValue)) {
-        if ((typeof preferenceValue !== 'string') && (this.fieldAttributes.componentPath !== 'FieldYesNo')) {
-          this.code = preferenceValue
-        } else {
-          this.code = preferenceValue
-        }
-      }
+      return expl
     }
   },
 
@@ -306,7 +292,7 @@ export default {
       })
         .then(() => {
           this.$message({
-            message: this.$t('components.preference.preferenceRemoved')
+            message: this.$t('fieldOptions.preference.preferenceRemoved')
           })
           this.close()
         })
@@ -324,15 +310,14 @@ export default {
       // Product Code
       this.preferenceFields.forEach(element => {
         this.createFieldFromDictionary(element)
-          .then(metadata => {
-            const data = metadata
+          .then(fieldResponse => {
             fieldsList.push({
-              ...data,
-              containerUuid: `field-preference`
+              ...fieldResponse,
+              containerUuid: this.containerUuid
             })
 
-            if (data.value) {
-              this.description.push(data.name)
+            if (fieldResponse.value) {
+              this.description.push(fieldResponse.name)
             }
           }).catch(error => {
             console.warn(`LookupFactory: Get Field From Server (State) - Error ${error.code}: ${error.message}.`)
@@ -353,17 +338,18 @@ export default {
       })
         .then(() => {
           this.$message({
-            message: this.$t('components.preference.preferenceIsOk')
+            message: this.$t('fieldOptions.preference.preferenceIsOk')
           })
-          this.close()
         })
         .catch(error => {
           this.$message({
             message: error.message,
             type: 'error'
           })
-          this.close()
           console.warn(`setPreference error: ${error.message}.`)
+        })
+        .finally(() => {
+          this.close()
         })
     }
   }

--- a/src/components/ADempiere/Field/FieldOptions/PreferenceValue/preferenceValueFieldsList.js
+++ b/src/components/ADempiere/Field/FieldOptions/PreferenceValue/preferenceValueFieldsList.js
@@ -22,6 +22,7 @@ export default [
     overwriteDefinition: {
       size: 24,
       sequence: 0,
+      isActiveLogics: true, // enable logics
       isReadOnly: true,
       handleActionPerformed: true,
       handleContentSelection: true,
@@ -37,10 +38,12 @@ export default [
     overwriteDefinition: {
       size: 24,
       sequence: 1,
+      isActiveLogics: true, // enable logics
       handleActionPerformed: true,
       handleContentSelection: true,
       handleActionKeyPerformed: true,
       componentPath: 'FieldYesNo',
+      readOnlyLogic: `@AD_Client_ID@='N'`,
       value: false
     }
   },
@@ -51,6 +54,7 @@ export default [
     overwriteDefinition: {
       size: 24,
       sequence: 2,
+      isActiveLogics: true, // enable logics
       isReadOnly: true,
       handleActionPerformed: true,
       handleContentSelection: true,
@@ -66,6 +70,7 @@ export default [
     overwriteDefinition: {
       size: 24,
       sequence: 3,
+      isActiveLogics: true, // enable logics
       isReadOnly: true,
       handleActionPerformed: true,
       handleContentSelection: true,

--- a/src/components/ADempiere/Field/FieldOptions/TranslatedField/index.vue
+++ b/src/components/ADempiere/Field/FieldOptions/TranslatedField/index.vue
@@ -1,7 +1,7 @@
 <!--
  ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
  Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
- Contributor(s): Edwin Betancourt edwinBetanc0urt@hotmail.com www.erpya.com
+ Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
@@ -15,9 +15,10 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https:www.gnu.org/licenses/>.
 -->
+
 <template>
-  <el-card class="box-card" style="padding: 1%;">
-    <div slot="header" class="clearfix">
+  <el-card class="field-option-card translated-field">
+    <div slot="header">
       <span>
         {{ $t('field.field') }}
         <b> {{ fieldAttributes.name }} </b>
@@ -93,7 +94,8 @@
 import { getLanguage } from '@/lang/index'
 
 export default {
-  name: 'FieldTranslated',
+  name: 'TranslatedField',
+
   props: {
     fieldAttributes: {
       type: Object,
@@ -104,6 +106,7 @@ export default {
       default: undefined
     }
   },
+
   data() {
     return {
       langValue: undefined,
@@ -111,6 +114,7 @@ export default {
       isLoading: false
     }
   },
+
   computed: {
     languageList() {
       return this.$store.getters.getLanguagesList.filter(itemLanguage => {
@@ -142,11 +146,13 @@ export default {
       return values[this.fieldAttributes.columnName]
     }
   },
+
   watch: {
     gettterValue(newValue, oldValue) {
       this.translatedValue = newValue
     }
   },
+
   created() {
     this.getTranslation()
     let langMatch = this.languageList.find(itemLanguage => {
@@ -159,6 +165,7 @@ export default {
     }
     this.langValue = langMatch
   },
+
   methods: {
     getTranslation() {
       if (this.isEmptyValue(this.getterTranslationValues)) {
@@ -193,9 +200,12 @@ export default {
       this.$store.commit('changeShowOptionField', false)
     }
   }
+
 }
 </script>
 
+<style lang="scss" src="../common-style.scss">
+</style>
 <style lang="scss" scoped>
   .custom-tittle-popover {
     font-size: 14px;

--- a/src/components/ADempiere/Field/FieldOptions/changeLogs/index.vue
+++ b/src/components/ADempiere/Field/FieldOptions/changeLogs/index.vue
@@ -15,14 +15,16 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https:www.gnu.org/licenses/>.
 -->
+
 <template>
-  <el-card class="box-card">
-    <div slot="header" class="clearfix">
+  <el-card class="field-option-card change-log">
+    <div slot="header">
       <span>
         {{ $t('field.logsField') }}
         <b> {{ fieldAttributes.name }} </b>
       </span>
     </div>
+
     <div>
       <el-scrollbar v-if="!isEmptyValue(listLogsField)" :wrap-class="classIsMobilePanel">
         <el-timeline>
@@ -152,6 +154,8 @@ export default {
 }
 </script>
 
+<style lang="scss" src="../common-style.scss">
+</style>
 <style lang="scss" scoped>
   .custom-tittle-popover {
     font-size: 14px;

--- a/src/components/ADempiere/Field/FieldOptions/common-style.scss
+++ b/src/components/ADempiere/Field/FieldOptions/common-style.scss
@@ -14,12 +14,35 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-const fieldOptions = {
-  // calculator
-  field: 'Field',
-  value: 'Value',
-  // preference value
-  currentValue: 'Current Value'
-}
+.field-option-card {
+  &.el-card {
+    border: 0px solid #e6ebf5 !important;
 
-export default fieldOptions
+    >.el-card__header {
+      padding: 0px;
+      padding-bottom: 5px;
+    }
+
+    >.el-card__body {
+      padding: 0px 0px;
+
+      .el-form-item {
+        margin-bottom: 0px !important;
+      }
+
+      // .el-form--label-top,
+      // .el-form--label-top &.el-form-item__label,
+      .el-form-item__label {
+        margin-top: 5px !important;
+        line-height: 20px !important;
+        padding: 0px;
+      }
+    }
+  }
+
+  &.el-card.is-always-shadow {
+    -webkit-box-shadow: 0 0px 0px 0 rgba(0, 0, 0, 0.1) !important;
+    box-shadow: 0 0px 0px 0 rgba(0, 0, 0, 0.1) !important;
+  }
+  
+}

--- a/src/components/ADempiere/Field/FieldOptions/fieldOptionsList.js
+++ b/src/components/ADempiere/Field/FieldOptions/fieldOptionsList.js
@@ -57,7 +57,7 @@ export const translateOptionItem = {
   enabled: true,
   svg: true,
   icon: 'language',
-  componentRender: () => import('@/components/ADempiere/Field/FieldOptions/translated')
+  componentRender: () => import('@/components/ADempiere/Field/FieldOptions/TranslatedField')
 }
 
 /**

--- a/src/components/ADempiere/Field/FieldOptions/fieldOptionsList.js
+++ b/src/components/ADempiere/Field/FieldOptions/fieldOptionsList.js
@@ -46,7 +46,7 @@ export const operatorOptionItem = {
   enabled: true,
   svg: false,
   icon: 'el-icon-rank',
-  componentRender: () => import('@/components/ADempiere/Field/FieldOptions/operatorComparison')
+  componentRender: () => import('@/components/ADempiere/Field/FieldOptions/OperatorComparison')
 }
 
 /**
@@ -84,7 +84,7 @@ export const logsOptionItem = {
   enabled: true,
   svg: true,
   icon: 'tree-table',
-  componentRender: () => import('@/components/ADempiere/Field/FieldOptions/changeLogs')
+  componentRender: () => import('@/components/ADempiere/Field/FieldOptions/ChangeLogs')
 }
 
 /**
@@ -95,7 +95,7 @@ export const documentStatusOptionItem = {
   enabled: true,
   svg: false,
   icon: 'el-icon-set-up',
-  componentRender: () => import('@/components/ADempiere/Field/FieldOptions/documentStatus')
+  componentRender: () => import('@/components/ADempiere/Field/FieldOptions/DocumentStatus')
 }
 
 export const optionsListStandad = [

--- a/src/components/ADempiere/Field/FieldOptions/index.vue
+++ b/src/components/ADempiere/Field/FieldOptions/index.vue
@@ -71,7 +71,8 @@
           <el-popover
             placement="top"
             trigger="click"
-            style="padding: 0px; max-width: 400px"
+            class="popover-field-options"
+            style="padding: 0px !important; max-width: 400px"
             @hide="closePopover"
           >
             <component
@@ -404,6 +405,7 @@ export default defineComponent({
 
 <style lang="scss">
 .field-options {
+  &.el-menu--horizontal,
   .el-menu--horizontal {
     // transparent background color of the field label
     &.el-menu {
@@ -432,95 +434,9 @@ export default defineComponent({
   }
 
   // hide bottom line in label
-  .el-menu.el-menu--horizontal {
-    border-bottom: solid 0px #E6E6E6;
+  .el-menu.el-menu--horizontal,
+  .el-submenu__title {
+    border-bottom: solid 0px transparent !important;
   }
 }
-</style>
-
-<style>
-/*
-.el-popover {
-  position: fixed;
-  padding: 0px;
-}
-.el-textarea {
-  position: relative;
-  width: 100%;
-  vertical-align: bottom;
-  font-size: 14px;
-  display: flex;
-}
-.el-menu--horizontal > .el-submenu .el-submenu__title {
-  height: 60px;
-  line-height: 60px;
-  border-bottom: 2px solid transparent;
-  color: #535457e3;
-}
-*/
-</style>
-<style lang="scss" scoped>
-/*
-.el-form--label-top .el-form-item__label {
-  padding-bottom: 0px !important;
-  display: block;
-}
-.el-menu.el-menu--horizontal {
-  border-bottom: solid 0px #E6E6E6;
-}
-.svg-icon {
-  width: 1em;
-  height: 1.5em;
-  vertical-align: -0.15em;
-  fill: currentColor;
-  overflow: hidden;
-}
-.el-dropdown .el-button-group {
-  display: flex;
-}
-.el-dropdown-menu {
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 10;
-  padding: 0px;
-  margin: 0px;
-  background-color: #FFFFFF;
-  border: 1px solid #e6ebf5;
-  border-radius: 4px;
-  -webkit-box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
-  box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
-  max-height: 250px;
-  max-width: 220px;
-  overflow: auto;
-}
-.el-dropdown-menu--mini .el-dropdown-menu__item {
-  line-height: 14px;
-  padding: 0px 15px;
-  padding-top: 1%;
-  padding-right: 15px;
-  padding-bottom: 1%;
-  padding-left: 15px;
-  font-size: 10px;
-}
-.el-dropdown-menu__item--divided {
-  position: relative;
-  // margin-top: 6px;
-  border-top: 1px solid #e6ebf5;
-}
-.label {
-  font-size: 14px;
-  margin-top: 0% !important;
-  margin-left: 0px;
-  text-align: initial;
-}
-.description {
-  margin: 0px;
-  font-size: 12px;
-  text-align: initial;
-}
-.contents {
-  display: inline-flex;
-}
-*/
 </style>

--- a/src/lang/ADempiere/en/fieldOptions.js
+++ b/src/lang/ADempiere/en/fieldOptions.js
@@ -19,7 +19,22 @@ const fieldOptions = {
   field: 'Field',
   value: 'Value',
   // preference value
-  currentValue: 'Current Value'
+  currentValue: 'Current Value',
+  preference: {
+    title: 'Preference Value',
+    defaultMessage: 'Applies for this ',
+    defaultMessageUser: 'Applies for this ',
+    preferenceIsOk: 'The preference is saved',
+    preferenceRemoved: 'Preference Removed',
+    for: 'For ',
+    clientAndOrganization: 'this Client and this Organization',
+    allOrganizationOfClient: 'all Organizations of this Client',
+    entireSystem: 'entire System',
+    thisUser: ', this User',
+    allUsers: ', all Users',
+    thisWindow: ' and this Window',
+    allWindows: ' and all Windows'
+  }
 }
 
 export default fieldOptions

--- a/src/lang/ADempiere/en/index.js
+++ b/src/lang/ADempiere/en/index.js
@@ -68,6 +68,7 @@ export default {
   navbar: {
     badge: {
       Notifications: 'Notifications',
+      activity: 'Worflow for Approval',
       link: 'Go to Procces Logs'
     },
     dashboard: 'Dashboard',
@@ -168,26 +169,7 @@ export default {
     resetAllFilters: 'Reset all filters',
     switchActiveText: 'Yes',
     switchInactiveText: 'Not',
-    contextFieldTitle: 'Context Information',
-    preference: {
-      title: 'Preference Value',
-      attribute: 'Attribute',
-      code: 'Code',
-      yes: 'Yes',
-      no: 'No',
-      defaultMessage: 'Applies for this ',
-      defaultMessageUser: 'Applies for this ',
-      preferenceIsOk: 'The preference is saved',
-      preferenceRemoved: 'Preference Removed',
-      for: 'For ',
-      clientAndOrganization: 'this Client and Organization',
-      allOrganizationOfClient: 'all Organizations of this Client',
-      entireSystem: 'entire System',
-      thisUser: ', this User',
-      allUsers: ', all Users',
-      thisWindow: ' and this Window',
-      allWindows: ' and all Windows'
-    }
+    contextFieldTitle: 'Context Information'
   },
   grid: {
     recordAccess: {

--- a/src/lang/ADempiere/es/fieldOptions.js
+++ b/src/lang/ADempiere/es/fieldOptions.js
@@ -19,7 +19,22 @@ const fieldOptions = {
   field: 'Campo',
   value: 'Valor',
   // preference value
-  currentValue: 'Valor Actual'
+  currentValue: 'Valor Actual',
+  preference: {
+    title: 'Valor de Preferencia',
+    defaultMessage: 'Aplica para Esta ',
+    defaultMessageUser: 'Aplica para Este ',
+    preferenceIsOk: 'Preferencia guardada',
+    preferenceRemoved: 'Preferencia Eliminada',
+    for: 'Para ',
+    clientAndOrganization: 'esta Compañía y esta Organización',
+    allOrganizationOfClient: 'todas las Organizaciones de esta Compañía',
+    entireSystem: 'todo el Sistema',
+    thisUser: ', este Usuario',
+    allUsers: ', todos los Usuarios',
+    thisWindow: ' y esta Ventana',
+    allWindows: ' y todas las Ventanas'
+  }
 }
 
 export default fieldOptions

--- a/src/lang/ADempiere/es/fieldOptions.js
+++ b/src/lang/ADempiere/es/fieldOptions.js
@@ -17,7 +17,9 @@
 const fieldOptions = {
   // calculator
   field: 'Campo',
-  value: 'Valor'
+  value: 'Valor',
+  // preference value
+  currentValue: 'Valor Actual'
 }
 
 export default fieldOptions

--- a/src/lang/ADempiere/es/index.js
+++ b/src/lang/ADempiere/es/index.js
@@ -169,26 +169,7 @@ export default {
     resetAllFilters: 'Reiniciar todos los filtros',
     switchActiveText: 'Si',
     switchInactiveText: 'No',
-    contextFieldTitle: 'Información de Contexto',
-    preference: {
-      title: 'Valor de Preferencia',
-      attribute: 'Atributo',
-      code: 'Codigo',
-      yes: 'Si',
-      no: 'No',
-      defaultMessage: 'Aplica para Esta ',
-      defaultMessageUser: 'Aplica para Este ',
-      preferenceIsOk: 'Preferencia guardada',
-      preferenceRemoved: 'Preferencia Eliminada',
-      for: 'Para ',
-      clientAndOrganization: 'esta Compañía y Organización',
-      allOrganizationOfClient: 'todas las Organizaciones de esta Compañía',
-      entireSystem: 'todo el Sistema',
-      thisUser: ', este Usuario',
-      allUsers: ', todos los Usuarios',
-      thisWindow: ' y esta Ventana',
-      allWindows: ' y todas las Ventanas'
-    }
+    contextFieldTitle: 'Información de Contexto'
   },
   grid: {
     recordAccess: {

--- a/src/styles/ADempiere/index.scss
+++ b/src/styles/ADempiere/index.scss
@@ -15,3 +15,4 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 @import './view.scss';
+@import './text.scss';

--- a/src/styles/ADempiere/text.scss
+++ b/src/styles/ADempiere/text.scss
@@ -14,12 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-const fieldOptions = {
-  // calculator
-  field: 'Field',
-  value: 'Value',
-  // preference value
-  currentValue: 'Current Value'
+.justify-text {
+  word-break: normal
 }
-
-export default fieldOptions


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open any panel with fields.
2. Expand fields options.
3. Select any option.

Note that you see 2 boxes, besides that for the select fields you only see the value but not the display value.

#### Screenshot or Gif

Before this changes:

https://user-images.githubusercontent.com/20288327/139493019-9c4d32ff-01ac-43ee-9b3a-dba15e4b2219.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/139492229-8f914f87-4a56-4243-9a96-6712a951e4e7.mp4

#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
Add any other context about the problem here.
