### PR TITLE
Add isOpenRefund parameters to the process order service

### DIFF
--- a/src/components/ADempiere/Form/VPOS/Collection/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Collection/index.vue
@@ -1086,6 +1086,7 @@ export default {
       processOrder({
         posUuid,
         orderUuid,
+        isOpenRefund: !this.isEmptyValue(this.$store.getters.getListRefundReference),
         createPayments: !this.isEmptyValue(payment),
         payments: payment
       })

--- a/src/components/ADempiere/Form/VPOS/Collection/overdrawnInvoice/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Collection/overdrawnInvoice/index.vue
@@ -1488,6 +1488,7 @@ export default {
       processOrder({
         posUuid,
         orderUuid,
+        isOpenRefund: !this.isEmptyValue(this.$store.getters.getListRefundReference),
         createPayments: !this.isEmptyValue(this.listAllPayments),
         payments: this.listAllPayments
       })

--- a/src/components/ADempiere/Form/VPOS/Options/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Options/index.vue
@@ -817,6 +817,7 @@ export default {
       processOrder({
         posUuid,
         orderUuid,
+        isOpenRefund: !this.isEmptyValue(this.$store.getters.getListRefundReference),
         createPayments: false,
         payments: []
       })

--- a/src/components/ADempiere/Form/VPOS/posMixin.js
+++ b/src/components/ADempiere/Form/VPOS/posMixin.js
@@ -379,7 +379,7 @@ export default {
       processOrder({
         posUuid,
         orderUuid,
-        isOpenRefund: true,
+        isOpenRefund: !this.isEmptyValue(this.$store.getters.getListRefundReference),
         createPayments: !this.isEmptyValue(payments),
         payments: payments
       })


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
Add `isOpenRefund` parameters to the process order service
#### Other relevant information
- Your OS: Debian 9
- Web Browser:Chrome 
- Node.js version:14.18.0
- Yarn version: 11.2.0
- adempiere-vue version:  4.4.0

#### Additional context
Add any other context about the problem here.
