### PR TITLE
feat: Add hide only this field.

### DIFF
--- a/src/components/ADempiere/Field/FieldOptions/EmptyOption.vue
+++ b/src/components/ADempiere/Field/FieldOptions/EmptyOption.vue
@@ -1,0 +1,25 @@
+<!--
+ ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+ Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https:www.gnu.org/licenses/>.
+-->
+
+<script>
+import { defineComponent } from '@vue/composition-api'
+
+export default defineComponent({
+  name: 'EmptyOption'
+})
+</script>

--- a/src/components/ADempiere/Field/FieldOptions/fieldOptionsList.js
+++ b/src/components/ADempiere/Field/FieldOptions/fieldOptionsList.js
@@ -35,7 +35,7 @@ export const zoomInOptionItem = {
   enabled: true,
   svg: false,
   icon: 'el-icon-files',
-  componentRender: () => import('@/components/ADempiere/Field/FieldOptions/ContextInfo')
+  componentRender: () => import('@/components/ADempiere/Field/FieldOptions/EmptyOption')
 }
 
 /**
@@ -96,6 +96,17 @@ export const documentStatusOptionItem = {
   svg: false,
   icon: 'el-icon-set-up',
   componentRender: () => import('@/components/ADempiere/Field/FieldOptions/DocumentStatus')
+}
+
+/**
+ * Hide only this field
+ */
+export const hideThisField = {
+  name: language.t('fieldOptions.hideThisField'),
+  enabled: true,
+  svg: true,
+  icon: 'eye',
+  componentRender: () => import('@/components/ADempiere/Field/FieldOptions/EmptyOption')
 }
 
 export const optionsListStandad = [

--- a/src/lang/ADempiere/en/fieldOptions.js
+++ b/src/lang/ADempiere/en/fieldOptions.js
@@ -34,7 +34,8 @@ const fieldOptions = {
     allUsers: ', all Users',
     thisWindow: ' and this Window',
     allWindows: ' and all Windows'
-  }
+  },
+  hideThisField: 'Hide This Field'
 }
 
 export default fieldOptions

--- a/src/lang/ADempiere/es/fieldOptions.js
+++ b/src/lang/ADempiere/es/fieldOptions.js
@@ -34,7 +34,8 @@ const fieldOptions = {
     allUsers: ', todos los Usuarios',
     thisWindow: ' y esta Ventana',
     allWindows: ' y todas las Ventanas'
-  }
+  },
+  hideThisField: 'Ocultar Este Campo'
 }
 
 export default fieldOptions

--- a/src/store/modules/ADempiere/browserManager.js
+++ b/src/store/modules/ADempiere/browserManager.js
@@ -27,6 +27,7 @@ import { ROW_ATTRIBUTES, ROW_KEY_ATTRIBUTES } from '@/utils/ADempiere/constants/
 import { isEmptyValue, generatePageToken } from '@/utils/ADempiere/valueUtils'
 import { getContextAttributes } from '@/utils/ADempiere/contextUtils'
 import { showMessage } from '@/utils/ADempiere/notification'
+import { isDisplayedField } from '@/utils/ADempiere/dictionary/browser'
 
 const initState = {
   browserData: {}
@@ -76,12 +77,14 @@ const browserControl = {
       value,
       valueTo
     }) {
-      const fieldsList = getters.getFieldsListFromPanel(containerUuid)
+      const fieldsList = getters.getStoredFieldsFromBrowser(containerUuid)
 
       const fieldsEmpty = getters.getFieldsListEmptyMandatory({
         containerUuid,
-        fieldsList
+        fieldsList,
+        showedMethod: isDisplayedField
       })
+
       if (!isEmptyValue(fieldsEmpty)) {
         showMessage({
           message: language.t('notifications.mandatoryFieldMissing') + fieldsEmpty,

--- a/src/store/modules/ADempiere/panel/getters.js
+++ b/src/store/modules/ADempiere/panel/getters.js
@@ -93,15 +93,21 @@ const getters = {
    * Obtain empty obligatory fields
    * @param {string} containerUuid
    * @param {array} fieldsList
+   * @param {function} showedMethod
    * @param {string} formatReturn
    */
   getFieldsListEmptyMandatory: (state, getters) => ({
     containerUuid,
     fieldsList,
+    showedMethod,
     formatReturn = 'name'
   }) => {
     if (isEmptyValue(fieldsList)) {
       fieldsList = getters.getFieldsListFromPanel(containerUuid)
+    }
+    // TODO: Remove conditional with complete support
+    if (!showedMethod) {
+      showedMethod = fieldIsDisplayed
     }
 
     // all mandatory and empty fields value
@@ -114,7 +120,7 @@ const getters = {
 
       if (isEmptyValue(value)) {
         const isMandatory = fieldItem.isMandatory || fieldItem.isMandatoryFromLogic
-        if (fieldIsDisplayed(fieldItem) && isMandatory) {
+        if (showedMethod(fieldItem) && isMandatory) {
           return true
         }
       }

--- a/src/views/ADempiere/Browser/index.vue
+++ b/src/views/ADempiere/Browser/index.vue
@@ -145,9 +145,11 @@ export default defineComponent({
       if (browserMetadata.value.awaitForValuesToQuery) {
         return false
       }
-      return root.isEmptyValue(root.$store.getters.getBrowserFieldsEmptyMandatory({
-        containerUuid: browserUuid
-      }))
+      return root.isEmptyValue(
+        root.$store.getters.getBrowserFieldsEmptyMandatory({
+          containerUuid: browserUuid
+        })
+      )
     })
 
     const openedCriteria = computed({
@@ -251,6 +253,10 @@ export default defineComponent({
           containerUuid,
           fieldsShowed
         })
+      },
+
+      getFieldsLit({ containerUuid }) {
+        return root.$store.getters.getStoredFieldsFromBrowser(containerUuid)
       }
     }
 

--- a/src/views/ADempiere/Window/index.vue
+++ b/src/views/ADempiere/Window/index.vue
@@ -160,6 +160,10 @@ export default defineComponent({
           containerUuid,
           fieldsShowed
         })
+      },
+
+      getFieldsLit({ parentUuid, containerUuid }) {
+        return root.$store.getters.getStoredFieldsFromTab(parentUuid, containerUuid)
       }
     }
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open any panel (Window, SmartBrowser).
2. Expand field options.
3. Selected option `Hide This Field`.

Note that mandatory fields cannot be hidden, and that hiding a field with a value triggers the `actionPerformed` callback encapsulated in the `containerManager`.

#### Screenshot or Gif

https://user-images.githubusercontent.com/20288327/141392302-ba6e6364-b1bc-450a-bba9-91a438c8e9a7.mp4


#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
fixes https://github.com/adempiere/adempiere-vue/issues/116
