### PR TITLE
fix: Context org not found in org list.

### DIFF
--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -29,7 +29,7 @@ import {
 import { resetRouter } from '@/router'
 import { showMessage } from '@/utils/ADempiere/notification'
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
-import { ORGANIZATION } from '@/utils/ADempiere/constants/systemColumns'
+import { ORGANIZATION, WAREHOUSE } from '@/utils/ADempiere/constants/systemColumns'
 import language from '@/lang'
 
 const state = {
@@ -74,8 +74,8 @@ const mutations = {
   SET_ORGANIZATIONS_LIST: (state, payload) => {
     state.organizationsList = payload
   },
-  SET_CURRENT_ORGANIZATION_ID: (state, payload) => {
-    state.currentOrganizationId = payload
+  SET_CURRENT_ORGANIZATION_ID: (state, organizationId) => {
+    state.currentOrganizationId = organizationId
   },
   SET_ORGANIZATION: (state, organization) => {
     state.organization = organization
@@ -179,7 +179,7 @@ const actions = {
           commit('SET_ROLE', role)
           setCurrentRole(role.uuid)
           const currentOrganizationSession = sessionInfo.defaultContext.find(context => {
-            if (context.key === '#' + ORGANIZATION) {
+            if (context.key === `#${ORGANIZATION}`) {
               return context
             }
           })
@@ -429,7 +429,7 @@ const actions = {
         commit('SET_ORGANIZATION', organization)
         commit('SET_CURRENT_ORGANIZATION_ID', organization.id)
         commit('setPreferenceContext', {
-          columnName: '#' + ORGANIZATION,
+          columnName: `#${ORGANIZATION}`,
           value: organization.id
         }, {
           root: true
@@ -483,7 +483,7 @@ const actions = {
           setCurrentWarehouse(warehouse.uuid)
           commit('SET_WAREHOUSE', warehouse)
           commit('setPreferenceContext', {
-            columnName: '#M_Warehouse_ID',
+            columnName: `#${WAREHOUSE}`,
             value: warehouse.id
           }, {
             root: true
@@ -504,7 +504,7 @@ const actions = {
     commit('SET_WAREHOUSE', currentWarehouse)
 
     commit('setPreferenceContext', {
-      columnName: '#M_Warehouse_ID',
+      columnName: `#${WAREHOUSE}`,
       value: currentWarehouse.id
     }, {
       root: true
@@ -569,8 +569,8 @@ const actions = {
 }
 
 const getters = {
-  getRoles: (state) => {
-    return state.rolesList
+  getIsSession: (state) => {
+    return state.isSession
   },
   getOrganizations: (state) => {
     return state.organizationsList
@@ -581,18 +581,19 @@ const getters = {
   getCurrentOrgId: (state) => {
     return state.currentOrganizationId
   },
-  getWarehouses: (state) => {
-    return state.warehousesList
+  getRoles: (state) => {
+    return state.rolesList
   },
   // current role info
   getRole: (state) => {
     return state.role
   },
+  getWarehouses: (state) => {
+    return state.warehousesList
+  },
+  // TODO: Manage with vuex module to warehouse
   getWarehouse: (state) => {
     return state.warehouse
-  },
-  getIsSession: (state) => {
-    return state.isSession
   },
   getUserUuid: (state) => {
     return state.userUuid
@@ -600,6 +601,7 @@ const getters = {
   userInfo: (state) => {
     return state.userInfo
   },
+  // TODO: Manage with vuex module to personal lock
   getIsPersonalLock: (state) => {
     return state.role.isPersonalLock
   }

--- a/src/utils/ADempiere/constants/systemColumns.js
+++ b/src/utils/ADempiere/constants/systemColumns.js
@@ -24,6 +24,8 @@ export const PROCESSING = 'Processing'
 
 export const PROCESSED = 'Processed'
 
+export const WAREHOUSE = 'M_Warehouse_ID'
+
 /**
  * Log columns list into table
  * Manages with user session


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Login with Garden Admin role.
2. Change to Garden User role.

#### Screenshot or Gif
Before this changes:

https://user-images.githubusercontent.com/20288327/144909063-a155f895-08f0-4a94-bf45-c63dd809b399.mp4


After this changes:

https://user-images.githubusercontent.com/20288327/144909431-37c79b7e-ee61-4ac9-9d65-0dc943fd2408.mp4

#### Expected behavior
It is expected to establish an organization.

#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context

The id of the organization of the session context (`#AD_Org_ID`) is 0, but the list of organizations has none with id 0.
- 11 - HQ
- 12 - Store Central
- 50000 - Furniture
- 50001 - Fertilizer
- 50007 - Stores

https://github.com/adempiere/adempiere-gRPC-Server/issues/31