### PR TITLE
Wrong symbol in Cash Withdrawal and Cash Opening

### DIFF
--- a/src/components/ADempiere/Field/FieldNumber.vue
+++ b/src/components/ADempiere/Field/FieldNumber.vue
@@ -148,8 +148,8 @@ export default {
     currencyCode() {
       const currencyIsoCode = this.$store.getters.getCurrencyCode
       if (!this.isEmptyValue(this.metadata.labelCurrency)) {
-        if (this.metadata.labelCurrency.iSOCode !== currencyIsoCode) {
-          return this.metadata.labelCurrency.iSOCode
+        if (this.metadata.labelCurrency !== currencyIsoCode) {
+          return this.metadata.labelCurrency
         }
       }
       return currencyIsoCode

--- a/src/components/ADempiere/Form/VPOS/Collection/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Collection/index.vue
@@ -50,7 +50,7 @@
                     <field-definition
                       :metadata-field="field.columnName === 'PayAmt' ? {
                         ...field,
-                        labelCurrency: isEmptyValue(dayRate.divideRate) ? dayRate : dayRate.currencyTo
+                        labelCurrency: currentFieldCurrency
                       } : field"
                       :container-uuid="'Collection'"
                       :container-manager="containerManager"

--- a/src/components/ADempiere/Form/VPOS/Options/CashOpening/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Options/CashOpening/index.vue
@@ -33,7 +33,10 @@
                 :span="8"
               >
                 <field-definition
-                  :metadata-field="fieldsList[0]"
+                  :metadata-field="{
+                    ...fieldsList[0],
+                    labelCurrency: currentFieldCurrency
+                  } "
                   :container-uuid="'Cash-Opening'"
                   :container-manager="containerManager"
                 />

--- a/src/components/ADempiere/Form/VPOS/Options/Cashwithdrawal/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Options/Cashwithdrawal/index.vue
@@ -33,7 +33,10 @@
                 :span="8"
               >
                 <field-definition
-                  :metadata-field="fieldsList[0]"
+                  :metadata-field="{
+                    ...fieldsList[0],
+                    labelCurrency: currentFieldCurrency
+                  } "
                   :container-uuid="'Cash-Withdrawal'"
                   :container-manager="containerManager"
                 />


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
In the Payment Total field, it shows "Bs" despite changing the payment method and currency

#### Screenshot or Gif

![epale](https://user-images.githubusercontent.com/45974454/151469523-b0a208a4-d98d-4a61-8002-e0d51bc17d3a.gif)

#### Other relevant information
- Your OS: Debian 10
- Web Browser: Opera
- Node.js version: 14.2.0
