### PR TITLE
fix: Set is read only fields with default value isActive field.

### DIFF
--- a/src/store/modules/ADempiere/fieldValue.js
+++ b/src/store/modules/ADempiere/fieldValue.js
@@ -16,7 +16,7 @@
 
 import Vue from 'vue'
 import { isEmptyValue, typeValue } from '@/utils/ADempiere/valueUtils.js'
-import { convertStringToBoolean } from '@/utils/ADempiere/valueFormat.js'
+import { convertStringToBoolean } from '@/utils/ADempiere/formatValue/booleanFormat.js'
 import {
   ACTIVE, PROCESSING, PROCESSED
 } from '@/utils/ADempiere/constants/systemColumns'

--- a/src/utils/ADempiere/constants/systemColumns.js
+++ b/src/utils/ADempiere/constants/systemColumns.js
@@ -76,3 +76,45 @@ export const DOCUMENT_STATUS_COLUMNS_LIST = [
   'DocStatus',
   'O_DocStatus'
 ]
+
+export const COLUMN_IS_ACTIVE = {
+  columnName: ACTIVE, // column name of field
+  defaultValue: true, // default value when loading
+  valueIsReadOnlyForm: false, // value that activates read-only form
+  isChangedAllForm: false // change the entire form to read only including this field
+}
+
+export const COLUMN_PROCESSING = {
+  columnName: PROCESSING,
+  defaultValue: true,
+  valueIsReadOnlyForm: false,
+  isChangedAllForm: true
+}
+
+export const COLUMN_PROCESSED = {
+  columnName: PROCESSED,
+  defaultValue: false,
+  valueIsReadOnlyForm: true,
+  isChangedAllForm: true
+}
+
+export const READ_ONLY_COLUMNS_LIST = [
+  ACTIVE,
+  PROCESSING,
+  PROCESSED
+]
+
+/**
+ * Fields with this column name, changed all fields is read only
+ */
+export const READ_ONLY_FORM_COLUMNS = [
+  COLUMN_IS_ACTIVE,
+  COLUMN_PROCESSED,
+  COLUMN_PROCESSING
+]
+
+export function readOnlyColumn(columnName) {
+  return READ_ONLY_FORM_COLUMNS.find(item => {
+    return item.columnName === columnName
+  })
+}

--- a/src/utils/ADempiere/evaluator.js
+++ b/src/utils/ADempiere/evaluator.js
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { convertStringToBoolean } from '@/utils/ADempiere/valueFormat.js'
+import { convertStringToBoolean } from '@/utils/ADempiere/formatValue/booleanFormat.js'
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 
 /**

--- a/src/utils/ADempiere/formatValue/booleanFormat.js
+++ b/src/utils/ADempiere/formatValue/booleanFormat.js
@@ -41,3 +41,31 @@ export const convertBooleanToString = (booleanValue) => {
 
   return 'N'
 }
+
+/**
+ * Convert string values ('Y' or 'N') to component compatible Boolean values
+ * @param {mixed} valueToParsed
+ */
+export const convertStringToBoolean = (valueToParsed) => {
+  let valReturn = valueToParsed
+
+  switch (String(valueToParsed).trim()) {
+    case 'N':
+    case 'false':
+    case language.t('components.switchInactiveText'):
+      valReturn = false
+      break
+
+    case 'Y':
+    case 'true':
+    case language.t('components.switchActiveText'):
+      valReturn = true
+      break
+
+    default:
+      valReturn = valueToParsed
+      break
+  }
+
+  return valReturn
+}

--- a/src/utils/ADempiere/references.js
+++ b/src/utils/ADempiere/references.js
@@ -631,42 +631,6 @@ export function isHiddenField(displayType) {
   FIELDS_HIDDEN.includes(displayType)
 }
 
-export const COLUMN_IS_ACTIVE = {
-  columnName: 'IsActive', // column name of field
-  defaultValue: true, // default value when loading
-  valueIsReadOnlyForm: false, // value that activates read-only form
-  isChangedAllForm: false // change the entire form to read only including this field
-}
-
-export const COLUMN_PROCESSED = {
-  columnName: 'Processed',
-  defaultValue: false,
-  valueIsReadOnlyForm: true,
-  isChangedAllForm: true
-}
-
-export const COLUMN_PROCESSING = {
-  columnName: 'Processing',
-  defaultValue: true,
-  valueIsReadOnlyForm: false,
-  isChangedAllForm: true
-}
-
-export const COLUMNS_NAME_READ_ONLY = [
-  COLUMN_IS_ACTIVE.columnName,
-  COLUMN_PROCESSED.columnName,
-  COLUMN_PROCESSING.columnName
-]
-
-/**
- * Fields with this column name, changed all fields is read only
- */
-export const COLUMNS_READ_ONLY_FORM = [
-  COLUMN_IS_ACTIVE,
-  COLUMN_PROCESSED,
-  COLUMN_PROCESSING
-]
-
 export const FIELDS_DECIMALS = [
   AMOUNT.id,
   COSTS_PLUS_PRICES.id,

--- a/src/utils/ADempiere/valueFormat.js
+++ b/src/utils/ADempiere/valueFormat.js
@@ -23,33 +23,6 @@ import store from '@/store'
 import { DATE, DATE_PLUS_TIME, TIME, AMOUNT, COSTS_PLUS_PRICES, NUMBER, QUANTITY } from '@/utils/ADempiere/references.js'
 
 /**
- * Convert string values ('Y' or 'N') to component compatible Boolean values
- * @param {mixed} valueToParsed
- */
-export const convertStringToBoolean = (valueToParsed) => {
-  let valReturn = valueToParsed
-
-  // TODO: Add lang values
-  switch (String(valueToParsed).trim()) {
-    case 'N':
-    case 'false':
-      valReturn = false
-      break
-
-    case 'Y':
-    case 'true':
-      valReturn = true
-      break
-
-    default:
-      valReturn = valueToParsed
-      break
-  }
-
-  return valReturn
-}
-
-/**
  * Convert a object to array pairs
  * @param {object} object, object to convert
  * @param {string} nameKey, name from key in pairs

--- a/src/utils/ADempiere/valueUtils.js
+++ b/src/utils/ADempiere/valueUtils.js
@@ -20,8 +20,7 @@ import language from '@/lang'
 import { TABLE, TABLE_DIRECT } from '@/utils/ADempiere/references.js'
 
 // utils and helper methods
-import { convertStringToBoolean } from '@/utils/ADempiere/valueFormat.js'
-import { convertBooleanToString } from '@/utils/ADempiere/formatValue/booleanFormat.js'
+import { convertBooleanToString, convertStringToBoolean } from '@/utils/ADempiere/formatValue/booleanFormat.js'
 import { OPERATION_PATTERN } from '@/utils/ADempiere/formatValue/numberFormat.js'
 
 /**
@@ -355,9 +354,6 @@ export function parsedValueComponent({
   const isEmpty = isEmptyValue(value)
   if (isEmpty && !isMandatory) {
     if (componentPath === 'FieldYesNo') {
-      if (columnName === 'IsActive') {
-        return true
-      }
       // Processing, Processed, and any other columnName, return false by default
       return Boolean(value)
     }

--- a/src/views/ADempiere/Window/windowUtils.js
+++ b/src/views/ADempiere/Window/windowUtils.js
@@ -87,7 +87,10 @@ export function generateTabs({
       containerUuid: tabItem.uuid,
       panelMetadata: tab,
       isAddFieldUuid: true,
-      isAddLinkColumn: true
+      isAddLinkColumn: true,
+      fieldOverwrite: {
+        isReadOnlyFromForm: true
+      }
     })
   })
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Login with GardenAdmin role.
2. Open `Model Validator` window.
3. Select new record in single record mode.

#### Screenshot or Gif
Before this changes:

https://user-images.githubusercontent.com/20288327/142775842-7cb978fe-1dd7-45c3-92e6-d4ed99983f78.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/142775847-e540cd87-1b55-4450-b317-c7db13d1e933.mp4

#### Expected behavior
It is expected to default to true if the default value is empty in the IsActive field if a new record is created unless it explicitly defaults to false.


#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
fixes https://github.com/adempiere/adempiere-vue/issues/8 , fixes https://github.com/adempiere/adempiere-vue/issues/68

