### PR TITLE
fix: Private access in tab childs records.

### DIFF
--- a/src/components/ADempiere/ContainerOptions/LockRecord/index.vue
+++ b/src/components/ADempiere/ContainerOptions/LockRecord/index.vue
@@ -87,21 +87,40 @@ export default defineComponent({
     })
 
     const storedPrivateAccess = computed(() => {
-      const { recordUuid } = getRecordKeys()
-
       return root.$store.getters.getStoredPrivateAccess({
         tableName,
-        recordUuid
+        recordUuid: recordUuid.value
       })
     })
 
-    const lockRecord = () => {
-      const { recordId, recordUuid } = getRecordKeys()
+    // TODO: Add client-side and server-side support for keys composed of more than 1 field
+    const recordId = computed(() => {
+      return root.$store.getters.getValueOfField({
+        parentUuid: props.parentUuid,
+        containerUuid: props.containerUuid,
+        columnName: tableName + '_ID'
+      })
+    })
+    const recordUuid = computed(() => {
+      return root.$store.getters.getValueOfField({
+        parentUuid: props.parentUuid,
+        containerUuid: props.containerUuid,
+        columnName: 'UUID'
+      })
+    })
 
+    const recordKeys = computed(() => {
+      return {
+        recordId: recordId.value,
+        recordUuid: recordUuid.value
+      }
+    })
+
+    const lockRecord = () => {
       root.$store.dispatch('lockRecordFromServer', {
         tableName,
-        recordId,
-        recordUuid
+        recordId: recordId.value,
+        recordUuid: recordUuid.value
       })
         .then(isLockedResponse => {
           isLocked.value = isLockedResponse
@@ -109,51 +128,20 @@ export default defineComponent({
     }
 
     const unLockRecord = () => {
-      const { recordId, recordUuid } = getRecordKeys()
-
       root.$store.dispatch('unlockRecordFromServer', {
         tableName,
-        recordId,
-        recordUuid
+        recordId: recordId.value,
+        recordUuid: recordUuid.value
       })
         .then(isUnLockedResponse => {
           isLocked.value = isUnLockedResponse
         })
     }
 
-    const record = computed(() => {
-      return root.$store.getters.getValuesView({
-        parentUuid: props.parentUuid,
-        containerUuid: props.containerUuid,
-        format: 'object'
-      })
-    })
-
-    const getRecordKeys = () => {
-      let recordId
-      let recordUuid
-      const recordRow = record.value
-      if (!root.isEmptyValue(recordRow)) {
-        recordId = recordRow[tableName + '_ID']
-        recordUuid = recordRow.UUID
-      } else {
-        if (isValidUuid(root.$route.query.action)) {
-          recordUuid = root.$route.query.action
-        }
-      }
-
-      return {
-        recordId,
-        recordUuid
-      }
-    }
-
     const isGettingRecordAccess = ref(false)
 
     const getPrivateAccess = () => {
-      const { recordId, recordUuid } = getRecordKeys()
-
-      if (root.isEmptyValue(recordId) && root.isEmptyValue(recordUuid)) {
+      if (root.isEmptyValue(recordId.value) && root.isEmptyValue(recordUuid.value)) {
         return
       }
 
@@ -168,8 +156,8 @@ export default defineComponent({
       // get from server
       root.$store.dispatch('getPrivateAccessFromServer', {
         tableName,
-        recordId,
-        recordUuid
+        recordId: recordId.value,
+        recordUuid: recordUuid.value
       })
         .then(privateAccessResponse => {
           isLocked.value = privateAccessResponse
@@ -182,8 +170,8 @@ export default defineComponent({
     // timer to execute the request between times
     const timeOut = ref(() => {})
 
-    watch(() => root.$route.query.action, (newValue, oldValue) => {
-      if (props.isActiveTab && isValidUuid(newValue) && !isGettingRecordAccess.value) {
+    watch(recordKeys, (newValue, oldValue) => {
+      if (props.isActiveTab && (isValidUuid(newValue.recordUuid) || !root.isEmptyValue(newValue.recordId)) && !isGettingRecordAccess.value) {
         clearTimeout(timeOut.value)
 
         timeOut.value = setTimeout(() => {

--- a/src/utils/ADempiere/dictionary/panel.js
+++ b/src/utils/ADempiere/dictionary/panel.js
@@ -144,6 +144,8 @@ export function generatePanelAndFields({
 
   const fieldsRangeList = []
   const selectionColumns = []
+  const keyColumns = []
+  const parentColumns = []
   let identifierColumns = []
 
   let keyColumn
@@ -160,6 +162,7 @@ export function generatePanelAndFields({
     const { columnName, componentPath } = fieldDefinition
 
     if (fieldDefinition.isKey) {
+      keyColumns.push(columnName)
       keyColumn = columnName
     }
     if (fieldDefinition.isSelectionColumn) {
@@ -171,6 +174,9 @@ export function generatePanelAndFields({
         identifierSequence: fieldDefinition.identifierSequence,
         componentPath
       })
+    }
+    if (fieldDefinition.isParent) {
+      parentColumns.push(columnName)
     }
 
     // Add new field if is range number
@@ -256,6 +262,8 @@ export function generatePanelAndFields({
     fieldsList,
     // app attributes
     keyColumn,
+    keyColumns,
+    parentColumns,
     selectionColumns,
     identifierColumns,
     isLoadedFieldsList: true,


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open any window with multiple tabs and records.
2. Change records in tab child.


#### Screenshot or Gif
Before this changes:

https://user-images.githubusercontent.com/20288327/148001440-6ede8ba7-3c6c-4e30-82b5-4eeedf12068f.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/148001490-65e80287-5e28-4209-a7d6-22a8b1f49cf1.mp4


#### Expected behavior
It is expected that if the record changes on both parent and child tabs, a private record request will be made.

#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.
