### PR TITLE
Fixe Price Consultant

### DIFF
--- a/src/components/ADempiere/Field/FieldOptions/index.vue
+++ b/src/components/ADempiere/Field/FieldOptions/index.vue
@@ -222,7 +222,6 @@ export default defineComponent({
       if (typeValue(window) === 'ARRAY') {
         window = window[0]
       }
-
       let value = valueField.value
       let columnName = props.metadata.columnName
       // TODO: Evaluate reference.keyColumnName

--- a/src/components/ADempiere/Form/PriceChecking/index.vue
+++ b/src/components/ADempiere/Form/PriceChecking/index.vue
@@ -19,18 +19,18 @@
 <template>
   <div
     v-if="isLoaded"
-    style="height: 100% !important;"
+    style="height: 100% !important;display: -webkit-box;"
     @click="focusProductValue"
   >
 
     <img
       fit="contain"
-      :src="backgroundForm"
+      :src="defaultImage"
       class="background-price-checking"
-      style="z-index: 5;"
+      style="z-index: 5;display: flex;"
     >
     <el-container style="height: 100% !important;">
-      <el-main>
+      <el-main style="display: contents">
         <el-form
           key="form-loaded"
           class="inquiry-form"
@@ -142,6 +142,18 @@ export default {
     parentUuid: {
       type: String,
       default: undefined
+    },
+    containerManager: {
+      type: Object,
+      default: () => ({
+        actionPerformed: () => {},
+        changeFieldShowedFromUser: () => {},
+        getFieldsLit: () => {},
+        isDisplayedField: () => { return true },
+        isMandatoryField: () => { return true },
+        isReadOnlyField: () => { return false },
+        setDefaultValues: () => {}
+      })
     }
   },
 
@@ -204,6 +216,14 @@ export default {
     }
   },
 
+  beforeMount() {
+    this.unsubscribe = this.subscribeChanges()
+  },
+
+  beforeDestroy() {
+    this.unsubscribe()
+  },
+
   mounted() {
     this.backgroundForm = this.defaultImage
     this.getImageFromSource(this.organizationImagePath)
@@ -245,9 +265,11 @@ export default {
     },
     subscribeChanges() {
       return this.$store.subscribe((mutation, state) => {
+        console.log({ mutation, state })
         if ((mutation.type === 'currentPointOfSales') || (mutation.type === 'setListProductPrice') || (mutation.type === 'addFocusLost')) {
           this.focusProductValue()
         }
+        console.log(mutation.type, mutation.payload.columnName, 'ProductValue', this.productPrice.upc, mutation.payload.value)
         if ((mutation.type === 'addActionKeyPerformed') && mutation.payload.columnName === 'ProductValue' && (this.productPrice.upc !== mutation.payload.value)) {
           // cleans all values except column name 'ProductValue'
           this.search = mutation.payload.value

--- a/src/components/ADempiere/Form/PriceChecking/index.vue
+++ b/src/components/ADempiere/Form/PriceChecking/index.vue
@@ -196,7 +196,6 @@ export default {
         }
       })
       if (convert) {
-        console.log(convert)
         return convert
       }
       return {}
@@ -265,11 +264,9 @@ export default {
     },
     subscribeChanges() {
       return this.$store.subscribe((mutation, state) => {
-        console.log({ mutation, state })
         if ((mutation.type === 'currentPointOfSales') || (mutation.type === 'setListProductPrice') || (mutation.type === 'addFocusLost')) {
           this.focusProductValue()
         }
-        console.log(mutation.type, mutation.payload.columnName, 'ProductValue', this.productPrice.upc, mutation.payload.value)
         if ((mutation.type === 'addActionKeyPerformed') && mutation.payload.columnName === 'ProductValue' && (this.productPrice.upc !== mutation.payload.value)) {
           // cleans all values except column name 'ProductValue'
           this.search = mutation.payload.value

--- a/src/components/ADempiere/Form/ProductInfo/productList.vue
+++ b/src/components/ADempiere/Form/ProductInfo/productList.vue
@@ -82,7 +82,6 @@
       <el-table-column
         :label="$t('form.productInfo.quantityAvailable')"
         align="right"
-        width="100"
       >
         <template slot-scope="scope">
           {{ formatQuantity(scope.row.quantityAvailable) }}
@@ -99,7 +98,6 @@
       <el-table-column
         :label="$t('form.productInfo.taxAmount')"
         align="right"
-        width="200"
       >
         <template slot-scope="scope">
           {{ formatPrice(getTaxAmount(scope.row.priceStandard, scope.row.taxRate.rate), scope.row.currency.iSOCode) }}
@@ -108,7 +106,6 @@
       <el-table-column
         :label="$t('form.productInfo.grandTotal')"
         align="right"
-        width="300"
       >
         <template slot-scope="scope">
           {{ formatPrice(getTaxAmount(scope.row.priceStandard, scope.row.taxRate.rate) + scope.row.priceStandard, scope.row.currency.iSOCode) }}


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
Good afternoon, Opening the Product Query window which, when trying to read a product by barcode, does nothing. It gives the impression that it does not even search for the scanned product
#### Steps to reproduce

1. Open the price viewer
2. scan a product

#### Screenshot or Gif

![error](https://user-images.githubusercontent.com/45974454/152791015-bdb48f66-44ff-4d2b-b7fe-d6b7f07144b3.gif)

#### Link to minimal reproduction

<!--
Please only use Codepen, JSFiddle, CodeSandbox or a github repo
-->

#### Expected behavior
This error was due to the new way of creating the fields. Which this form was not supported

#### Other relevant information
- Your OS: Debian 9
- Web Browser: Chrome
- Node.js version: 14.8.1

#### Issues
#1512
