### PR TITLE
fix: Create new component composition api template

### DIFF
--- a/plop-templates/ADempiere/component/compositionApiTemplate.hbs
+++ b/plop-templates/ADempiere/component/compositionApiTemplate.hbs
@@ -1,18 +1,20 @@
-// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
-// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
-// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+<!--
+ ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+ Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
 
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
 
-// You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https:www.gnu.org/licenses/>.
+-->
 
 {{#if template}}
 <template>
@@ -24,7 +26,7 @@
 <script>
 import { defineComponent } from '@vue/composition-api'
 
-export default {
+export default defineComponent({
   name: '{{ capitalize name }}',
 
   props: {},
@@ -32,7 +34,7 @@ export default {
   setup(props, { root }) {
     return {}
   }
-}
+})
 </script>
 {{/if}}
 

--- a/plop-templates/ADempiere/component/index.hbs
+++ b/plop-templates/ADempiere/component/index.hbs
@@ -1,3 +1,21 @@
+<!--
+ ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+ Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https:www.gnu.org/licenses/>.
+-->
+
 {{#if template}}
 <template>
   <div />
@@ -7,12 +25,16 @@
 {{#if script}}
 <script>
 export default {
-  name: '{{ properCase name }}',
+  name: '{{ capitalize name }}',
+
   props: {},
+
   data() {
     return {}
   },
+
   computed: {},
+
   methods: {}
 }
 </script>

--- a/plop-templates/ADempiere/view/compositionApiTemplate.hbs
+++ b/plop-templates/ADempiere/view/compositionApiTemplate.hbs
@@ -1,18 +1,20 @@
-// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
-// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
-// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+<!--
+ ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+ Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
 
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
 
-// You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https:www.gnu.org/licenses/>.
+-->
 
 {{#if template}}
 <template>
@@ -24,7 +26,7 @@
 <script>
 import { defineComponent } from '@vue/composition-api'
 
-export default {
+export default defineComponent({
   name: '{{ capitalize name }}',
 
   props: {},
@@ -32,7 +34,7 @@ export default {
   setup(props, { root }) {
     return {}
   }
-}
+})
 </script>
 {{/if}}
 

--- a/plop-templates/ADempiere/view/index.hbs
+++ b/plop-templates/ADempiere/view/index.hbs
@@ -1,3 +1,21 @@
+<!--
+ ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+ Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https:www.gnu.org/licenses/>.
+-->
+
 {{#if template}}
 <template>
   <div />
@@ -7,14 +25,20 @@
 {{#if script}}
 <script>
 export default {
-  name: '{{ properCase name }}',
+  name: '{{ capitalize name }}',
+
   props: {},
+
   data() {
     return {}
   },
+
   computed: {},
+
   created() {},
+
   mounted() {},
+
   methods: {}
 }
 </script>


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. With console run `yarn new`
2. Select `ADempiere View Composition API` or  `ADempiere Component Composition API`

#### Screenshot or Gif

![yarn new](https://user-images.githubusercontent.com/20288327/144271682-0558e727-8637-4734-921c-0bea374f13d3.png)


#### Expected behavior
the output of the component code for the Composition API, created from the template, is expected to be correct.

#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context

Current output
```javascript
export default {
  name: 'Test',

  props: {},

  setup(props, { root }) {
    return {}
  }
}
```
Correct output

```javascript
import { defineComponent } from '@vue/composition-api'

export default defineComponent({
  name: 'Test',

  props: {},

  setup(props, { root }) {
    return {}
  }
})
```
