### PR TITLE
Fixe Quick search "To be delivered"

### DIFF
--- a/src/components/ADempiere/Form/VPOS/OrderList/fastOrder.vue
+++ b/src/components/ADempiere/Form/VPOS/OrderList/fastOrder.vue
@@ -227,6 +227,7 @@ export default {
           title: this.$t('form.byInvoice.toDeliver'),
           params: {
             isOnlyProcessed: true,
+            isOnlyAisleSeller: true,
             isWaitingForShipment: true
           },
           isVisible: false,


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
The search returns nothing since isOnlyAisleSeller was not being sent.
#### Steps to reproduce

1. Go to 'Point of Sale'
2. Click on 'To Deliver'
3. Look at the error (does not show orders)

#### Screenshot or Gif

![image](https://user-images.githubusercontent.com/45974454/152217314-103406e0-467a-4fd1-aefe-623a11dfbdb7.png)

#### Other relevant information
- Your OS: Debian 10
- Web Browser:  Chrome
- Node.js version: v14.18.0
- Yarn version: 1.22.17

#### Issues
#1504 