### PR TITLE
Open the price viewer with a user without an assigned POS terminal

### DIFF
--- a/src/components/ADempiere/Form/PriceChecking/index.vue
+++ b/src/components/ADempiere/Form/PriceChecking/index.vue
@@ -237,7 +237,7 @@ export default {
     formatPrice,
     formatQuantity,
     focusProductValue() {
-      if (!this.isEmptyValue(this.$refs.ProductValue[0])) {
+      if (!this.isEmptyValue(this.$refs.ProductValue[0]) && !this.isEmptyValue(this.$refs.ProductValue[0].$children[0]) && !this.isEmptyValue(this.$refs.ProductValue[0].$children[0].$children[0]) && !this.isEmptyValue(this.$refs.ProductValue[0].$children[0].$children[0].$children[1])) {
         this.$refs.ProductValue[0].$children[0].$children[0].$children[1].$children[0].focus()
       }
     },

--- a/src/lang/ADempiere/en/index.js
+++ b/src/lang/ADempiere/en/index.js
@@ -64,7 +64,8 @@ export default {
     recordLocked: 'This record has been locked',
     recordUnlocked: 'This record has been unlocked',
     noRoleAccess: 'With your current role and settings, you cannot view this information.',
-    errorPointOfSale: 'No point of sale selected'
+    errorPointOfSale: 'No point of sale selected',
+    emptyPos: 'This User has no Assigned POS Terminal'
   },
   navbar: {
     badge: {

--- a/src/lang/ADempiere/es/index.js
+++ b/src/lang/ADempiere/es/index.js
@@ -64,7 +64,8 @@ export default {
     recordLocked: 'Este registro ha sido bloqueado',
     recordUnlocked: 'Este registro ha sido desbloqueado',
     noRoleAccess: 'Con su rol y configuración actuales, no puede ver esta información.',
-    errorPointOfSale: 'Sin punto de venta seleccionado'
+    errorPointOfSale: 'Sin punto de venta seleccionado',
+    emptyPos: 'Este Usuario no tiene Ningún Terminal de PDV Asignado'
   },
   navbar: {
     badge: {

--- a/src/store/modules/ADempiere/pointOfSales/point/actions.js
+++ b/src/store/modules/ADempiere/pointOfSales/point/actions.js
@@ -27,6 +27,7 @@ import {
 } from '@/api/ADempiere/form/point-of-sales.js'
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 import { showMessage } from '@/utils/ADempiere/notification.js'
+import language from '@/lang'
 
 /**
  * Pos Actions
@@ -74,17 +75,25 @@ export default {
     })
       .then(response => {
         pointOfSalesList = response.sellingPointsList
-        if (isEmptyValue(pos) && isEmptyValue(posToSet)) {
+        if (isEmptyValue(pos) && isEmptyValue(posToSet) && !isEmptyValue(pointOfSalesList)) {
           pos = pointOfSalesList.find(itemPOS => itemPOS.salesRepresentative.uuid === userUuid)
         }
-        if (isEmptyValue(pos)) {
+        if (isEmptyValue(pos) && !isEmptyValue(pointOfSalesList)) {
           pos = pointOfSalesList[0]
         }
-        if (!isEmptyValue(router.app._route.query.pos)) {
-          pos = response.sellingPointsList.find(point => point.id === parseInt(router.app._route.query.pos))
+        if (!isEmptyValue(router.app._route.query.pos) && !isEmptyValue(pointOfSalesList)) {
+          pos = pointOfSalesList.find(point => point.id === parseInt(router.app._route.query.pos))
         }
         commit('setPointOfSalesList', pointOfSalesList)
-        dispatch('setCurrentPOS', pos)
+        if (pos) {
+          dispatch('setCurrentPOS', pos)
+        } else {
+          showMessage({
+            type: 'error',
+            message: language.t('notifications.emptyPos'),
+            showClose: true
+          })
+        }
       })
       .catch(error => {
         console.warn(`listPointOfSalesFromServer: ${error.message}. Code: ${error.code}.`)


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
Open the price viewer with a user without an assigned POS terminal

#### Screenshot or Gif
![error](https://user-images.githubusercontent.com/45974454/152866150-5ad54b4b-7044-4d5a-bdc2-bc4d5ab34b65.gif)


#### Link to minimal reproduction
[Demo-ADempiere-Vue](https://demo-ui.erpya.com/#/login)

#### Issues
#1518

#### Other relevant information
- Your OS: Debian 9
- Web Browser: Chrome
- Node.js version: 14.18.0
- Yarn version: 1.22.17
- adempiere-vue version: 4.4.0

