### PR TITLE
Fix overflow on product name search

### DIFF
--- a/src/components/ADempiere/Form/VPOS/ProductInfo/index.vue
+++ b/src/components/ADempiere/Form/VPOS/ProductInfo/index.vue
@@ -297,6 +297,7 @@ export default {
       .header {
         text-overflow: ellipsis;
         overflow: hidden;
+        white-space: initial;
       }
 
       .upc {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

In the POS, the product name is hidden the overflow when is too large in the product search box.

There is an example

#### Steps to reproduce

1. Open the POS
2. Find a product with a large name

#### Screenshot or Gif

![Peek 28-12-2021 16-41](https://user-images.githubusercontent.com/14218144/147602291-07fcff41-151c-4633-a90c-eef17555d3d2.gif)

#### Expected behavior

With this modification, longer product names will jump to a new line when overflow

![Peek 28-12-2021 16-42](https://user-images.githubusercontent.com/14218144/147602375-785e004c-6f03-45f8-a810-882b3c6b635f.gif)

