### PR TITLE
Make card number and bank ID not mandatory

### DIFF
--- a/src/components/ADempiere/Form/VPOS/Collection/fieldsListCollection.js
+++ b/src/components/ADempiere/Form/VPOS/Collection/fieldsListCollection.js
@@ -50,7 +50,7 @@ export default [
       displayLogicPayment: 'D,K,T,A,P,C',
       size: 24,
       isActiveLogics: true,
-      isMandatory: true
+      isMandatory: false
     }
   },
   // Date
@@ -139,7 +139,7 @@ export default [
       size: 24,
       displayLogicPayment: 'C',
       isActiveLogics: true,
-      isMandatory: true
+      isMandatory: false
     }
   },
   // accountno


### PR DESCRIPTION
Fixes #1361

In POS Payment, make Bank ID and card number not mandatory
