### PR TITLE
fix: Get private access request.

### DIFF
--- a/src/api/ADempiere/actions/private-access.js
+++ b/src/api/ADempiere/actions/private-access.js
@@ -17,7 +17,14 @@
 // Get Instance for connection
 import { request } from '@/utils/ADempiere/request'
 
-// Get private access for a record
+import { camelizeObjectKeys } from '@/utils/ADempiere/transformObject'
+
+/**
+ * Get private access for a record
+ * @param {string}  tableName
+ * @param {number}  recordId
+ * @param {string}  recordUuid
+ */
 export function getPrivateAccess({
   tableName,
   recordId,
@@ -33,16 +40,16 @@ export function getPrivateAccess({
     }
   })
     .then(responsePrivateAccess => {
-      return {
-        tableName: responsePrivateAccess.table_name,
-        recordId: responsePrivateAccess.id,
-        recordUuid: responsePrivateAccess.uuid,
-        isLocked: responsePrivateAccess.is_locked
-      }
+      return camelizeObjectKeys(responsePrivateAccess)
     })
 }
 
-// Lock a record for a user
+/**
+ * Lock a record for a user
+ * @param {string}  tableName
+ * @param {number}  recordId
+ * @param {string}  recordUuid
+ */
 export function lockPrivateAccess({
   tableName,
   recordId,
@@ -58,15 +65,16 @@ export function lockPrivateAccess({
     }
   })
     .then(responsePrivateAccess => {
-      return {
-        tableName: responsePrivateAccess.table_name,
-        recordId: responsePrivateAccess.record_id,
-        recordUuid: responsePrivateAccess.record_uuid
-      }
+      return camelizeObjectKeys(responsePrivateAccess)
     })
 }
 
-// Unlock a record from a user
+/**
+ * Unlock a record from a user
+ * @param {string}  tableName
+ * @param {number}  recordId
+ * @param {string}  recordUuid
+ */
 export function unlockPrivateAccess({
   tableName,
   recordId,
@@ -82,10 +90,6 @@ export function unlockPrivateAccess({
     }
   })
     .then(responsePrivateAccess => {
-      return {
-        tableName: responsePrivateAccess.table_name,
-        recordId: responsePrivateAccess.record_id,
-        recordUuid: responsePrivateAccess.record_uuid
-      }
+      return camelizeObjectKeys(responsePrivateAccess)
     })
 }

--- a/src/store/modules/ADempiere/data/actions.js
+++ b/src/store/modules/ADempiere/data/actions.js
@@ -27,11 +27,6 @@ import {
   requestDefaultValue,
   requestGetContextInfoValue
 } from '@/api/ADempiere/window'
-import {
-  getPrivateAccess,
-  lockPrivateAccess,
-  unlockPrivateAccess
-} from '@/api/ADempiere/actions/private-access'
 
 // utils and helper methods
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
@@ -588,93 +583,7 @@ const actions = {
         console.warn(`Error ${error.code} getting context info value for field ${error.message}.`)
       })
   },
-  getPrivateAccessFromServer({ rootGetters }, {
-    tableName,
-    recordId,
-    recordUuid
-  }) {
-    return getPrivateAccess({
-      tableName,
-      recordId,
-      recordUuid
-    })
-      .then(privateAccessResponse => {
-        return {
-          ...privateAccessResponse
-        }
-      })
-      .catch(error => {
-        console.warn(`Error get private access: ${error.message}. Code: ${error.code}.`)
-      })
-  },
-  lockRecord({ rootGetters }, {
-    tableName,
-    recordId,
-    recordUuid
-  }) {
-    return lockPrivateAccess({
-      tableName,
-      recordId,
-      recordUuid
-    })
-      .then(privateAccessResponse => {
-        if (!isEmptyValue(privateAccessResponse.recordId)) {
-          const recordLocked = {
-            isPrivateAccess: true,
-            isLocked: true,
-            ...privateAccessResponse
-          }
-          showMessage({
-            title: language.t('notifications.succesful'),
-            message: language.t('notifications.recordLocked'),
-            type: 'success'
-          })
-          return recordLocked
-        }
-      })
-      .catch(error => {
-        showMessage({
-          title: language.t('notifications.error'),
-          message: language.t('login.unexpectedError') + error.message,
-          type: 'error'
-        })
-        console.warn(`Error lock private access: ${error.message}. Code: ${error.code}.`)
-      })
-  },
-  unlockRecord({ rootGetters }, {
-    tableName,
-    recordId,
-    recordUuid
-  }) {
-    return unlockPrivateAccess({
-      tableName,
-      recordId,
-      recordUuid
-    })
-      .then(privateAccessResponse => {
-        if (!isEmptyValue(privateAccessResponse.recordId)) {
-          const recordUnlocked = {
-            isPrivateAccess: true,
-            isLocked: false,
-            ...privateAccessResponse
-          }
-          showMessage({
-            title: language.t('notifications.succesful'),
-            message: language.t('notifications.recordUnlocked'),
-            type: 'success'
-          })
-          return recordUnlocked
-        }
-      })
-      .catch(error => {
-        showMessage({
-          title: language.t('notifications.error'),
-          message: language.t('login.unexpectedError') + error.message,
-          type: 'error'
-        })
-        console.warn(`Error unlock private access: ${error.message}. Code: ${error.code}.`)
-      })
-  },
+
   resetStateBusinessData({ commit }) {
     commit('resetStateContainerInfo')
     commit('setInitialContext', {})

--- a/src/store/modules/ADempiere/data/getters.js
+++ b/src/store/modules/ADempiere/data/getters.js
@@ -101,15 +101,8 @@ const getters = {
         return info
       }
     })
-  },
-  getRecordPrivateAccess: (state) => (tableName, recordId) => {
-    if (!isEmptyValue(tableName) && !isEmptyValue(recordId)) {
-      if (state.recordPrivateAccess.tableName === tableName && state.recordPrivateAccess.recordId === recordId) {
-        return state.recordPrivateAccess
-      }
-      return undefined
-    }
   }
+
 }
 
 export default getters

--- a/src/store/modules/ADempiere/data/index.js
+++ b/src/store/modules/ADempiere/data/index.js
@@ -4,8 +4,7 @@ import mutations from './mutations.js'
 
 const initStateBusinessData = {
   recordSelection: [], // record data and selection
-  contextInfoField: [],
-  recordPrivateAccess: {}
+  contextInfoField: []
 }
 
 const data = {

--- a/src/store/modules/ADempiere/data/mutations.js
+++ b/src/store/modules/ADempiere/data/mutations.js
@@ -60,9 +60,6 @@ const mutations = {
   },
   setContextInfoField(state, payload) {
     state.contextInfoField.push(payload)
-  },
-  setPrivateAccess(state, payload) {
-    state.recordPrivateAccess = payload
   }
 }
 

--- a/src/store/modules/ADempiere/privateAccess.js
+++ b/src/store/modules/ADempiere/privateAccess.js
@@ -1,0 +1,167 @@
+// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import Vue from 'vue'
+import language from '@/lang'
+
+// api request methods
+import {
+  getPrivateAccess,
+  lockPrivateAccess,
+  unlockPrivateAccess
+} from '@/api/ADempiere/actions/private-access'
+
+// utils and helper methods
+import { showMessage } from '@/utils/ADempiere/notification'
+
+const initState = {
+  privateAccessRecord: {}
+}
+
+const privateAccess = {
+  state: initState,
+
+  mutations: {
+    resetStatePrivateAccess(state) {
+      state = initState
+    },
+    setPrivateAccess(state, { tableName, recordUuid, recordId, isLocked }) {
+      const key = `${tableName}_${recordUuid}`
+
+      Vue.set(state.privateAccessRecord, key, {
+        tableName,
+        recordUuid,
+        recordId,
+        isLocked
+      })
+    }
+  },
+
+  actions: {
+    getPrivateAccessFromServer({ commit }, {
+      tableName,
+      recordId,
+      recordUuid
+    }) {
+      return new Promise(resolve => {
+        getPrivateAccess({
+          tableName,
+          recordId,
+          recordUuid
+        })
+          .then(privateAccessResponse => {
+            const { isLocked } = privateAccessResponse
+
+            commit('setPrivateAccess', {
+              tableName,
+              recordId,
+              recordUuid,
+              isLocked
+            })
+
+            resolve(isLocked)
+          })
+          .catch(error => {
+            console.warn(`Error get private access: ${error.message}. Code: ${error.code}.`)
+          })
+      })
+    },
+
+    lockRecordFromServer({ commit }, {
+      tableName,
+      recordId,
+      recordUuid
+    }) {
+      return new Promise(resolve => {
+        lockPrivateAccess({
+          tableName,
+          recordId,
+          recordUuid
+        })
+          .then(lockRecordResponse => {
+            const { isLocked } = lockRecordResponse
+
+            commit('setPrivateAccess', {
+              tableName,
+              recordId,
+              recordUuid,
+              isLocked
+            })
+
+            showMessage({
+              message: language.t('notifications.recordLocked'),
+              type: 'success'
+            })
+
+            resolve(isLocked)
+          })
+          .catch(error => {
+            showMessage({
+              message: language.t('login.unexpectedError') + error.message,
+              type: 'error'
+            })
+            console.warn(`Error lock private access: ${error.message}. Code: ${error.code}.`)
+          })
+      })
+    },
+
+    unlockRecordFromServer({ commit }, {
+      tableName,
+      recordId,
+      recordUuid
+    }) {
+      return new Promise(resolve => {
+        unlockPrivateAccess({
+          tableName,
+          recordId,
+          recordUuid
+        })
+          .then(unLockRecordResponse => {
+            const { isLocked } = unLockRecordResponse
+
+            commit('setPrivateAccess', {
+              tableName,
+              recordId,
+              recordUuid,
+              isLocked
+            })
+
+            showMessage({
+              message: language.t('notifications.recordUnlocked'),
+              type: 'success'
+            })
+
+            resolve(isLocked)
+          })
+          .catch(error => {
+            showMessage({
+              message: language.t('login.unexpectedError') + error.message,
+              type: 'error'
+            })
+            console.warn(`Error unlock private access: ${error.message}. Code: ${error.code}.`)
+          })
+      })
+    }
+  },
+
+  getters: {
+    getStoredPrivateAccess: (state) => ({ tableName, recordUuid }) => {
+      return state.privateAccessRecord[`${tableName}_${recordUuid}`]
+    }
+  }
+}
+
+export default privateAccess


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Test` window
2. Create 2 records.
4. Change between records.

The private access is saved in the vuex store taking as key `tableName_recordUuid`, so if this record is already loaded it does not make the request again for the private access.

#### Screenshot or Gif

https://user-images.githubusercontent.com/20288327/142551718-0cc11b5b-b06e-41cd-ac3a-b2279cd5dd11.mp4


#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context

however when blocking a record and refreshing to get the request from the server the response does not bring the id of the record and indicates that it is not blocked. https://github.com/adempiere/adempiere-gRPC-Server/pull/24

1. Open `Test` window
2. Create 1 record.
3. Lock record.
4. Refresh.
5. Select same locked record.
