### PR TITLE
feat: Add smart browser load table records.

### DIFF
--- a/src/components/ADempiere/DefaultTable/ColumnsDisplayOption.vue
+++ b/src/components/ADempiere/DefaultTable/ColumnsDisplayOption.vue
@@ -1,3 +1,21 @@
+<!--
+ ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+ Contributor(s): Elsio Sanchez elsiosanches@gmail.com www.erpya.com
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https:www.gnu.org/licenses/>.
+-->
+
 <template>
   <el-dropdown trigger="click" class="column-option" @command="handleCommand">
     <span class="el-dropdown-link">

--- a/src/components/ADempiere/DefaultTable/index.vue
+++ b/src/components/ADempiere/DefaultTable/index.vue
@@ -97,9 +97,12 @@
 <script>
 import { defineComponent, computed, ref } from '@vue/composition-api'
 
+// components
 import CellInfo from './CellInfo'
-import columnsDisplayOption from './columnsDisplayOption'
+import ColumnsDisplayOption from './ColumnsDisplayOption'
 import CustomPagination from '@/components/ADempiere/Pagination'
+
+// utils and helper methods
 import { fieldIsDisplayed } from '@/utils/ADempiere/dictionaryUtils'
 import { isLookup } from '@/utils/ADempiere/references'
 
@@ -108,7 +111,7 @@ export default defineComponent({
 
   components: {
     CellInfo,
-    columnsDisplayOption,
+    ColumnsDisplayOption,
     CustomPagination
   },
 
@@ -243,7 +246,7 @@ export default defineComponent({
     const handleSelection = (rowsSelection, rowsSelected) => {
       props.containerManager.setSelection({
         containerUuid: props.containerUuid,
-        recordsSelected: rowsSelected
+        recordsSelected: rowsSelection
       })
     }
 

--- a/src/utils/ADempiere/constants/table.js
+++ b/src/utils/ADempiere/constants/table.js
@@ -1,0 +1,30 @@
+// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Row default app attributes
+ */
+export const ROW_ATTRIBUTES = {
+  isNew: false,
+  isEdit: false,
+  indexRow: 0,
+  isReadOnlyFromRow: false
+}
+
+/**
+ * Row table key name attributes
+ */
+export const ROW_KEY_ATTRIBUTES = Object.keys(ROW_ATTRIBUTES)

--- a/src/utils/ADempiere/contextUtils.js
+++ b/src/utils/ADempiere/contextUtils.js
@@ -288,3 +288,33 @@ export function parseContext({
     value: outString
   }
 } // parseContext
+
+/**
+ * Get context attribures list
+ * @param {string} containerUuid
+ * @param {array<string>} contextColumnNames
+ * @returns {array<object>}
+ */
+export function getContextAttributes({
+  containerUuid,
+  contextColumnNames = []
+}) {
+  const contextAttriburesList = []
+  if (isEmptyValue(contextColumnNames)) {
+    return contextAttriburesList
+  }
+
+  contextColumnNames.forEach(columnName => {
+    const value = getContext({
+      containerUuid,
+      columnName
+    })
+
+    contextAttriburesList.push({
+      value,
+      columnName
+    })
+  })
+
+  return contextAttriburesList
+}

--- a/src/views/ADempiere/Browser/index.vue
+++ b/src/views/ADempiere/Browser/index.vue
@@ -61,7 +61,8 @@
         :container-manager="containerManagerTable"
         :panel-metadata="browserMetadata"
         :header="tableHeader"
-        :data-table="[]"
+        :data-table="recordsList"
+        :record-count="recordCount"
       />
     </el-main>
   </el-container>
@@ -263,7 +264,31 @@ export default defineComponent({
 
       isMandatoryColumn,
 
-      isReadOnlyColumn
+      isReadOnlyColumn,
+
+      seekRecord: ({
+        containerUuid,
+        row
+      }) => {
+        console.log(containerUuid, row)
+      },
+
+      setSelection: ({
+        containerUuid,
+        recordsSelected
+      }) => {
+        root.$store.commit('setBrowserSelectionsList', {
+          containerUuid,
+          selectionsList: recordsSelected
+        })
+      },
+
+      setPage: ({ containerUuid, pageNumber }) => {
+        root.$store.commit('getBrowserSearch', {
+          containerUuid,
+          pageNumber
+        })
+      }
     }
 
     const actionsManager = ref({
@@ -288,6 +313,19 @@ export default defineComponent({
       menuParentUuid: root.$route.meta.parentUuid
     })
 
+    // get records list
+    const recordsList = computed(() => {
+      return root.$store.getters.getBrowserRecordsList(browserUuid)
+    })
+
+    const recordCount = computed(() => {
+      const data = root.$store.getters.getBrowserData(browserUuid)
+      if (data && data.recordCount) {
+        return data.recordCount
+      }
+      return 0
+    })
+
     getBrowserDefinition()
 
     return {
@@ -301,7 +339,9 @@ export default defineComponent({
       // computed
       openedCriteria,
       isShowContextMenu,
-      tableHeader
+      tableHeader,
+      recordCount,
+      recordsList
     }
   }
 })


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open Smart Browser `Warehouse Replenish`
2. Search records.

#### Screenshot or Gif

https://user-images.githubusercontent.com/20288327/141231278-5b4d93b6-3a66-4c25-85d1-5f6404e3bd23.mp4


#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.


