### PR TITLE
fix: Correct previously loaded dependent list.

### DIFF
--- a/src/components/ADempiere/Field/FieldSelect.vue
+++ b/src/components/ADempiere/Field/FieldSelect.vue
@@ -385,7 +385,10 @@ export default {
      */
     getDataLookupList(isShowList) {
       if (isShowList) {
+        // get stored list values
         const list = this.getLookupList
+        // refresh local list component
+        this.optionsList = list
         if (this.isEmptyValue(list) || (list.length === 1 &&
           this.blankValues.includes(list[0].value))) {
           this.remoteMethod()

--- a/src/utils/ADempiere/contextUtils.js
+++ b/src/utils/ADempiere/contextUtils.js
@@ -148,6 +148,13 @@ export function getParentFields({
   reference,
   defaultValue
 }) {
+  const validationCode = []
+  //  Validate reference
+  if (!isEmptyValue(reference) && !isEmptyValue(reference.validationCode)) {
+    validationCode.push(
+      ...evaluator.parseDepends(reference.validationCode)
+    )
+  }
   const parentFields = Array.from(new Set([
     //  For Display logic
     ...evaluator.parseDepends(displayLogic),
@@ -156,12 +163,11 @@ export function getParentFields({
     //  For Read Only Logic
     ...evaluator.parseDepends(readOnlyLogic),
     //  For Default Value
-    ...evaluator.parseDepends(defaultValue)
+    ...evaluator.parseDepends(defaultValue),
+    //  For Validation Code
+    ...validationCode
   ]))
-  //  Validate reference
-  if (!isEmptyValue(reference)) {
-    parentFields.push(...evaluator.parseDepends(reference.validationCode))
-  }
+
   return parentFields
 }
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Login with GardenAdmin role.
2. Open `Invoice (Customer)` window.
3. Select `C&W Construction` in `Business Partner` field.
4. List `Partner Location` field (only list `Stamford`).
5. Change `GardenAdmin BP` in `Business Partner` field.
6. List `Partner Location` field (only list `Near Village`).
7. Select `C&W Construction` in `Business Partner` field.
8. List `Partner Location` field (only list `Near Village`).

#### Screenshot or Gif

https://user-images.githubusercontent.com/20288327/153320551-57fbb330-85aa-4532-aab9-660149d35961.mp4


https://user-images.githubusercontent.com/20288327/153320557-b53ec3fa-eca0-4196-b756-ea93605185da.mp4


#### Expected behavior
As the address list of the `C&W Construction` business partner was previously loaded, it is not refreshing the list showing its corresponding value but the last loaded value of the addresses corresponding to the `GardenAdmin BP` business partner.


#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
Related https://github.com/adempiere/adempiere-vue/issues/1529
