### PR TITLE
feat: Add document status field option.

### DIFF
--- a/src/components/ADempiere/ContainerOptions/DocumentStatusTag/index.vue
+++ b/src/components/ADempiere/ContainerOptions/DocumentStatusTag/index.vue
@@ -1,3 +1,21 @@
+<!--
+ ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+ Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https:www.gnu.org/licenses/>.
+-->
+
 <template>
   <el-tag
     :size="size"

--- a/src/components/ADempiere/ContainerOptions/DocumentStatusTag/index.vue
+++ b/src/components/ADempiere/ContainerOptions/DocumentStatusTag/index.vue
@@ -1,0 +1,98 @@
+<template>
+  <el-tag
+    :size="size"
+    :type="tagRender.type"
+    :effect="tagRender.effect"
+    disable-transitions
+  >
+    {{ displayedValue }}
+  </el-tag>
+</template>
+
+<script>
+import { defineComponent, computed } from '@vue/composition-api'
+
+export default defineComponent({
+  name: 'DocumentStatusTag',
+
+  props: {
+    value: {
+      type: String,
+      default: ''
+    },
+    displayedValue: {
+      type: [String, Number, Boolean, Date],
+      default: ''
+    },
+    size: {
+      type: String,
+      default: 'medium'
+    }
+  },
+
+  setup(props) {
+    /**
+     * add a tab depending on the status of the document
+     * @param {string} status, document status key
+     */
+    const tagRender = computed(() => {
+      let effect = 'plain'
+      let type = 'info'
+
+      switch (props.value) {
+        case 'AP':
+          type = 'success'
+          effect = 'light'
+          break
+
+        case 'CO':
+          type = 'success'
+          effect = 'dark'
+          break
+
+        case '??':
+        case 'DR':
+          type = 'info'
+          effect = 'light'
+          break
+
+        case 'CL':
+          type = 'primary'
+          break
+        case 'IP':
+          type = 'warning'
+          effect = 'light'
+          break
+
+        case 'WC':
+        case 'WP':
+          type = 'warning'
+          effect = 'dark'
+          break
+
+        case 'VO':
+          type = 'danger'
+          effect = 'plain'
+          break
+
+        case 'NA':
+        case 'IN':
+        case 'RE':
+          type = 'danger'
+          effect = 'light'
+          break
+      }
+
+      return {
+        type,
+        a: 1,
+        effect
+      }
+    })
+
+    return {
+      tagRender
+    }
+  }
+})
+</script>

--- a/src/components/ADempiere/ContainerOptions/DocumentStatusTag/index.vue
+++ b/src/components/ADempiere/ContainerOptions/DocumentStatusTag/index.vue
@@ -85,7 +85,6 @@ export default defineComponent({
 
       return {
         type,
-        a: 1,
         effect
       }
     })

--- a/src/components/ADempiere/Field/FieldOptions/index.vue
+++ b/src/components/ADempiere/Field/FieldOptions/index.vue
@@ -119,9 +119,6 @@ import { zoomIn } from '@/utils/ADempiere/coreUtils.js'
 import { isLookup, LIST } from '@/utils/ADempiere/references.js'
 import { typeValue } from '@/utils/ADempiere/valueUtils.js'
 
-// constants
-import { DOCUMENT_STATUS_COLUMNS_LIST } from '@/utils/ADempiere/constants/systemColumns.js'
-
 export default defineComponent({
   name: 'FieldOptions',
   components: {
@@ -249,20 +246,24 @@ export default defineComponent({
     }
 
     const isDocuemntStatus = computed(() => {
-      if (props.metadata.isPanelWindow && !props.metadata.isAdvancedQuery) {
-        const { parentUuid, containerUuid, columnName } = props.metadata
-        if (DOCUMENT_STATUS_COLUMNS_LIST.includes(columnName)) {
-          const statusValue = root.$store.getters.getValueOfField({
-            parentUuid,
-            containerUuid,
-            columnName
-          })
-          // if (!root.isEmptyValue(root.$store.getters.getOrders)) {
-          if (!root.isEmptyValue(statusValue)) {
-            return true
-          }
-        }
+      if (!props.metadata.isColumnDocumentStatus) {
+        return false
       }
+
+      // if (!root.isEmptyValue(root.$store.getters.getOrders)) {
+      //   reutrn false
+      // }
+
+      const { parentUuid, containerUuid, columnName } = props.metadata
+      const statusValue = root.$store.getters.getValueOfField({
+        parentUuid,
+        containerUuid,
+        columnName
+      })
+      if (!root.isEmptyValue(statusValue)) {
+        return true
+      }
+
       return false
     })
 

--- a/src/utils/ADempiere/dictionaryUtils.js
+++ b/src/utils/ADempiere/dictionaryUtils.js
@@ -19,7 +19,11 @@ import { isEmptyValue, parsedValueComponent } from '@/utils/ADempiere/valueUtils
 import { getContext, getParentFields, getPreference, parseContext } from '@/utils/ADempiere/contextUtils'
 import REFERENCES, { BUTTON, YES_NO, DEFAULT_SIZE, isHiddenField } from '@/utils/ADempiere/references'
 import { FIELD_OPERATORS_LIST } from '@/utils/ADempiere/dataUtils'
-import { READ_ONLY_FORM_COLUMNS, readOnlyColumn } from '@/utils/ADempiere/constants/systemColumns'
+import {
+  DOCUMENT_STATUS_COLUMNS_LIST,
+  READ_ONLY_FORM_COLUMNS,
+  readOnlyColumn
+} from '@/utils/ADempiere/constants/systemColumns'
 
 /**
  * Generate field to app
@@ -44,6 +48,8 @@ export function generateField({
   let isColumnReadOnlyForm = false
   let isChangedAllForm = false
   let valueIsReadOnlyForm
+
+  let isColumnDocumentStatus = false
 
   const componentReference = evalutateTypeField(fieldToGenerate.displayType)
   let evaluatedLogics = {
@@ -139,6 +145,10 @@ export function generateField({
       containerUuid: moreAttributes.containerUuid,
       ...fieldToGenerate
     })
+
+    // manage document status and tag document status
+    isColumnDocumentStatus = DOCUMENT_STATUS_COLUMNS_LIST.includes(columnName) ||
+      DOCUMENT_STATUS_COLUMNS_LIST.includes(fieldToGenerate.elementColumnName)
   }
 
   const field = {
@@ -181,6 +191,7 @@ export function generateField({
     defaultOperator: operator,
     operatorsList,
     // popover's
+    isColumnDocumentStatus,
     isComparisonField,
     isNumericField,
     isTranslatedField

--- a/src/utils/ADempiere/globalMethods.js
+++ b/src/utils/ADempiere/globalMethods.js
@@ -16,7 +16,6 @@
 
 export {
   tagStatus,
-  iconStatus,
   isEmptyValue,
   currencyFind,
   tenderTypeFind,

--- a/src/utils/ADempiere/valueUtils.js
+++ b/src/utils/ADempiere/valueUtils.js
@@ -441,46 +441,32 @@ export function parsedValueComponent({
 }
 
 /**
- * add a tab depending on the status of the document
+ * Get tag type of the document status
  * @author Elsio Sanchez <elsiosanches@gmail.com>
- * @param {string} tag, document status key
+ * @param {string} status, document status key
  */
-export function tagStatus(tag) {
+export function tagStatus(status) {
   let type
-  switch (tag) {
-    case 'VO':
-      type = 'danger'
-      break
+  switch (status) {
     case 'AP':
+    case 'CO':
       type = 'success'
       break
+    case '??':
     case 'DR':
       type = 'info'
       break
     case 'CL':
       type = 'primary'
       break
-    case 'CO':
-      type = 'success'
-      break
-    case '??':
-      type = 'info'
-      break
     case 'IP':
-      type = 'warning'
-      break
     case 'WC':
-      type = 'warning'
-      break
     case 'WP':
       type = 'warning'
       break
+    case 'VO':
     case 'NA':
-      type = 'danger'
-      break
     case 'IN':
-      type = 'danger'
-      break
     case 'RE':
       type = 'danger'
       break
@@ -489,16 +475,14 @@ export function tagStatus(tag) {
 }
 
 /**
- * add a tab depending on the status of the document
+ * Payment method icon element-ui supported
  * @author Elsio Sanchez <elsiosanches@gmail.com>
- * @param {string} iconElment, icon the Elment
+ * @param {string} paymentMethod, value the payment
  */
-export function iconStatus(iconElment) {
+export function paymentIcon(paymentMethod) {
   let icon
-  switch (iconElment) {
+  switch (paymentMethod) {
     case 'A':
-      icon = 'el-icon-wallet'
-      break
     case 'M':
       icon = 'el-icon-wallet'
       break
@@ -511,15 +495,11 @@ export function iconStatus(iconElment) {
     case 'Z':
       icon = 'el-icon-coin'
       break
-    case 'T':
-      icon = 'el-icon-bank-card'
-      break
     case 'P':
       icon = 'el-icon-mobile'
       break
+    case 'T':
     case 'C':
-      icon = 'el-icon-bank-card'
-      break
     case 'D':
       icon = 'el-icon-bank-card'
       break


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open docuent window.
2. In document status field show options field.
3. Select `Document Status` option

#### Screenshot or Gif

https://user-images.githubusercontent.com/20288327/142969216-91b03c49-a7b0-4890-9635-0d6f31d7d4ad.mp4



#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
Add any other context about the problem here.
