### PR TITLE
fix: #1516 Set warehouse value.

### DIFF
--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -29,7 +29,7 @@ import {
 import { resetRouter } from '@/router'
 import { showMessage } from '@/utils/ADempiere/notification'
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
-import { ORGANIZATION } from '@/utils/ADempiere/constants/systemColumns'
+import { ORGANIZATION, WAREHOUSE } from '@/utils/ADempiere/constants/systemColumns'
 import language from '@/lang'
 
 const state = {
@@ -483,7 +483,7 @@ const actions = {
           setCurrentWarehouse(warehouse.uuid)
           commit('SET_WAREHOUSE', warehouse)
           commit('setPreferenceContext', {
-            columnName: '#' + ORGANIZATION,
+            columnName: `#${WAREHOUSE}`,
             value: warehouse.id
           }, {
             root: true
@@ -504,7 +504,7 @@ const actions = {
     commit('SET_WAREHOUSE', currentWarehouse)
 
     commit('setPreferenceContext', {
-      columnName: '#' + ORGANIZATION,
+      columnName: `#${WAREHOUSE}`,
       value: currentWarehouse.id
     }, {
       root: true

--- a/src/utils/ADempiere/constants/systemColumns.js
+++ b/src/utils/ADempiere/constants/systemColumns.js
@@ -26,6 +26,8 @@ export const PROCESSED = 'Processed'
 
 export const UUID = 'UUID'
 
+export const WAREHOUSE = 'M_Warehouse_ID'
+
 /**
  * Log columns list into table
  * Manages with user session


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature


Greetings, it is correct to set properly in the context the value of the store when it changes.

#### Expected behavior

Currently, when the warehouse is changed, the warehouse value is set in the context using the column name `AD_Org_ID`, instead of `M_Warehouse_ID`.

https://github.com/adempiere/adempiere-vue/blob/develop/src/store/modules/user.js#L486

https://github.com/adempiere/adempiere-vue/blob/develop/src/store/modules/user.js#L507

#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
fixes https://github.com/adempiere/adempiere-vue/issues/1516
