### PR TITLE
fix: New parent record show old records tab childs

### DIFF
--- a/src/components/ADempiere/TabManager/index.vue
+++ b/src/components/ADempiere/TabManager/index.vue
@@ -331,7 +331,6 @@ export default defineComponent({
       })
 
       watch(recordUuidTabParent, (newValue, oldValue) => {
-        console.log(oldValue !== newValue, isReadyFromGetData.value)
         if (newValue !== oldValue && !root.isEmptyValue(newValue)) {
           getData()
         }

--- a/src/components/ADempiere/TabManager/index.vue
+++ b/src/components/ADempiere/TabManager/index.vue
@@ -173,7 +173,8 @@ export default defineComponent({
     })
 
     function isDisabledTab(key) {
-      return key > 0 && isCreateNew.value
+      return (key > 0 || !props.isParentTabs) &&
+        (isCreateNew.value || root.isEmptyValue(recordUuidTabParent.value))
     }
 
     function setCurrentTab() {
@@ -240,6 +241,9 @@ export default defineComponent({
 
     // get records list
     const recordsList = computed(() => {
+      if (!props.isParentTabs && root.isEmptyValue(recordUuidTabParent.value)) {
+        return []
+      }
       return tabData.value.recordsList
     })
 
@@ -255,6 +259,14 @@ export default defineComponent({
       }
       // TODO: add is loaded context columns
       return isLoadedParentRecords.value && !tabData.value.isLoaded
+    })
+
+    const recordUuidTabParent = computed(() => {
+      return root.$store.getters.getValueOfField({
+        parentUuid: props.parentUuid,
+        containerUuid: currentTabMetadata.value.firstTabUuid,
+        columnName: 'UUID'
+      })
     })
 
     const getData = () => {
@@ -314,6 +326,13 @@ export default defineComponent({
     } else {
       watch(isReadyFromGetData, (newValue, oldValue) => {
         if (newValue) {
+          getData()
+        }
+      })
+
+      watch(recordUuidTabParent, (newValue, oldValue) => {
+        console.log(oldValue !== newValue, isReadyFromGetData.value)
+        if (newValue !== oldValue && !root.isEmptyValue(newValue)) {
           getData()
         }
       })

--- a/src/components/ADempiere/TabManager/index.vue
+++ b/src/components/ADempiere/TabManager/index.vue
@@ -274,6 +274,7 @@ export default defineComponent({
         parentUuid: props.parentUuid,
         containerUuid: tabUuid.value
       }).then(responseData => {
+        const tab = root.$store.getters.getStoredTab(props.parentUuid, tabUuid.value)
         if (!isCreateNew.value && !root.isEmptyValue(responseData)) {
           let row
           const { action } = root.$route.query
@@ -288,14 +289,29 @@ export default defineComponent({
               row = responseData.find(rowData => {
                 return rowData.UUID === action
               })
+
+              // search link value
+              if (root.isEmptyValue(row) && !tab.isParentTab) {
+                const { linkColumnName } = tab
+                const value = root.$store.getters.getValueOfField({
+                  parentUuid: props.parentUuid,
+                  columnName: linkColumnName
+                })
+                if (linkColumnName && !root.isEmptyValue(value)) {
+                  row = responseData.find(rowData => {
+                    return rowData[linkColumnName] === value
+                  })
+                }
+              }
             }
           }
+
           // set first record
           if (root.isEmptyValue(row)) {
             row = responseData[0]
           }
 
-          const tableName = props.tabsList[currentTab.value].tableName
+          const { tableName } = tab
           // set values in panel
           props.containerManager.seekRecord({
             parentUuid: props.parentUuid,

--- a/src/store/modules/ADempiere/fieldValue.js
+++ b/src/store/modules/ADempiere/fieldValue.js
@@ -15,11 +15,15 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import Vue from 'vue'
-import { isEmptyValue, typeValue } from '@/utils/ADempiere/valueUtils.js'
-import { convertStringToBoolean } from '@/utils/ADempiere/formatValue/booleanFormat.js'
+
+// constants
 import {
   ACTIVE, PROCESSING, PROCESSED
 } from '@/utils/ADempiere/constants/systemColumns'
+
+// utils and helpers methods
+import { isEmptyValue, typeValue } from '@/utils/ADempiere/valueUtils.js'
+import { convertStringToBoolean } from '@/utils/ADempiere/formatValue/booleanFormat.js'
 
 const UUID_KEY = 'UUID'
 
@@ -34,8 +38,9 @@ const value = {
         field: {}
       }
     },
+
     /**
-     *
+     * Set value into column names
      * @param {string}  parentUuid
      * @param {string}  containerUuid
      * @param {string}  columnName
@@ -52,8 +57,43 @@ const value = {
       // Only Parent
       if (parentUuid) {
         const keyParent = parentUuid + '_' + columnName
-        const valueParent = state.field[keyParent]
-        if (value !== valueParent) {
+        if (isOverWriteParent) {
+          Vue.set(state.field, keyParent, value)
+        } else {
+          if (!isEmptyValue(value)) {
+            // tab child no replace parent context with empty
+            Vue.set(state.field, keyParent, value)
+          }
+        }
+      }
+
+      // Only Container
+      if (containerUuid) {
+        const keyContainer = containerUuid + '_' + columnName
+        Vue.set(state.field, keyContainer, value)
+      }
+    },
+
+    /**
+     * Set values into container column names
+     * @param {string}  parentUuid
+     * @param {string}  containerUuid
+     * @param {string}  columnName
+     * @param {mixed}   value
+     * @param {boolean} isOverWriteParent // overwite parent context values
+     */
+    updateValuesOfContainer(state,
+      parentUuid,
+      containerUuid,
+      attributes = [],
+      isOverWriteParent = false
+    ) {
+      attributes.forEach(attribute => {
+        const { value, columnName } = attribute
+
+        // Only Parent
+        if (parentUuid) {
+          const keyParent = parentUuid + '_' + columnName
           if (isOverWriteParent) {
             Vue.set(state.field, keyParent, value)
           } else {
@@ -63,43 +103,11 @@ const value = {
             }
           }
         }
-      }
-
-      // Only Container
-      if (containerUuid) {
-        const keyContainer = containerUuid + '_' + columnName
-        if (value !== state.field[keyContainer]) {
-          Vue.set(state.field, keyContainer, value)
-        }
-      }
-    },
-    updateValuesOfContainer(state, payload) {
-      const { parentUuid, containerUuid, isOverWriteParent } = payload
-      payload.attributes.forEach(attribute => {
-        const { value, columnName } = attribute
-
-        // Only Parent
-        if (parentUuid) {
-          const keyParent = parentUuid + '_' + columnName
-          const valueParent = state.field[keyParent]
-          if (value !== valueParent) {
-            if (isOverWriteParent) {
-              Vue.set(state.field, keyParent, value)
-            } else {
-              if (!isEmptyValue(value)) {
-                // tab child no replace parent context with empty
-                Vue.set(state.field, keyParent, value)
-              }
-            }
-          }
-        }
 
         // Only Container
         if (containerUuid) {
           const keyContainer = containerUuid + '_' + columnName
-          if (value !== state.field[keyContainer]) {
-            Vue.set(state.field, keyContainer, value)
-          }
+          Vue.set(state.field, keyContainer, value)
         }
       })
     }

--- a/src/store/modules/ADempiere/windowManager.js
+++ b/src/store/modules/ADempiere/windowManager.js
@@ -119,12 +119,14 @@ const windowManager = {
         const token = getters.getPageToken({ containerUuid })
         pageToken = generatePageToken({ pageNumber, token })
       }
+
       const { contextColumnNames } = rootGetters.getStoredTab(parentUuid, containerUuid)
 
       const contextAttriburesList = []
       if (!isEmptyValue(contextColumnNames)) {
         contextColumnNames.forEach(columnName => {
           const value = getContext({
+            parentUuid,
             containerUuid,
             columnName
           })
@@ -139,7 +141,7 @@ const windowManager = {
         getEntities({
           windowUuid: parentUuid,
           tabUuid: containerUuid,
-          contextAttriburesList,
+          attributes: contextAttriburesList,
           pageToken
         })
           .then(dataResponse => {

--- a/src/utils/ADempiere/constants/actionsMenuList.js
+++ b/src/utils/ADempiere/constants/actionsMenuList.js
@@ -98,7 +98,7 @@ export const deleteRecord = {
   type: 'deleteEntity',
   actionName: 'deleteRecord',
   deleteRecord: ({ root, parentUuid, containerUuid, recordId, recordUuid }) => {
-    root.$store.dispatch('dataManager/deleteEntity', {
+    root.$store.dispatch('deleteEntity', {
       parentUuid,
       containerUuid,
       recordId,
@@ -146,7 +146,7 @@ export const refreshRecords = {
   actionName: 'refreshRecords',
   refreshRecords: ({ root, parentUuid, containerUuid, tableName }) => {
     // used to window
-    root.$store.dispatch('dataManager/getEntities', {
+    root.$store.dispatch('getEntities', {
       parentUuid,
       containerUuid
     })

--- a/src/views/ADempiere/Test/MultiTabWindow/index.vue
+++ b/src/views/ADempiere/Test/MultiTabWindow/index.vue
@@ -103,8 +103,7 @@ export default defineComponent({
             {
               ...refreshRecords,
               callBack: () => {
-                console.log('call getEntities')
-                root.$store.dispatch('dataManager/getEntities', {
+                root.$store.dispatch('getEntities', {
                   parentUuid: props.parentUuid,
                   containerUuid: uuid,
                   tableName

--- a/src/views/ADempiere/Window/MultiTabWindow.vue
+++ b/src/views/ADempiere/Window/MultiTabWindow.vue
@@ -158,7 +158,7 @@ export default defineComponent({
         containerUuid,
         pageNumber = 0
       }) => {
-        root.$store.dispatch('dataManager/getEntities', {
+        root.$store.dispatch('getEntities', {
           parentUuid,
           containerUuid,
           pageNumber


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open any window with child tabs and records.
2. Run create new record in tab parent.


#### Screenshot or Gif
Before this changes:

https://user-images.githubusercontent.com/20288327/147424444-a2fa17ef-eef5-41d2-894e-07a64eb56435.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/147424399-1a567d32-9ee2-4c24-93ce-8f6b1fc7bcd3.mp4

#### Expected behavior

If you select create new record on the parent tab, the records on the child tabs should be blank since there are no related records yet.

#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional Context

cURL code:
```
curl 'http://localhost:8085/api/adempiere/user-interface/window/entities?window_uuid=a521b0ee-fb40-11e8-a479-7a0060f0aa01&tab_uuid=a4a2b050-fb40-11e8-a479-7a0060f0aa01&context_attributes[]=%7B%22column_name%22:%22AD_View_ID%22,%22value%22:50000%7D&token=7658aa61-bb91-4cc0-b7b5-3136671bad4e&language=es'  -H 'Accept: application/json, text/plain, */*' '
```

URL link:
http://localhost:8085/api/adempiere/user-interface/window/entities?window_uuid=a521b0ee-fb40-11e8-a479-7a0060f0aa01&tab_uuid=a4a2b050-fb40-11e8-a479-7a0060f0aa01&context_attributes[]=%7B%22column_name%22:%22AD_View_ID%22,%22value%22:50000%7D&token=7658aa61-bb91-4cc0-b7b5-3136671bad4e&language=es


