### PR TITLE
fix: Displayed column type button in table.

### DIFF
--- a/src/utils/ADempiere/dictionary/window.js
+++ b/src/utils/ADempiere/dictionary/window.js
@@ -20,7 +20,7 @@ import { generatePanelAndFields } from '@/utils/ADempiere/dictionary/panel.js'
 import { isHiddenField } from '@/utils/ADempiere/references.js'
 
 /**
- * Is displayed field in panel tab
+ * Is displayed field in panel single record
  */
 export function isDisplayedField({ isDisplayed, isDisplayedFromLogic, isActive, displayType }) {
   // button field not showed
@@ -28,12 +28,8 @@ export function isDisplayedField({ isDisplayed, isDisplayedFromLogic, isActive, 
     return false
   }
 
-  // verify if field is active
-  if (!isActive) {
-    return false
-  }
-
-  return isDisplayed && isDisplayedFromLogic
+  // verify if field is active and displayed
+  return isActive && isDisplayed && isDisplayedFromLogic
 }
 
 /**
@@ -53,18 +49,13 @@ export function isReadOnlyField({ isQueryCriteria, isReadOnlyFromLogic }) {
  * Is displayed column in table multi record
  */
 export function isDisplayedColumn({ isDisplayedGrid, isDisplayedFromLogic, isActive, isKey, displayType }) {
-  // button field not showed
-  if (isHiddenField(displayType)) {
-    return false
-  }
-
-  // verify if field is active
-  if (!isActive) {
+  // key or button field not showed
+  if (isKey || isHiddenField(displayType)) {
     return false
   }
 
   // window (table) result
-  return isDisplayedGrid && isDisplayedFromLogic && !isKey
+  return isActive && isDisplayedGrid && isDisplayedFromLogic
 }
 
 export function isMandatoryColumn({ isMandatory, isMandatoryFromLogic }) {

--- a/src/utils/ADempiere/dictionaryUtils.js
+++ b/src/utils/ADempiere/dictionaryUtils.js
@@ -228,6 +228,7 @@ export function generateField({
   // hidden field type button
   if (isHiddenField(field.displayType)) {
     field.isDisplayedFromLogic = false
+    field.isDisplayedGrid = false
     field.isDisplayed = false
   }
 

--- a/src/utils/ADempiere/references.js
+++ b/src/utils/ADempiere/references.js
@@ -623,12 +623,12 @@ export const FIELDS_HIDDEN = [
 ]
 
 /**
- * Hidden field
+ * Hidden field or column by displayType
  * @param {number} displayType
  * @returns {boolean}
  */
 export function isHiddenField(displayType) {
-  FIELDS_HIDDEN.includes(displayType)
+  return FIELDS_HIDDEN.includes(displayType)
 }
 
 export const FIELDS_DECIMALS = [


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Login with `GardenWorld Admin` role.
2. Open window  `Physical Inventory`
3. Show table records in parent tab.

#### Screenshot or Gif

Before this changes:

https://user-images.githubusercontent.com/20288327/147012829-8ce289a0-6375-4c5c-89ac-53fd945605e3.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/147012834-a1769ed3-1a6c-4458-9145-ea177ff7036f.mp4


#### Expected behavior
It is expected that number columns should not be displayed.

#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.
