### PR TITLE
fix: Load records in tab parents.

### DIFF
--- a/src/components/ADempiere/TabManager/index.vue
+++ b/src/components/ADempiere/TabManager/index.vue
@@ -339,6 +339,12 @@ export default defineComponent({
       if (isReadyFromGetData.value) {
         getData()
       }
+      // if changed tab and not records in stored, get records from server
+      watch(tabUuid, (newValue, oldValue) => {
+        if (newValue !== oldValue && !root.isEmptyValue(recordUuidTabParent.value) && !tabData.value.isLoaded) {
+          getData()
+        }
+      })
     } else {
       watch(isReadyFromGetData, (newValue, oldValue) => {
         if (newValue) {
@@ -346,6 +352,7 @@ export default defineComponent({
         }
       })
 
+      // if changed record in parent tab, reload tab child
       watch(recordUuidTabParent, (newValue, oldValue) => {
         if (newValue !== oldValue && !root.isEmptyValue(newValue)) {
           getData()


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open window `Business Partner`.
2. Select any parent tab (`Client`).
3. Showed records.

#### Screenshot or Gif
Before this changes:

https://user-images.githubusercontent.com/20288327/147505664-7841a09c-3c5d-43b4-b7bf-1b85bb08981d.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/147505673-6bf47cdf-d195-4ca7-8f05-55c09560ddff.mp4


#### Expected behavior
It is expected that the records of the parent tabs will be loaded and displayed.


#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
On the server side the filtering with the `context_attributes` is not working as it should show only the record of the selected business partner in the first tab.

