### PR TITLE
fix: Number field text align right.

### DIFF
--- a/src/components/ADempiere/DefaultTable/CellInfo.vue
+++ b/src/components/ADempiere/DefaultTable/CellInfo.vue
@@ -67,7 +67,7 @@
       </el-popover>
     </p>
 
-    <p v-else key="only-value">
+    <p v-else key="only-value" :class="cellCssClass">
       {{ displayedValue }}
     </p>
   </span>
@@ -137,6 +137,21 @@ export default defineComponent({
         field: props.fieldAttributes,
         row: props.dataRow
       })
+    })
+
+    /**
+     * Css class style
+     */
+    const cellCssClass = computed(() => {
+      let classCss = ''
+      if (isReadOnly.value) {
+        classCss += ' cell-no-edit '
+      }
+      if (props.fieldAttributes.componentPath === 'FieldNumber') {
+        classCss += ' cell-align-right '
+      }
+      // return 'cell-edit'
+      return classCss
     })
 
     const formatNumber = ({ displayType, value }) => {
@@ -212,6 +227,7 @@ export default defineComponent({
 
     return {
       // computeds
+      cellCssClass,
       fieldValue,
       displayedValue,
       // methods
@@ -220,3 +236,15 @@ export default defineComponent({
   }
 })
 </script>
+
+<style lang="scss">
+// used in cell type number
+.cell-align-right {
+  text-align: right !important;
+}
+
+// style in cursor if cell is no edit
+.cell-no-edit {
+  cursor: not-allowed !important;
+}
+</style>

--- a/src/components/ADempiere/Field/FieldNumber.vue
+++ b/src/components/ADempiere/Field/FieldNumber.vue
@@ -38,6 +38,7 @@
       :controls="isShowControls"
       :controls-position="controlsPosition"
       :class="cssClassStyle"
+      style="text-align-last: end !important"
       autofocus
       @change="preHandleChange"
       @focus="focusGained"


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open window with any number field.
2. Focus field number.

#### Screenshot or Gif
Before this changes:

https://user-images.githubusercontent.com/20288327/147013858-76321731-8cbe-42f7-924a-415df819a4b5.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/147013870-4fb6181f-a059-46a5-857a-fb01b8636299.mp4


#### Expected behavior
A clear and concise description of what you expected to happen.

#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

