### PR TITLE
Disabling checkout button when order is processed

### DIFF
--- a/src/components/ADempiere/Form/VPOS/Collection/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Collection/index.vue
@@ -103,7 +103,7 @@
             <el-button type="danger" icon="el-icon-close" @click="exit" />
             <el-button type="info" icon="el-icon-minus" :disabled="isDisabled" @click="undoPatment" />
             <el-button type="success" icon="el-icon-plus" :disabled="validPay || addPay || isDisabled" @click="addCollectToList(paymentBox)" />
-            <el-button type="primary" :disabled="validatePaymentBeforeProcessing" icon="el-icon-shopping-cart-full" @click="validateOrder(listPayments)" />
+            <el-button type="primary" :disabled="validatePaymentBeforeProcessing || porcessInvoce" icon="el-icon-shopping-cart-full" @click="validateOrder(listPayments)" />
           </samp>
         </el-header>
         <!-- Panel where they show the payments registered from the collection container -->


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

In the POS, when processing the order, when the pay button is clicked repeatedly, for each click a new customer invoice is made and then the second time a rollback is made, but in certain cases when the invoice is sent to an external billing provider, all persistent bills remain

#### Steps to reproduce

1. Make a POS order
2. Add the payment
3. Click the proccess POS Order button repeatedly before the answer returns

#### Screenshot or Gif

![Peek_27-12-2021_13-03](https://user-images.githubusercontent.com/14218144/147507768-f89e1e0b-819c-427c-902f-62ad71dab8d4.gif)

#### Expected behavior

This pull request disable the process POS Order button after click to prevent the repeated click

![Peek 27-12-2021 18-19](https://user-images.githubusercontent.com/14218144/147507950-ce363899-b461-40b6-9a81-257c5d82df12.gif)


