### PR TITLE
fix: #1474 Disabled tabs when create record.

### DIFF
--- a/src/views/ADempiere/Window/MultiTabWindow.vue
+++ b/src/views/ADempiere/Window/MultiTabWindow.vue
@@ -45,9 +45,9 @@
 <script>
 import { defineComponent, computed, ref } from '@vue/composition-api'
 
-// components
+// components and mixins
 import ActionMenu from '@/components/ADempiere/ActionMenu/index.vue'
-import TabManager from '@/components/ADempiere/TabManager'
+import TabManager from '@/components/ADempiere/TabManager/index.vue'
 
 // utils and helpers methods
 import { convertObjectToKeyValue } from '@/utils/ADempiere/valueFormat.js'
@@ -99,6 +99,17 @@ export default defineComponent({
                 }
               }, () => {})
             }
+
+            const { parentUuid, containerUuid } = field
+            const tab = root.$store.getters.getStoredTab(parentUuid, containerUuid)
+
+            // set response values
+            root.$store.dispatch('updateValuesOfContainer', {
+              parentUuid,
+              containerUuid,
+              isOverWriteParent: tab.isParentTab,
+              attributes: response.attributes
+            })
           })
       },
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Business Partner` window.
2. Select `New Record` action.
3. Fill fields to create record

#### Screenshot or Gif

https://user-images.githubusercontent.com/20288327/151713365-23610ea9-f81f-4343-b850-d2d660f44c6a.mp4


#### Expected behavior
If you create a new record you must block all other tabs except the first one, but once the record is created you must enable all other tabs.

#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
fixes #1474 