### PR TITLE
feat: Use computed caching in shorcut keys

### DIFF
--- a/src/components/ADempiere/Form/VPOS/Order/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Order/index.vue
@@ -15,6 +15,7 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https:www.gnu.org/licenses/>.
 -->
+
 <template>
   <div
     v-if="isLoaded"
@@ -101,7 +102,7 @@
                       <el-input-number
                         ref="editField"
                         v-model="currentEditLine"
-                        v-shortkey="isEditQtyOrdered ? {close: ['esc'], enter: ['enter']} : {}"
+                        v-shortkey="shortKeysInputTable"
                         :autofocus="true"
                         controls-position="right"
                         @change="changeEdit(currentValuePriceLine(scope.row), 'PriceEntered')"
@@ -112,7 +113,7 @@
                       <el-input-number
                         ref="editField"
                         v-model="scope.row.quantityOrdered"
-                        v-shortkey="isEditQtyOrdered ? {close: ['esc'], enter: ['enter']} : {}"
+                        v-shortkey="shortKeysInputTable"
                         :autofocus="true"
                         controls-position="right"
                         @change="changeEdit(scope.row.quantityOrdered, valueOrder.columnName)"
@@ -123,7 +124,7 @@
                       <el-input-number
                         ref="editField"
                         v-model="scope.row.discount"
-                        v-shortkey="isEditQtyOrdered ? {close: ['esc'], enter: ['enter']} : {}"
+                        v-shortkey="shortKeysInputTable"
                         :autofocus="true"
                         controls-position="right"
                         @change="changeEdit(scope.row.discount, valueOrder.columnName)"
@@ -523,6 +524,17 @@ export default {
     shortsKey() {
       return {
         popoverConvet: ['ctrl', 'x']
+      }
+    },
+    shortKeysInputTable() {
+      return {
+        if (this.isEditQtyOrdered) {
+          return {
+            close: ['esc'],
+            enter: ['enter']
+          }
+        }
+        return {}
       }
     },
     isShowedPOSKeyLayout: {

--- a/src/components/ADempiere/Form/VPOS/Order/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Order/index.vue
@@ -528,13 +528,8 @@ export default {
     },
     shortKeysInputTable() {
       return {
-        if (this.isEditQtyOrdered) {
-          return {
-            close: ['esc'],
-            enter: ['enter']
-          }
-        }
-        return {}
+        close: ['esc'],
+        enter: ['enter']
       }
     },
     isShowedPOSKeyLayout: {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

Currently we have the evaluation of the key shortcut in the template 3 times, and we recommend the use of computed in this case because if the template is rendered it will redo the evaluation 3 times, with computed it will be evaluated only once and even if the template is rendered it will not redo the evaluation of the key shortcut unless the value of `isEditQtyOrdered` is changed, in this case it will be evaluated only once.


#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
https://vuejs.org/v2/guide/computed.html#Computed-Caching-vs-Methods
https://github.com/adempiere/adempiere-vue/pull/1318
