### PR TITLE
fix: Load field location address.

### DIFF
--- a/src/components/ADempiere/Field/FieldLocation/fieldsList.js
+++ b/src/components/ADempiere/Field/FieldLocation/fieldsList.js
@@ -13,15 +13,12 @@
 
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
-import language from '@/lang'
+
+// import language from '@/lang'
 
 const fieldBase = {
   tableName: 'C_Location',
-  isFromDictionary: true,
-  overwriteDefinition: {
-    size: 24,
-    index: 0
-  }
+  isFromDictionary: true
 }
 
 export default [
@@ -42,6 +39,7 @@ export default [
     columnName: 'C_Country_ID',
     overwriteDefinition: {
       isCustomField: true,
+      isUpdateable: true,
       isActiveLogics: true, // enable logics
       defaultValue: '@#C_Country_ID@',
       size: 24,
@@ -56,10 +54,11 @@ export default [
     columnName: 'C_Region_ID',
     overwriteDefinition: {
       isCustomField: true,
+      isUpdateable: true,
       size: 24,
       sequenceFields: 'R',
       index: 3,
-      isMandatory: true
+      isMandatory: false
     }
   },
   {
@@ -68,6 +67,7 @@ export default [
     columnName: 'C_City_ID',
     overwriteDefinition: {
       isCustomField: true,
+      isUpdateable: true,
       size: 24,
       sequenceFields: 'C',
       index: 4,
@@ -80,6 +80,7 @@ export default [
     columnName: 'Address1',
     overwriteDefinition: {
       isCustomField: true,
+      isUpdateable: true,
       size: 24,
       sequenceFields: 'A1',
       index: 5
@@ -91,6 +92,7 @@ export default [
     columnName: 'Address2',
     overwriteDefinition: {
       isCustomField: true,
+      isUpdateable: true,
       size: 24,
       sequenceFields: 'A2',
       index: 6
@@ -102,6 +104,7 @@ export default [
     columnName: 'Address3',
     overwriteDefinition: {
       isCustomField: true,
+      isUpdateable: true,
       size: 24,
       sequenceFields: 'A3',
       index: 7
@@ -113,6 +116,7 @@ export default [
     columnName: 'Address4',
     overwriteDefinition: {
       isCustomField: true,
+      isUpdateable: true,
       size: 24,
       sequenceFields: 'A4',
       index: 8
@@ -124,21 +128,25 @@ export default [
     columnName: 'Postal',
     overwriteDefinition: {
       isCustomField: true,
+      isUpdateable: true,
       size: 24,
       sequenceFields: 'P',
       index: 9
     }
-  },
+  }
+  /*,
   {
     elementColumnName: 'Name',
     isFromDictionary: true,
     overwriteDefinition: {
       tabindex: 1,
       isCustomField: true,
+      isUpdateable: true,
       size: 24,
       name: language.t('components.contextMenuReferences'),
       sequence: 1,
       isMandatory: true
     }
   }
+  */
 ]

--- a/src/components/ADempiere/Field/FieldLocation/index.vue
+++ b/src/components/ADempiere/Field/FieldLocation/index.vue
@@ -15,20 +15,34 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https:www.gnu.org/licenses/>.
 -->
+
 <template>
   <el-popover
     v-if="!metadata.pos"
+    key="standard"
     ref="locationAddress"
     v-model="isShowedLocationForm"
+    class="popover-location"
     placement="left-end"
-    width="300"
+    width="350"
     trigger="manual"
   >
     <location-address-form
+      v-if="isShowedLocationForm"
+      class="location-form"
       :values="localValues"
       :parent-metadata="metadata"
+      :parent-uuid="parentUuid"
+      :container-uuid="containerUuid"
+      :container-manager="containerManager"
     />
-    <el-button slot="reference" type="text" style="width: -webkit-fill-available;" @click="setShowedLocationForm(true)">
+
+    <el-button
+      slot="reference"
+      class="button-location-show"
+      type="text"
+      @click="isShowedLocationForm = true"
+    >
       <el-input
         v-model="displayedValue"
         :class="cssClassStyle"
@@ -38,20 +52,26 @@
       </el-input>
     </el-button>
   </el-popover>
+
   <location-address-form
     v-else
+    key="point-of-sales"
+    class="location-form"
     :values="localValues"
     :parent-metadata="metadata"
+    :parent-uuid="parentUuid"
+    :container-uuid="containerUuid"
+    :container-manager="containerManager"
   />
 </template>
 
 <script>
 // mixins
 import fieldMixin from '@/components/ADempiere/Field/mixin/mixinField.js'
-import mixinLocation from './mixinLocation.js'
+import mixinLocation, { LOCATION_ADDRESS_FORM } from './mixinLocation.js'
 
 // components
-import LocationAddressForm from './locationAddressForm'
+import LocationAddressForm from './locationAddressForm.vue'
 
 export default {
   name: 'FieldLocation',
@@ -65,9 +85,14 @@ export default {
     mixinLocation
   ],
 
-  data() {
-    return {
-      localValues: {}
+  props: {
+    parentUuid: {
+      type: String,
+      default: undefined
+    },
+    containerUuid: {
+      type: String,
+      required: true
     }
   },
 
@@ -117,6 +142,19 @@ export default {
     }
   },
 
+  watch: {
+    value(newValue, oldValue) {
+      if (this.isEmptyValue(newValue)) {
+        this.displayedValue = undefined
+      } else {
+        if (newValue !== oldValue) {
+          this.displayedValue = undefined
+          this.getLocation()
+        }
+      }
+    }
+  },
+
   mounted() {
     if (!this.metadata.isAdvancedQuery) {
       this.getLocation()
@@ -124,7 +162,14 @@ export default {
   },
 
   methods: {
+    /**
+     * Request location entity
+     */
     getLocation() {
+      if (this.isGettingLocation) {
+        return
+      }
+
       if (!this.isEmptyValue(this.displayedValue)) {
         return
       }
@@ -134,21 +179,39 @@ export default {
         return
       }
 
+      this.isGettingLocation = true
       this.getLocationAddress({
         id: value
       })
         .then(responseLocation => {
-          const { values } = responseLocation
-
-          this.localValues = values
+          const { attributes } = responseLocation
+          this.localValues = attributes
 
           // TODO: Get Display_ColumnName from server request
-          this.displayedValue = this.getDisplayedValue(values) || value
+          this.displayedValue = this.getDisplayedValue(attributes) || value
+
+          this.$store.commit('updateValuesOfContainer', {
+            // parentUuid,
+            containerUuid: LOCATION_ADDRESS_FORM,
+            attributes
+          })
         })
         .catch(error => {
-          console.warn(`Get Location Address, Field Location - Error ${error.code}: ${error.message}.`)
+          console.warn(`Get Location Address Form, Field Location - Error ${error.code}: ${error.message}.`)
+        })
+        .finally(() => {
+          this.isGettingLocation = false
         })
     }
   }
 }
 </script>
+
+<style lang="scss">
+/**
+ * span tag as button and label text
+ */
+.button-location-show {
+  padding-top: 0px !important;
+}
+</style>

--- a/src/components/ADempiere/Field/FieldLocation/locationAddressForm.vue
+++ b/src/components/ADempiere/Field/FieldLocation/locationAddressForm.vue
@@ -15,6 +15,7 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <https:www.gnu.org/licenses/>.
 -->
+
 <template>
   <div class="wrapper">
     <el-form
@@ -24,14 +25,18 @@
       class="location-address"
       @shortkey.native="keyAction"
     >
-      <el-row :gutter="24">
+      <el-row :gutter="0">
         <template v-if="isLoaded">
           <el-col v-for="(field) in fieldsListLocation" :key="field.columnName" :span="12">
-            <field
+            <field-definition
+              :parent-uuid="parentUuid"
+              :container-uuid="containerUuid"
+              :container-manager="containerManagerLocation"
               :metadata-field="field"
             />
           </el-col>
         </template>
+
         <div
           v-else
           key="form-loading"
@@ -42,6 +47,7 @@
           style="min-height: calc(50vh - 84px)"
           class="loading-panel"
         />
+
         <el-col v-show="!parentMetadata.pos" :span="24" style="padding-left: 12px;padding-right: 12px;padding-top: 3%;padding-bottom: 3%;">
           <samp style="float: right; padding-right: 10px;">
             <el-button
@@ -55,7 +61,7 @@
               type="danger"
               class="custom-button-address-location"
               icon="el-icon-close"
-              @click="setShowedLocationForm(false)"
+              @click="cancelChanges"
             />
           </samp>
         </el-col>
@@ -65,33 +71,47 @@
 </template>
 
 <script>
+// components and mixins
 import formMixin from '@/components/ADempiere/Form/formMixin.js'
-import mixinLocation from './mixinLocation.js'
-import fieldsList from './fieldsList.js'
+import mixinLocation, { LOCATION_ADDRESS_FORM } from './mixinLocation.js'
+
+// constants
+import FieldsList from './fieldsList.js'
+
+// api request methods
 import {
   createLocationAddress,
   updateLocationAddress
 } from '@/api/ADempiere/field/location.js'
+
+// utils and helper methods
 import { showNotification } from '@/utils/ADempiere/notification.js'
 import { getSequenceAsList } from '@/utils/ADempiere/location'
 
 /**
- * TODO: Add sequence fields by country selected
+ * Location Address form to field
  */
 export default {
   name: 'LocationAdressFrom',
+
   mixins: [
     formMixin,
     mixinLocation
   ],
+
   props: {
+    parentUuid: {
+      type: String,
+      default: undefined
+    },
     metadata: {
       type: Object,
       default: () => {
         return {
           // TODO: Add container uuid parent
-          uuid: 'Location-Address-Create',
-          containerUuid: 'Location-Address-Create'
+          uuid: LOCATION_ADDRESS_FORM,
+          containerUuid: LOCATION_ADDRESS_FORM,
+          isSetDefaultValues: false
         }
       }
     },
@@ -105,19 +125,32 @@ export default {
       default: () => {}
     }
   },
+
   data() {
     return {
-      fieldsList,
-      isCustomForm: true,
-      request: 0
+      fieldsList: FieldsList,
+      isCustomForm: true
     }
   },
+
   computed: {
+    containerManagerLocation() {
+      return {
+        ...this.containerManager,
+
+        getFieldsList({ containerUuid, root }) {
+          return root.$store.getters.getFieldLocation
+        }
+      }
+    },
     fieldsListLocation() {
       if (!this.isEmptyValue(this.$store.getters.getFieldLocation)) {
         return this.$store.getters.getFieldLocation
       }
-      return this.fieldsList
+
+      // return this.fieldsList
+
+      return this.getterPanel.fieldsList
     },
     locationId() {
       return this.$store.getters.getValueOfField({
@@ -127,14 +160,17 @@ export default {
       })
     }
   },
+
   created() {
-    if (this.parentMetadata.pos) {
-      this.fieldsList.forEach(element => {
-        element.containerUuid = this.parentMetadata.containerUuid
+    this.unsubscribe = this.subscribeChanges()
+
+    if (!this.isEmptyValue(this.values)) {
+      this.setValues({
+        values: this.values
       })
     }
-    this.unsubscribe = this.subscribeChanges()
   },
+
   mounted() {
     if (this.parentMetadata.pos) {
       this.fieldsList.forEach(element => {
@@ -143,75 +179,109 @@ export default {
     }
     this.getLocation()
   },
-  beforeDestroy() {
-    this.unsubscribe()
-  },
+
   methods: {
     keyAction(event) {
       if (event.srcKey === 'closeForm') {
         this.toggleShowedLocationForm()
       }
     },
+    cancelChanges() {
+      // TODO: Set old values
+      this.isShowedLocationForm = false
+    },
     sortSequence(itemA, itemB) {
       return itemA.index - itemB.index
     },
     subscribeChanges() {
       return this.$store.subscribe((mutation, state) => {
-        const withOutColumnNames = ['C_Country_ID', 'DisplayColumn_C_Country_ID', 'C_Location_ID']
+        // when first load country field with value
+        if (
+          mutation.type === 'setLookupItem' &&
+          mutation.payload.containerUuid === this.metadata.containerUuid &&
+          mutation.payload.tableName === 'C_Country'
+        ) {
+          this.changeCaptureSequence(mutation.payload.value)
+        }
 
-        if (mutation.type === 'updateValueOfField' &&
-          mutation.payload.containerUuid === this.parentMetadata.containerUuid) {
-          if (mutation.payload.columnName === 'C_Country_ID') {
-            const values = []
-            // Get country definition to sequence fields and displayed value
-            if (mutation.payload.value !== this.currentCountryDefinition.countryId) {
-              this.requestGetCountryDefinition({
-                id: mutation.payload.value
+        // if changed country field
+        if (
+          mutation.type === 'updateValueOfField' &&
+          mutation.payload.containerUuid === this.metadata.containerUuid &&
+          mutation.payload.columnName === 'C_Country_ID'
+        ) {
+          const withOutColumnNames = ['C_Country_ID', 'DisplayColumn_C_Country_ID', 'C_Location_ID']
+          // Get country definition to sequence fields and displayed value
+          this.changeCaptureSequence(mutation.payload.value)
+
+          // clear values
+          const values = []
+          FieldsList.forEach(item => {
+            if (!withOutColumnNames.includes(item.columnName)) {
+              values.push({
+                columnName: item.columnName,
+                value: undefined
               })
-                .then(responseCountry => {
-                  const newSequence = getSequenceAsList(responseCountry.captureSequence)
-                  const newFieldsList = this.fieldsList.map(item => {
-                    if (newSequence.includes(item.sequenceFields)) {
-                      return {
-                        ...item,
-                        isDisplayed: true,
-                        index: newSequence.indexOf(item.sequenceFields)
-                      }
-                    }
-                    return {
-                      ...item,
-                      isDisplayed: false
-                    }
-                  })
-                  this.$store.dispatch('changeSequence', newFieldsList.sort(this.sortSequence))
-                })
-                .catch(error => {
-                  this.$message({
-                    message: error.message,
-                    isShowClose: true,
-                    type: 'error'
-                  })
-                  console.warn(`Error getting Country Definition: ${error.message}. Code: ${error.code}.`)
-                })
             }
+            if (!withOutColumnNames.includes(item.displayColumnName)) {
+              values.push({
+                columnName: item.displayColumnName,
+                value: undefined
+              })
+            }
+          })
 
-            fieldsList.forEach(item => {
-              if (!withOutColumnNames.includes(item.columnName)) {
-                values.push({
-                  columnName: item.columnName,
-                  value: undefined
-                })
-              }
-            })
-
-            this.setValues({
-              values,
-              withOutColumnNames
-            })
-          }
+          this.setValues({
+            values,
+            withOutColumnNames
+          })
         }
       })
     },
+
+    /**
+     * Change fields order
+     * @param {number} countryId
+     */
+    changeCaptureSequence(countryId) {
+      this.$store.dispatch('getCountryDefinition', {
+        id: countryId
+      })
+        .then(responseCountry => {
+          // capture sequence by form fields
+          const newSequence = getSequenceAsList(responseCountry.captureSequence)
+          const newFieldsList = this.fieldsListLocation.map(item => {
+            if (newSequence.includes(item.sequenceFields)) {
+              return {
+                ...item,
+                isDisplayed: true,
+                index: newSequence.indexOf(item.sequenceFields)
+              }
+            }
+            return {
+              ...item,
+              isDisplayed: false
+            }
+          }).sort((itemA, itemB) => {
+            return itemA.index - itemB.index
+          })
+
+          this.$store.dispatch('changeSequence', newFieldsList)
+        })
+        .catch(error => {
+          this.$message({
+            message: error.message,
+            isShowClose: true,
+            type: 'error'
+          })
+          console.warn(`Error getting Country Definition: ${error.message}. Code: ${error.code}.`)
+        })
+    },
+
+    /**
+     * set context values to parent continer
+     * @param {object} values
+     */
     setParentValues(values) {
       const {
         parentUuid,
@@ -234,39 +304,13 @@ export default {
         columnName: displayColumnName,
         value: this.getDisplayedValue(values)
       })
-
-      this.$store.commit('updateValueOfField', {
-        parentUuid,
-        containerUuid,
-        columnName: 'Postal',
-        value: values.Postal
-      })
-
-      this.$store.commit('updateValueOfField', {
-        parentUuid,
-        containerUuid,
-        columnName: 'C_Country_ID',
-        value: values.C_Country_ID
-      })
-
-      this.$store.commit('updateValueOfField', {
-        parentUuid,
-        containerUuid,
-        columnName: 'C_City_ID',
-        value: values.C_City_ID
-      })
-
-      // active update record to server
-      // this.$store.dispatch('notifyFieldChange', {
-      //   containerUuid,
-      //   field: this.parentMetadata
-      // })
     },
     sendValuesToServer() {
       const emptyMandatoryFields = this.$store.getters.getFieldsListEmptyMandatory({
         containerUuid: this.containerUuid,
         formatReturn: 'name'
       })
+
       if (!this.isEmptyValue(emptyMandatoryFields)) {
         showNotification({
           type: 'warning',
@@ -285,10 +329,7 @@ export default {
       })
       const attributesToServer = attributes.filter(attributeItem => {
         const { columnName } = attributeItem
-        if (columnName.includes('DisplayColumn_')) {
-          return false
-        }
-        if (columnName === 'C_Location_ID') {
+        if (columnName.includes('DisplayColumn_') || columnName === 'C_Location_ID') {
           return false
         }
         return true
@@ -302,16 +343,16 @@ export default {
 
         // set field parent values
         this.setParentValues(responseLocation.attributes)
-        this.setShowedLocationForm(false)
+        this.isShowedLocationForm = false
 
-        // set context values to parent continer
-        if (this.parentMetadata.isSendParentValues) {
-          this.$store.dispatch('updateValuesOfContainer', {
-            parentUuid: this.parentMetadata.parentUuid,
-            containerUuid: this.parentMetadata.containerUuid,
-            attributes
-          })
-        }
+        // set context values to form continer
+        this.$store.dispatch('updateValuesOfContainer', {
+          parentUuid: this.parentUuid,
+          containerUuid: this.containerUuid,
+          attributes
+        })
+
+        return responseLocation.attributes
       }
 
       if (this.isEmptyValue(locationId) || locationId === 0) {
@@ -319,6 +360,26 @@ export default {
           attributesList: attributesToServer
         })
           .then(updateLocation)
+          .then(responseCreate => {
+            const {
+              parentUuid,
+              containerUuid,
+              columnName // 'C_Location_ID' by default
+            } = this.parentMetadata
+
+            const recordUuid = this.$store.getters.getValueOfField({
+              parentUuid,
+              containerUuid,
+              columnName: 'UUID'
+            })
+
+            this.containerManager.actionPerformed({
+              containerUuid,
+              field: this.parentMetadata,
+              value: responseCreate[columnName],
+              recordUuid
+            })
+          })
           .catch(error => {
             this.$message({
               message: error.message,
@@ -343,10 +404,12 @@ export default {
           })
           console.warn(`Error update Location Address: ${error.message}. Code: ${error.code}.`)
         })
-      this.$store.dispatch('changeSequence', fieldsList)
     },
+    /**
+     * TODO: Manage with vuex module
+     */
     getLocation() {
-      if (this.request > 0) {
+      if (this.isGettingLocation) {
         return
       }
 
@@ -362,6 +425,7 @@ export default {
         return
       }
 
+      this.isGettingLocation = true
       this.getLocationAddress({
         id
       })
@@ -371,10 +435,12 @@ export default {
           this.setValues({
             values
           })
-          this.request++
         })
         .catch(error => {
           console.warn(`Get Location Address, Form Location - Error ${error.code}: ${error.message}.`)
+        })
+        .finally(() => {
+          this.isGettingLocation = false
         })
     }
   }

--- a/src/components/ADempiere/Field/FieldLocation/locationAddressForm.vue
+++ b/src/components/ADempiere/Field/FieldLocation/locationAddressForm.vue
@@ -327,13 +327,36 @@ export default {
       const attributes = this.$store.getters.getValuesView({
         containerUuid: this.containerUuid
       })
-      const attributesToServer = attributes.filter(attributeItem => {
-        const { columnName } = attributeItem
-        if (columnName.includes('DisplayColumn_') || columnName === 'C_Location_ID') {
-          return false
-        }
-        return true
+      const attributesToServer = attributes
+        .filter(attributeItem => {
+          const { columnName } = attributeItem
+          if (columnName.includes('DisplayColumn_') || columnName === 'C_Location_ID') {
+            return false
+          }
+          return true
+        })
+
+      const cityName = this.$store.getters.getValueOfField({
+        containerUuid: this.containerUuid,
+        columnName: 'DisplayColumn_C_City_ID'
       })
+      if (!this.isEmptyValue(cityName)) {
+        attributesToServer.push({
+          columnName: 'City',
+          value: cityName
+        })
+      }
+
+      const regionName = this.$store.getters.getValueOfField({
+        containerUuid: this.containerUuid,
+        columnName: 'DisplayColumn_C_Region_ID'
+      })
+      if (!this.isEmptyValue(cityName)) {
+        attributesToServer.push({
+          columnName: 'RegionName',
+          value: regionName
+        })
+      }
 
       const updateLocation = (responseLocation) => {
         // set form values

--- a/src/components/ADempiere/Field/FieldLocation/locationAddressForm.vue
+++ b/src/components/ADempiere/Field/FieldLocation/locationAddressForm.vue
@@ -305,29 +305,13 @@ export default {
         value: this.getDisplayedValue(values)
       })
     },
-    sendValuesToServer() {
-      const emptyMandatoryFields = this.$store.getters.getFieldsListEmptyMandatory({
-        containerUuid: this.containerUuid,
-        formatReturn: 'name'
-      })
 
-      if (!this.isEmptyValue(emptyMandatoryFields)) {
-        showNotification({
-          type: 'warning',
-          title: this.$t('notifications.emptyValues'),
-          name: '<b>' + emptyMandatoryFields + '.</b> ',
-          message: this.$t('notifications.fieldMandatory'),
-          isRedirect: false
-        })
-        return
-      }
-
-      const locationId = this.locationId
-
-      const attributes = this.$store.getters.getValuesView({
-        containerUuid: this.containerUuid
-      })
-      const attributesToServer = attributes
+    /**
+     * Get attributes list to server
+     * @returns {array} attributesToServer
+     */
+    getAttributesToServer(attributesList) {
+      const attributesToServer = attributesList
         .filter(attributeItem => {
           const { columnName } = attributeItem
           if (columnName.includes('DisplayColumn_') || columnName === 'C_Location_ID') {
@@ -358,6 +342,31 @@ export default {
         })
       }
 
+      return attributesToServer
+    },
+
+    sendValuesToServer() {
+      const emptyMandatoryFields = this.$store.getters.getFieldsListEmptyMandatory({
+        containerUuid: this.containerUuid,
+        formatReturn: 'name'
+      })
+
+      if (!this.isEmptyValue(emptyMandatoryFields)) {
+        showNotification({
+          type: 'warning',
+          title: this.$t('notifications.emptyValues'),
+          name: '<b>' + emptyMandatoryFields + '.</b> ',
+          message: this.$t('notifications.fieldMandatory'),
+          isRedirect: false
+        })
+        return
+      }
+
+      const attributes = this.$store.getters.getValuesView({
+        containerUuid: this.containerUuid
+      })
+      const attributesToServer = this.getAttributesToServer(attributes)
+
       const updateLocation = (responseLocation) => {
         // set form values
         this.setValues({
@@ -378,6 +387,7 @@ export default {
         return responseLocation.attributes
       }
 
+      const locationId = this.locationId
       if (this.isEmptyValue(locationId) || locationId === 0) {
         createLocationAddress({
           attributesList: attributesToServer

--- a/src/components/ADempiere/Field/FieldLocation/mixinLocation.js
+++ b/src/components/ADempiere/Field/FieldLocation/mixinLocation.js
@@ -14,56 +14,148 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { requestGetCountryDefinition } from '@/api/ADempiere/system-core.js'
+// api request methods
 import { getLocationAddress } from '@/api/ADempiere/field/location.js'
+
+// constants
+export const LOCATION_ADDRESS_FORM = 'Location-Address-Form'
+import FieldsList from './fieldsList.js'
+
+// utils and helpers methods
+import { getSequenceAsList } from '@/utils/ADempiere/location'
 
 export default {
   name: 'MixinLocationField',
+
+  props: {
+    containerManager: {
+      type: Object,
+      required: true
+    }
+  },
+
+  data() {
+    return {
+      localValues: {},
+      isGettingLocation: false
+    }
+  },
+
   computed: {
+    countryId() {
+      return this.$store.getters.getValueOfField({
+        containerUuid: LOCATION_ADDRESS_FORM,
+        columnName: 'C_Country_ID'
+      })
+    },
     currentCountryDefinition() {
-      return this.$store.getters.getCountry
+      return this.$store.getters.getStoredCountryFromId({
+        id: this.countryId
+      })
     },
     isShowedLocationForm: {
       get() {
         return this.$store.getters.getIsShowedLocation
       },
-      set() {
-        // empty
+      set(value) {
+        this.$store.commit('setShowedLocation', Boolean(value))
       }
     }
   },
+
   methods: {
     getLocationAddress,
-    requestGetCountryDefinition,
     toggleShowedLocationForm() {
-      this.$store.commit('setShowedLocation', !this.isShowedLocationForm)
-    },
-    setShowedLocationForm(isShow) {
-      this.$store.commit('setShowedLocation', isShow)
+      this.isShowedLocationForm = !this.isShowedLocationForm
     },
     /**
-     * TODO: Add support with sequence to displayed
+     * Displayed sequence location
      * @param {object} entityValues
      */
     getDisplayedValue(entityValues) {
-      let value = ''
+      let displayValue = ''
 
-      if (!this.isEmptyValue(entityValues)) {
-        if (!this.isEmptyValue(entityValues.Address1)) {
-          value = entityValues.Address1
-        }
-        if (!this.isEmptyValue(entityValues.City)) {
-          value += ', ' + entityValues.City
-        }
-        if (!this.isEmptyValue(entityValues.RegionName)) {
-          value += ', ' + entityValues.RegionName
-        }
-        if (!this.isEmptyValue(entityValues.Postal)) {
-          value += ', ' + entityValues.Postal
-        }
+      if (this.isEmptyValue(entityValues)) {
+        return displayValue
       }
 
-      return value
+      let displaySequence = this.$store.getters.getDisplaySequence
+      const country = this.currentCountryDefinition
+      if (!this.isEmptyValue(country)) {
+        displaySequence = country.displaySequence
+      }
+      const locationDisplayedSequence = getSequenceAsList(displaySequence)
+
+      const newFieldsList = FieldsList.map(item => {
+        const { sequenceFields } = item.overwriteDefinition
+        if (locationDisplayedSequence.includes(sequenceFields)) {
+          return {
+            ...item,
+            isDisplayed: true,
+            sequenceFields,
+            index: locationDisplayedSequence.indexOf(sequenceFields)
+          }
+        }
+        return {
+          ...item,
+          sequenceFields,
+          isDisplayed: false
+        }
+      }).filter(field => {
+        return field.isDisplayed
+      }).sort((itemA, itemB) => {
+        return itemA.index - itemB.index
+      })
+
+      const addDisplayValue = (value) => {
+        if (this.isEmptyValue(value)) {
+          value = ''
+        }
+        displayValue = displayValue
+          ? displayValue + ', ' + value
+          : value
+      }
+
+      // displayed value of Address column names
+      Object.keys(entityValues).forEach(columnName => {
+        if (columnName.includes('Address')) {
+          const currrentValue = entityValues[columnName]
+          addDisplayValue(currrentValue)
+        }
+      })
+
+      newFieldsList.forEach(field => {
+        const { columnName } = field
+        const displayColumnName = `DisplayColumn_${columnName}`
+
+        let currrentValue = ''
+        if (!this.isEmptyValue(entityValues[displayColumnName])) {
+          currrentValue = entityValues[displayColumnName]
+        }
+
+        if (this.isEmptyValue(currrentValue)) {
+          if (columnName === 'C_City_ID') {
+            currrentValue = entityValues['City']
+          }
+          if (columnName === 'C_Region_ID') {
+            currrentValue = entityValues['RegionName']
+          }
+
+          if (this.isEmptyValue(currrentValue)) {
+            currrentValue = this.$store.getters.getValueOfField({
+              containerUuid: LOCATION_ADDRESS_FORM,
+              columnName: displayColumnName
+            })
+          }
+        }
+        if (this.isEmptyValue(currrentValue)) {
+          currrentValue = entityValues[columnName]
+        }
+
+        addDisplayValue(currrentValue)
+      })
+
+      return displayValue
     }
   }
 }

--- a/src/components/ADempiere/Field/FieldLocation/mixinLocation.js
+++ b/src/components/ADempiere/Field/FieldLocation/mixinLocation.js
@@ -111,9 +111,11 @@ export default {
         if (this.isEmptyValue(value)) {
           value = ''
         }
-        displayValue = displayValue
-          ? displayValue + ', ' + value
-          : value
+        if (!this.isEmptyValue(displayValue)) {
+          displayValue += ', ' + value
+        } else {
+          displayValue = value
+        }
       }
 
       // displayed value of Address column names

--- a/src/components/ADempiere/Field/FieldOptions/LabelField.vue
+++ b/src/components/ADempiere/Field/FieldOptions/LabelField.vue
@@ -6,7 +6,7 @@
 
     <span v-if="isMandatory" :style="'color: #f34b4b'"> * </span>
 
-    <i class="el-icon-info" :style="iconStyle" />
+    <i :class="cssClassName" />
   </div>
 </template>
 
@@ -41,26 +41,44 @@ export default defineComponent({
       return displayStyle + ' margin-left: 3px;'
     })
 
-    const iconStyle = computed(() => {
+    const cssClassName = computed(() => {
+      const iconClass = 'el-icon-info '
       if (isMobile.value) {
-        return 'margin-left: 5px; margin-top: 7px;'
+        return iconClass + 'icon-mobile'
       }
-      return 'margin-left: -5px; padding-bottom: 6px;'
+      return iconClass + 'icon-desktop'
     })
 
     return {
-      iconStyle,
+      cssClassName,
       labelStyle
     }
   }
 })
 </script>
 
+<style lang="scss">
+.el-popover {
+  .el-icon-info.icon-desktop {
+    margin-left: 0px !important;
+  }
+}
+</style>
 <style lang="scss" scoped>
 .label-field {
   .el-icon-info {
     font-size: 11px;
     color: #008fd3;
+
+    &.icon-mobile {
+      margin-left: 5px;
+      margin-top: 7px;
+    }
+
+    &.icon-desktop {
+      margin-left: -5px;
+      padding-bottom: 6px;
+    }
   }
 }
 </style>

--- a/src/components/ADempiere/Field/mixin/mixinField.js
+++ b/src/components/ADempiere/Field/mixin/mixinField.js
@@ -230,7 +230,8 @@ export default {
           if (this.containerManager.getFieldsList) {
             fieldsList = this.containerManager.getFieldsList({
               parentUuid: this.metadata.parentUuid,
-              containerUuid: this.metadata.containerUuid
+              containerUuid: this.metadata.containerUuid,
+              root: this
             })
           }
           this.$store.dispatch('changeDependentFieldsList', {

--- a/src/components/ADempiere/Form/formMixin.js
+++ b/src/components/ADempiere/Form/formMixin.js
@@ -1,6 +1,6 @@
 // ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
 // Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
-// Contributor(s): Edwin Betancourt edwinBetanc0urt@hotmail.com www.erpya.com
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
@@ -14,14 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import Field from '@/components/ADempiere/Field'
+import FieldDefinition from '@/components/ADempiere/Field'
 import { createFieldFromDefinition, createFieldFromDictionary } from '@/utils/ADempiere/lookupFactory'
 
 export default {
   name: 'FormMixn',
   components: {
-    Field,
-    FieldDefinition: Field
+    Field: FieldDefinition, // TODO: deprecated component name, replace with FieldDefinition
+    FieldDefinition
   },
   props: {
     metadata: {
@@ -57,6 +57,11 @@ export default {
   created() {
     this.getPanel()
   },
+
+  beforeDestroy() {
+    this.unsubscribe()
+  },
+
   methods: {
     createFieldFromDefinition,
     createFieldFromDictionary,

--- a/src/lang/ADempiere/en/index.js
+++ b/src/lang/ADempiere/en/index.js
@@ -147,6 +147,7 @@ export default {
     binaryTip: 'Only files with a size smaller than 500kb',
     imageError: 'The image exceeds 2MB and does not comply with the valid formats!',
     contextMenuActions: 'Actions',
+    contextMenuReferences: 'References',
     withOutReferences: 'Without references for record',
     ChangeParameters: 'Change Parameters',
     RunProcessAs: 'Run As',

--- a/src/lang/ADempiere/es/index.js
+++ b/src/lang/ADempiere/es/index.js
@@ -147,6 +147,7 @@ export default {
     binaryTip: 'Solo archivos con un tamaño menor a 500kb',
     imageError: 'La imagen excede los 2MB y no cumple con los formato validos!',
     contextMenuActions: 'Acciones',
+    contextMenuReferences: 'Referencias',
     withOutReferences: 'Sin referencias para el registro',
     contextMenuDownload: 'Descargar',
     contextMennuExport: 'Exportar Smart Browser',

--- a/src/store/modules/ADempiere/field.js
+++ b/src/store/modules/ADempiere/field.js
@@ -1,11 +1,26 @@
+// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// api request methods
 import { requestFieldMetadata } from '@/api/ADempiere/dictionary/window'
 
 const initStateLookup = {
   referenceList: [],
   fieldsList: [],
-  validationRuleList: [],
-  fieldsListLocation: [],
-  isShowedLocation: false
+  validationRuleList: []
 }
 
 const field = {
@@ -22,12 +37,6 @@ const field = {
     },
     resetStateLookup(state) {
       state = initStateLookup
-    },
-    setShowedLocation(state, isShowed) {
-      state.isShowedLocation = isShowed
-    },
-    setFieldsListLocation(state, fieldsListLocation) {
-      state.fieldsListLocation = fieldsListLocation
     }
   },
   actions: {
@@ -68,15 +77,9 @@ const field = {
         .catch(error => {
           console.warn(`Get Field - Error ${error.code}: ${error.message}.`)
         })
-    },
-    changeSequence({ commit }, params) {
-      commit('setFieldsListLocation', params)
     }
   },
   getters: {
-    getIsShowedLocation: (state) => {
-      return state.isShowedLocation
-    },
     getFieldFromUuid: (state) => (uuid) => {
       return state.fieldsList.find(fieldItem => {
         return fieldItem.uuid === uuid
@@ -104,9 +107,6 @@ const field = {
       return state.fieldsList.find(fieldItem => {
         return fieldItem.tableName === tableName && fieldItem.columnName === columnName
       })
-    },
-    getFieldLocation: (state) => {
-      return state.fieldsListLocation
     }
   }
 }

--- a/src/store/modules/ADempiere/fieldValue.js
+++ b/src/store/modules/ADempiere/fieldValue.js
@@ -22,6 +22,7 @@ import {
 } from '@/utils/ADempiere/constants/systemColumns'
 
 // utils and helpers methods
+import { convertObjectToKeyValue } from '@/utils/ADempiere/valueFormat.js'
 import { isEmptyValue, typeValue } from '@/utils/ADempiere/valueUtils.js'
 import { convertStringToBoolean } from '@/utils/ADempiere/formatValue/booleanFormat.js'
 
@@ -88,6 +89,12 @@ const value = {
       attributes = [],
       isOverWriteParent = false
     }) {
+      if (typeValue(attributes) === 'OBJECT') {
+        attributes = convertObjectToKeyValue({
+          object: attributes
+        })
+      }
+
       attributes.forEach(attribute => {
         const { value, columnName } = attribute
 

--- a/src/store/modules/ADempiere/form/locationAddress.js
+++ b/src/store/modules/ADempiere/form/locationAddress.js
@@ -1,0 +1,92 @@
+// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import Vue from 'vue'
+
+// api request methods
+import { requestGetCountryDefinition } from '@/api/ADempiere/system-core.js'
+
+// utils and helpers methods
+import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
+
+const initState = {
+  countries: {},
+  isShowedLocation: false,
+  fieldsListLocation: []
+}
+
+const locationAddress = {
+  state: initState,
+
+  mutations: {
+    setCountryDefinition(state, country) {
+      Vue.set(state.countries, country.id, country)
+    },
+    setShowedLocation(state, isShowed) {
+      state.isShowedLocation = isShowed
+    },
+    setFieldsListLocation(state, fieldsListLocation) {
+      state.fieldsListLocation = fieldsListLocation
+    },
+    resetStateLocation(state) {
+      state = initState
+    }
+  },
+
+  actions: {
+    getCountryDefinition({ commit, getters }, {
+      id,
+      uuid
+    }) {
+      return new Promise(resolve => {
+        const storedCountry = getters.getStoredCountryFromId({ id })
+        if (!isEmptyValue(storedCountry)) {
+          return resolve(storedCountry)
+        }
+
+        requestGetCountryDefinition({
+          id,
+          uuid
+        })
+          .then(responseCountry => {
+            commit('setCountryDefinition', responseCountry)
+
+            resolve(responseCountry)
+          })
+          .catch(error => {
+            console.warn(`Error getting Country Definition: ${error.message}. Code: ${error.code}.`)
+          })
+      })
+    },
+    changeSequence({ commit }, params) {
+      commit('setFieldsListLocation', params)
+    }
+  },
+
+  getters: {
+    getStoredCountryFromId: state => ({ id }) => {
+      return state.countries[id]
+    },
+    getIsShowedLocation: (state) => {
+      return state.isShowedLocation
+    },
+    getFieldLocation: (state) => {
+      return state.fieldsListLocation
+    }
+  }
+}
+
+export default locationAddress

--- a/src/store/modules/ADempiere/lookupManager.js
+++ b/src/store/modules/ADempiere/lookupManager.js
@@ -142,6 +142,8 @@ const lookupManager = {
             }
 
             commit('setLookupItem', {
+              parentUuid, // used by suscription filter
+              containerUuid, // used by suscription filter
               option,
               value, // isNaN(value) ? value : parseInt(value, 10),
               parsedDirectQuery: directQuery,

--- a/src/store/modules/ADempiere/panel/actions.js
+++ b/src/store/modules/ADempiere/panel/actions.js
@@ -30,6 +30,7 @@ const actions = {
       panelType,
       // isParentTab,
       // parentUuid,
+      isSetDefaultValues = true,
       uuid: containerUuid
     } = params
     let keyColumn = ''
@@ -115,7 +116,7 @@ const actions = {
 
     commit('addPanel', params)
 
-    if (!['table'].includes(panelType)) {
+    if (isSetDefaultValues) {
       dispatch('setDefaultValues', {
         parentUuid: params.parentUuid,
         containerUuid,

--- a/src/store/modules/ADempiere/persistence.js
+++ b/src/store/modules/ADempiere/persistence.js
@@ -78,7 +78,9 @@ const persistence = {
           containerUuid,
           formatReturn: false
         }).filter(itemField => {
-          return !LOG_COLUMNS_NAME_LIST.includes(itemField.columnName)
+          // omit send to server (to create or update) columns manage by backend
+          return itemField.isAlwaysUpdateable ||
+            !LOG_COLUMNS_NAME_LIST.includes(itemField.columnName)
         }).map(itemField => {
           return itemField.name
         })
@@ -116,7 +118,8 @@ const persistence = {
         let attributesList = getters.getPersistenceAttributes(containerUuid)
           .filter(itemField => {
             // omit send to server (to create or update) columns manage by backend
-            return !LOG_COLUMNS_NAME_LIST.includes(itemField.columnName)
+            return itemField.isAlwaysUpdateable ||
+              !LOG_COLUMNS_NAME_LIST.includes(itemField.columnName)
           })
 
         if (!isEmptyValue(attributesList)) {

--- a/src/store/modules/ADempiere/system.js
+++ b/src/store/modules/ADempiere/system.js
@@ -16,7 +16,6 @@
 
 // api request methods
 import {
-  requestGetCountryDefinition,
   requestLanguagesList
 } from '@/api/ADempiere/system-core.js'
 
@@ -27,16 +26,12 @@ import { convertDateFormat } from '@/utils/ADempiere/formatValue/dateFormat.js'
 const system = {
   state: {
     systemDefinition: {},
-    country: {},
     languagesList: []
   },
 
   mutations: {
     setSystemDefinition(state, payload) {
       state.systemDefinition = payload
-    },
-    setCountry(state, payload) {
-      state.country = payload
     },
     setLanguagesList: (state, payload) => {
       const languagesList = payload.map(language => {
@@ -52,25 +47,6 @@ const system = {
   },
 
   actions: {
-    getCountryFormServer({ commit }, {
-      id,
-      uuid
-    }) {
-      return new Promise(resolve => {
-        requestGetCountryDefinition({
-          id,
-          uuid
-        })
-          .then(responseCountry => {
-            commit('setCountry', responseCountry)
-
-            resolve(responseCountry)
-          })
-          .catch(error => {
-            console.warn(`Error getting Country Definition: ${error.message}. Code: ${error.code}.`)
-          })
-      })
-    },
     getLanguagesFromServer({ commit, dispatch, rootGetters }) {
       return new Promise(resolve => {
         requestLanguagesList({
@@ -99,9 +75,6 @@ const system = {
   },
 
   getters: {
-    getCountry: (state) => {
-      return state.country
-    },
     getCurrency: (state) => {
       const { currencyIsoCode, standardPrecision } = state.systemDefinition
 
@@ -122,6 +95,9 @@ const system = {
     },
     getCountryLanguage: (state) => {
       return state.systemDefinition.language.replace('_', '-')
+    },
+    getDisplaySequence: (state) => {
+      return state.systemDefinition.displaySequence
     },
     getLanguagesList: (state) => {
       return state.languagesList

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -205,6 +205,13 @@ const actions = {
             root: true
           })
 
+          // get country definition of context session
+          dispatch('getCountryDefinition', {
+            id: sessionInfo.countryId
+          }, {
+            root: true
+          })
+
           dispatch('getRolesListFromServer', sessionUuid)
         })
         .catch(error => {

--- a/src/views/ADempiere/Window/index.vue
+++ b/src/views/ADempiere/Window/index.vue
@@ -121,26 +121,29 @@ export default defineComponent({
         isProcessed,
         isWithRecord
       }) {
-        // evaluate client id context with record
-        const preferenceClientId = root.$store.getters.getPreferenceClientId
-        if (preferenceClientId !== clientId && isWithRecord) {
-          return true
+        if (isWithRecord) {
+          // evaluate client id context with record
+          const preferenceClientId = root.$store.getters.getPreferenceClientId
+          if (preferenceClientId !== clientId) {
+            return true
+          }
+
+          // not updateable and record saved
+          if (!field.isUpdateable) {
+            return true
+          }
+
+          // record is inactive isReadOnlyFromForm
+          if (!isActive && field.columnName !== 'IsActive') {
+            return true
+          }
+          if (isProcessing || isProcessed) {
+            return true
+          }
         }
 
-        // not updateable and record saved
-        if (!field.isUpdateable && isWithRecord) {
-          return true
-        }
-
-        // record is inactive isReadOnlyFromForm
-        if (!isActive && field.columnName !== 'IsActive') {
-          return true
-        }
         if (field.isAlwaysUpdateable) {
           return false
-        }
-        if (isWithRecord && (isProcessing || isProcessed)) {
-          return true
         }
 
         return isReadOnlyField(field) || field.isReadOnlyFromForm


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Login with Garden Admin role.
2. Open Business Partner window.
3. Set tab location.
4. Open Location / Address field.

#### Screenshot or Gif

Before this changes:

https://user-images.githubusercontent.com/20288327/148707844-ed86cb00-5395-4508-ab51-d095c63e4d24.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/148707696-98aaf487-8e5d-41e5-913e-9158c61e49c3.mp4

#### Expected behavior
The location field is expected to load and open the form correctly to create or update the address.

#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
Add any other context about the problem here.
