### PR TITLE
Add image to assign seller window

### DIFF
--- a/src/components/ADempiere/Form/VPOS/BusinessPartner/addAddress.vue
+++ b/src/components/ADempiere/Form/VPOS/BusinessPartner/addAddress.vue
@@ -416,7 +416,8 @@ export default {
       }
       const newAddress = { uuid: customer.uuid, value: customer.value, taxId: customer.taxId, name: customer.name, addresses, posUuid: this.$store.getters.posAttributes.currentPointOfSales.uuid }
       newAddress.uuid = this.isEmptyValue(customer.uuid) ? this.$store.getters.getValueOfField({ containerUuid: this.$route.meta.uuid, columnName: 'C_BPartner_ID_UUID' }) : customer.uuid
-      newAddress.value = this.isEmptyValue(customer.value) ? this.addressToUpdate.value : customer.value
+      newAddress.value = this.isEmptyValue(this.$store.getters.getNewCustomer.value) ? this.addressToUpdate.value : this.$store.getters.getNewCustomer.value
+      newAddress.name = this.$store.getters.getNewCustomer.name
       updateCustomer(newAddress)
         .then(response => {
           const orderUuid = this.$store.getters.posAttributes.currentPointOfSales.currentOrder.uuid

--- a/src/components/ADempiere/Form/VPOS/BusinessPartner/fieldsListSearch.js
+++ b/src/components/ADempiere/Form/VPOS/BusinessPartner/fieldsListSearch.js
@@ -23,6 +23,7 @@ export default [
     overwriteDefinition: {
       sequence: 0,
       size: 6,
+      componentPath: 'FieldText',
       isCustomField: true
     }
   },
@@ -33,6 +34,7 @@ export default [
     isFromDictionary: true,
     overwriteDefinition: {
       sequence: 1,
+      componentPath: 'FieldText',
       size: 6,
       isCustomField: true
     }

--- a/src/components/ADempiere/Form/VPOS/Collection/overdrawnInvoice/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Collection/overdrawnInvoice/index.vue
@@ -717,7 +717,7 @@ export default {
       const clear = false
       this.clearAccountData(clear)
       this.currentFieldPaymentMethods = this.isEmptyValue(this.searchPaymentMethods) ? '' : this.searchPaymentMethods[0].uuid
-      if (this.isEmptyValue(value) && this.showDialogo) {
+      if (this.isEmptyValue(value) && this.showDialogo && !this.isEmptyValue(this.selectionTypeRefund.refund_reference_currency)) {
         this.findRefundCurrencyConversion(this.selectionTypeRefund.refund_reference_currency)
       }
     },
@@ -993,7 +993,7 @@ export default {
       const fieldBank = this.fieldsList.find(fields => fields.columnName === 'C_Bank_ID')
       let listBank
       if (!this.isEmptyValue(fieldBank) && fieldBank.reference) {
-        listBank = this.$store.getters.getLookupList({
+        listBank = this.$store.getters.getStoredLookupList({
           containerUuid: this.metadata.containerUuid,
           query: fieldBank.reference.query,
           tableName: fieldBank.reference.tableName
@@ -1088,7 +1088,7 @@ export default {
           },
           {
             columnName: 'C_Bank_ID',
-            value: value.bank.id
+            value: value.bank.value
           },
           {
             columnName: 'C_Bank_ID_UUID',

--- a/src/components/ADempiere/Form/VPOS/Options/AssignSeller/index.vue
+++ b/src/components/ADempiere/Form/VPOS/Options/AssignSeller/index.vue
@@ -21,7 +21,7 @@
       <el-card class="box-card" style="padding-left: 0px;padding-right: 0px;">
         <el-scrollbar wrap-class="scroll-seller">
           <el-row style="padding: 2px">
-            <template v-for="(seller, key) in listSeller">
+            <template v-for="(seller, key) in listSellers">
               <el-col :key="key" :span="8">
                 <el-card
                   :shadow="seller.uuid === salesRepresentative.uuid ? 'always' : 'never'"
@@ -34,7 +34,7 @@
                         shape="circle"
                         :size="100"
                         fit="fill"
-                        :src="avatarResize(seller.image)"
+                        :src="seller.image"
                       />
                     </div>
                     <div class="footer-product">
@@ -141,6 +141,17 @@ export default {
     },
     showAssignSeller() {
       return this.isEmptyValue(this.$store.getters.getShowAssignSeller) ? false : this.$store.getters.getShowAssignSeller
+    },
+    listSellers() {
+      if (!this.isEmptyValue(this.listSeller)) {
+        return this.listSeller.map(seller => {
+          return {
+            ...seller,
+            image: this.avatarResize(seller.image)
+          }
+        })
+      }
+      return []
     }
   },
   watch: {
@@ -161,8 +172,8 @@ export default {
 
       const { uri } = getImagePath({
         file: image,
-        width: 40,
-        height: 40
+        width: 500,
+        height: 500
       })
 
       return uri


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
Add image to assign seller window
#### Steps to reproduce

1. Open the point of sale
2. Open the left panel ---> Cash Management ---> Assign Vendor

#### Screenshot or Gif

![error](https://user-images.githubusercontent.com/45974454/153222361-f5722d23-5d6e-49a5-8d00-f23f3046c081.gif)

#### Other relevant information
- Your OS: Debian 9
- Web Browser: Chrome
- Node.js version: 14.18.0
- Yarn version: 1.22.0
- adempiere-vue version: 4.4.0

#### Issues
#1534