### PR TITLE
fix: Edit record in child tab.

### DIFF
--- a/src/store/modules/ADempiere/fieldValue.js
+++ b/src/store/modules/ADempiere/fieldValue.js
@@ -18,15 +18,13 @@ import Vue from 'vue'
 
 // constants
 import {
-  ACTIVE, PROCESSING, PROCESSED
+  ACTIVE, PROCESSING, PROCESSED, UUID
 } from '@/utils/ADempiere/constants/systemColumns'
 
 // utils and helpers methods
 import { convertObjectToKeyValue } from '@/utils/ADempiere/valueFormat.js'
 import { isEmptyValue, typeValue } from '@/utils/ADempiere/valueUtils.js'
 import { convertStringToBoolean } from '@/utils/ADempiere/formatValue/booleanFormat.js'
-
-const UUID_KEY = 'UUID'
 
 const value = {
   state: {
@@ -257,8 +255,9 @@ const value = {
     },
 
     getUuidOfContainer: (state) => (containerUuid) => {
-      return state.field[containerUuid + '_' + UUID_KEY]
+      return state.field[`${containerUuid}_${UUID}`]
     },
+
     // Using to read only in data tables in Window
     getContainerIsActive: (state) => (parentUuid) => {
       const valueIsActive = state.field[`${parentUuid}_${ACTIVE}`]

--- a/src/store/modules/ADempiere/persistence.js
+++ b/src/store/modules/ADempiere/persistence.js
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import router from '@/router'
 import language from '@/lang'
 
 // constants
@@ -92,10 +91,10 @@ const persistence = {
           })
           return
         }
-        const route = router.app._route
-        recordUuid = route.query.action === 'create-new'
-          ? getters.getUuidOfContainer(field.containerUuid)
-          : route.query.action
+
+        if (isEmptyValue(recordUuid) || recordUuid === 'create-new') {
+          recordUuid = getters.getUuidOfContainer(field.containerUuid)
+        }
 
         dispatch('flushPersistenceQueue', {
           containerUuid,

--- a/src/store/modules/ADempiere/windowManager.js
+++ b/src/store/modules/ADempiere/windowManager.js
@@ -22,7 +22,6 @@ import {
   getEntities
 } from '@/api/ADempiere/user-interface/persistence.js'
 import {
-  createEntity,
   deleteEntity
 } from '@/api/ADempiere/common/persistence.js'
 
@@ -79,24 +78,6 @@ const windowManager = {
   },
 
   actions: {
-    createEntity({
-      rootGetters
-    }, {
-      parentUuid,
-      containerUuid
-    }) {
-      return new Promise(resolve => {
-        const tab = rootGetters.getStoredTab(parentUuid, containerUuid)
-
-        createEntity({
-          tableName: tab.tableName
-        })
-          .then(createResponse => {
-            resolve(createResponse)
-          })
-      })
-    },
-
     /**
      * Get list entities
      * @param {string} parentUuid

--- a/src/utils/ADempiere/constants/systemColumns.js
+++ b/src/utils/ADempiere/constants/systemColumns.js
@@ -24,6 +24,8 @@ export const PROCESSING = 'Processing'
 
 export const PROCESSED = 'Processed'
 
+export const UUID = 'UUID'
+
 /**
  * Log columns list into table
  * Manages with user session
@@ -44,7 +46,7 @@ export const STANDARD_COLUMNS_NAME_LIST = [
   CLIENT,
   ORGANIZATION,
   ACTIVE,
-  'UUID'
+  UUID
 ]
 
 /**


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce
1. Open `Business Partner` window.
2. Select tab child `Bank Account`.
3. Edit record.

#### Screenshot or Gif

https://user-images.githubusercontent.com/20288327/151907537-2ea9e7d3-ae40-4c4f-a981-302bb0258d4f.mp4

#### Expected behavior
It is expected that when editing a record the attributes of the entity will be returned.

#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
Related on https://github.com/adempiere/adempiere-vue/issues/1494
