### PR TITLE
establish the point of sale along the route

### DIFF
--- a/src/store/modules/ADempiere/pointOfSales/point/actions.js
+++ b/src/store/modules/ADempiere/pointOfSales/point/actions.js
@@ -67,19 +67,21 @@ export default {
    */
   listPointOfSalesFromServer({ commit, getters, dispatch }, posToSet = null) {
     const userUuid = getters['user/getUserUuid']
-    let pos, pontOfSalesList
+    let pos, pointOfSalesList
     listPointOfSales({
       userUuid
     })
       .then(response => {
-        pontOfSalesList = response.sellingPointsList
+        pointOfSalesList = response.sellingPointsList
         if (isEmptyValue(pos) && isEmptyValue(posToSet)) {
-          pos = pontOfSalesList.find(itemPOS => itemPOS.salesRepresentative.uuid === userUuid)
+          pos = pointOfSalesList.find(itemPOS => itemPOS.salesRepresentative.uuid === userUuid)
+        } else if (isEmptyValue(pos)) {
+          pos = pointOfSalesList[0]
         }
-        if (isEmptyValue(pos)) {
-          pos = pontOfSalesList[0]
+        if (!isEmptyValue(router.app._route.query.pos)) {
+          pos = response.sellingPointsList.find(point => point.id === parseInt(router.app._route.query.pos))
         }
-        commit('setPointOfSalesList', pontOfSalesList)
+        commit('setPointOfSalesList', pointOfSalesList)
         dispatch('setCurrentPOS', pos)
       })
       .catch(error => {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
establish the point of sale along the route
#### Steps to reproduce

It is entered with the GTienda user (the same password), the order is created from the Advisor terminal and the order is released. Then, the terminal is changed to CASH 01 (USD) and collect is selected, the charge is added and left there until the session is closed due to inactivation. Subsequently, after the inactivation time has elapsed and it is carried out, it is entered again and the advisor terminal with the payment is displayed. The expected result is that when entering, it will be shown in the CAJA 01 (USD) terminal, which is the terminal in which it was left when the session was closed.

#### Screenshot or Gif

![route](https://user-images.githubusercontent.com/45974454/149042791-92d10141-3bf9-4d84-80f4-33d220311171.gif)
