### PR TITLE
fix: Set correct boolean value.

### DIFF
--- a/src/store/modules/ADempiere/dictionary/window/actions.js
+++ b/src/store/modules/ADempiere/dictionary/window/actions.js
@@ -179,6 +179,19 @@ export default {
         }, {
           root: true
         })
+
+        if (!attribute.columnName.includes('DisplayColumn')) {
+          const field = rootGetters.getStoredFieldFromTab({
+            windowUuid: parentUuid,
+            tabUuid: containerUuid,
+            columnName: attribute.columnName
+          })
+          // activate logics
+          dispatch('changeDependentFieldsList', {
+            field,
+            fieldsList: tab.fieldsList
+          })
+        }
       })
 
       dispatch('updateValuesOfContainer', {

--- a/src/store/modules/ADempiere/dictionary/window/getters.js
+++ b/src/store/modules/ADempiere/dictionary/window/getters.js
@@ -70,7 +70,7 @@ export default {
 
   getStoredFieldFromTab: (state, getters) => ({ windowUuid, tabUuid, columnName, fieldUuid }) => {
     return getters.getStoredFieldsFromTab(windowUuid, tabUuid)
-      .map(field => {
+      .find(field => {
         return field.columnName === columnName || field.uuid === fieldUuid
       })
   },

--- a/src/store/modules/ADempiere/panel/getters.js
+++ b/src/store/modules/ADempiere/panel/getters.js
@@ -19,7 +19,6 @@ import {
   parsedValueComponent
 } from '@/utils/ADempiere/valueUtils.js'
 import {
-  ACCOUNTING_COLUMNS,
   LOG_COLUMNS_NAME_LIST
 } from '@/utils/ADempiere/constants/systemColumns'
 import {
@@ -290,39 +289,26 @@ const getters = {
     let attributesList = fieldsList
       .map(fieldItem => {
         const { columnName, defaultValue } = fieldItem
-        let isSQL = false
-        let parsedDefaultValue = fieldItem.parsedDefaultValue
-        const isSpeciaColumn = ACCOUNTING_COLUMNS.includes(columnName) || ACCOUNTING_COLUMNS.includes(fieldItem.elementName)
+        const isSQL = String(defaultValue).includes('@SQL=') && isGetServer
 
-        if (String(defaultValue).includes('@') || isSpeciaColumn) {
-          parsedDefaultValue = getDefaultValue({
-            ...fieldItem,
-            parentUuid,
-            isSOTrxMenu
-          })
-          if (String(defaultValue).includes('@SQL=') && isGetServer) {
-            isSQL = true
-          }
-        }
+        const parsedDefaultValue = getDefaultValue({
+          ...fieldItem,
+          parentUuid,
+          isSOTrxMenu
+        })
         attributesObject[columnName] = parsedDefaultValue
 
         if (fieldItem.isRange && fieldItem.componentPath !== 'FieldNumber') {
           const { columnNameTo, elementNameTo, defaultValueTo } = fieldItem
-          let parsedDefaultValueTo = fieldItem.parsedDefaultValueTo
-          let isSQLTo = false
-          if (String(defaultValueTo).includes('@') || isSpeciaColumn) {
-            if (String(defaultValueTo).includes('@SQL=') && isGetServer) {
-              isSQLTo = true
-            }
+          const isSQLTo = String(defaultValueTo).includes('@SQL=') && isGetServer
 
-            parsedDefaultValueTo = getDefaultValue({
-              ...fieldItem,
-              parentUuid,
-              isSOTrxMenu,
-              columnName: columnNameTo,
-              elementName: elementNameTo
-            })
-          }
+          const parsedDefaultValueTo = getDefaultValue({
+            ...fieldItem,
+            parentUuid,
+            isSOTrxMenu,
+            columnName: columnNameTo,
+            elementName: elementNameTo
+          })
 
           attributesObject[columnNameTo] = parsedDefaultValueTo
           attributesRangue.push({

--- a/src/utils/ADempiere/contextUtils.js
+++ b/src/utils/ADempiere/contextUtils.js
@@ -26,7 +26,14 @@ import evaluator from '@/utils/ADempiere/evaluator'
 
 export default evaluator
 
-// get context state from vuex store
+/**
+ * Get context state from vuex store
+ * @param {string} parentUuid UUID Window
+ * @param {string} containerUuid  UUID Tab, Process, SmartBrowser, Report and Form
+ * @param {boolean} isBooleanToString if convert true to 'Y'
+ * @param {string} columnName (context)  Entity to search
+ * @returns
+ */
 export const getContext = ({
   parentUuid,
   containerUuid,
@@ -37,14 +44,16 @@ export const getContext = ({
   const isPreferenceValue = columnName.startsWith('$') ||
     columnName.startsWith('#') ||
     columnName.startsWith(`P|`)
+
+  // get value to session context
   if (isPreferenceValue) {
     value = store.getters.getPreference({
       parentUuid,
       containerUuid,
       columnName
     })
-  }
-  if (!isPreferenceValue && isEmptyValue(value)) {
+  } else {
+    // get value to container view
     value = store.getters.getValueOfField({
       parentUuid,
       containerUuid,
@@ -88,8 +97,8 @@ export function getPreference({
   // View Preferences
   if (parentUuid) {
     value = getContext({
-      parentUuid: 'P' + parentUuid,
-      containerUuid,
+      parentUuid: 'P|' + parentUuid,
+      containerUuid: 'P|' + containerUuid,
       columnName
     })
     if (!isEmptyValue(value)) {

--- a/src/utils/ADempiere/valueUtils.js
+++ b/src/utils/ADempiere/valueUtils.js
@@ -425,6 +425,27 @@ export function parsedValueComponent({
 }
 
 /**
+ * Returns matching elements of arrays
+ * @param {array} arrayA
+ * @param {array} arrayB
+ * @returns {array}
+ */
+export function arrayMatches(arrayA = [], arrayB = []) {
+  const matches = []
+
+  if (isEmptyValue(arrayA) || isEmptyValue(arrayB)) {
+    return matches
+  }
+  arrayA.forEach(elementA => {
+    if (arrayB.includes(elementA)) {
+      matches.push(elementA)
+    }
+  })
+
+  return matches
+}
+
+/**
  * Payment method icon element-ui supported
  * @author Elsio Sanchez <elsiosanches@gmail.com>
  * @param {string} paymentMethod, value the payment


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Business Partner` window.
2. Set `New Record` action.
3. Fill in the `Name` field.

Note the `Prospect` mandatory field, which is of type Yes/No indicates that it is empty.

#### Screenshot or Gif

Before this changes:

https://user-images.githubusercontent.com/20288327/151686919-1afda2c5-adc0-4a4a-b996-82a739d83c9e.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/151686926-dbb88d18-dd99-45bc-a513-c5452269a596.mp4


#### Expected behavior
If the type field has no default value, do not take it as empty but as false (except for the case of IsActive columns).

#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
related https://github.com/adempiere/adempiere-vue/issues/1490
