### PR TITLE
fix: Parameters isRange number

### DIFF
--- a/src/store/modules/ADempiere/dictionary/browser/getters.js
+++ b/src/store/modules/ADempiere/dictionary/browser/getters.js
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+// utils and helper methods
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
 import { isDisplayedField, isMandatoryField } from '@/utils/ADempiere/dictionary/browser.js'
 import { isNumberField } from '@/utils/ADempiere/references'
@@ -70,7 +71,7 @@ export default {
         columnName
       })
 
-      if (fieldItem.isRange && isNumberField(fieldItem.displayType)) {
+      if (fieldItem.isRange && !isNumberField(fieldItem.displayType)) {
         const valueTo = rootGetters.getValueOfField({
           containerUuid,
           columnName: fieldItem.columnNameTo
@@ -83,13 +84,12 @@ export default {
         }
       }
 
-      if (isEmptyValue(value)) {
-        return
+      if (!isEmptyValue(value)) {
+        queryParams.push({
+          columnName,
+          value
+        })
       }
-      queryParams.push({
-        columnName,
-        value
-      })
     })
 
     return queryParams

--- a/src/store/modules/ADempiere/dictionary/process/getters.js
+++ b/src/store/modules/ADempiere/dictionary/process/getters.js
@@ -14,8 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+// utils and helper methods
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
-import { isDisplayedField, isMandatoryField } from '@/utils/ADempiere/dictionary/process'
+import { isDisplayedField, isMandatoryField } from '@/utils/ADempiere/dictionary/process.js'
 import { isNumberField } from '@/utils/ADempiere/references'
 
 /**
@@ -70,7 +71,7 @@ export default {
         columnName
       })
 
-      if (fieldItem.isRange && isNumberField(fieldItem.displayType)) {
+      if (fieldItem.isRange && !isNumberField(fieldItem.displayType)) {
         const valueTo = rootGetters.getValueOfField({
           containerUuid,
           columnName: fieldItem.columnNameTo
@@ -83,13 +84,12 @@ export default {
         }
       }
 
-      if (isEmptyValue(value)) {
-        return
+      if (!isEmptyValue(value)) {
+        processParameters.push({
+          columnName,
+          value
+        })
       }
-      processParameters.push({
-        columnName,
-        value
-      })
     })
 
     return processParameters


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

If there is a numeric range field, more parameters are sent. Note that there should be 4 parameters and 6 are being sent, in a repeated way the range type.


#### Screenshot or Gif
Before this changes:

https://user-images.githubusercontent.com/20288327/142795521-39d9f083-68a8-48f6-9f27-93ab1487de42.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/142795529-df186c53-c77d-4deb-aa4f-df6011adeee4.mp4


#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.
