### PR TITLE
feat: Add render report to xml extension file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "vue-split-panel": "^1.0.4",
     "vue-splitpane": "1.0.6",
     "vue-workflow-chart": "^0.4.5",
+    "vue-xml-viewer": "0.1.4",
     "vuedraggable": "2.24.3",
     "vuex": "3.6.2",
     "xlsx": "0.17.2"

--- a/src/components/ADempiere/FileRender/XmlFile/index.vue
+++ b/src/components/ADempiere/FileRender/XmlFile/index.vue
@@ -1,0 +1,102 @@
+<!--
+ ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+ Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+ Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <https:www.gnu.org/licenses/>.
+-->
+
+<template>
+  <div class="container p-5">
+    <download-file
+      :format="format"
+      :name="name"
+      :mime-type="mimeType"
+      :stream="stream"
+    />
+
+    <br>
+    <span style="margin:0 0 10px 20px; color: gray;">
+      {{ xmlComment }}
+    </span>
+
+    <XmlViewer :xml="xmlParsed" style="margin:0 0 10px 20px;" />
+  </div>
+</template>
+
+<script>
+import { defineComponent, computed, ref, onMounted } from '@vue/composition-api'
+
+// components and mixins
+import XmlViewer from 'vue-xml-viewer'
+import DownloadFile from '@/components/ADempiere/FileRender/downloadFile.vue'
+
+export default defineComponent({
+  name: 'XML-File',
+
+  components: {
+    DownloadFile,
+    XmlViewer
+  },
+
+  props: {
+    format: {
+      type: String,
+      required: true
+    },
+    mimeType: {
+      type: String,
+      default: undefined
+    },
+    name: {
+      type: String,
+      default: undefined
+    },
+    stream: {
+      type: [Object, Array],
+      required: true
+    }
+  },
+
+  setup(props, { root }) {
+    const xmlParsed = ref('')
+    const xmlComment = ref('')
+    const htmlCommentPattern = /<\!--.*?-->/g
+
+    const getStoredReportOutput = computed(() => {
+      return root.$store.getters.getReportOutput(root.$route.params.instanceUuid)
+    })
+
+    onMounted(() => {
+      // eslint-disable-next-line new-cap
+      const xmlDocument = new Buffer.from(getStoredReportOutput.value.outputStream_asB64, 'base64')
+      const xmlAsString = xmlDocument.toString()
+
+      xmlComment.value = xmlAsString.match(htmlCommentPattern).toString()
+      xmlParsed.value = xmlAsString.replace(htmlCommentPattern, '')
+    })
+
+    return {
+      xmlParsed,
+      xmlComment
+    }
+  }
+
+})
+</script>
+
+<style lang="scss" scoped>
+.pdf-content {
+  width: 100%;
+  height: 90%;
+  padding-right: 10px;
+}
+</style>

--- a/src/components/ADempiere/FileRender/XmlFile/index.vue
+++ b/src/components/ADempiere/FileRender/XmlFile/index.vue
@@ -15,7 +15,7 @@
 -->
 
 <template>
-  <div class="container p-5">
+  <div class="xml-content">
     <download-file
       :format="format"
       :name="name"
@@ -94,9 +94,9 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-.pdf-content {
+.xml-content {
   width: 100%;
-  height: 90%;
+  height: inherit;
   padding-right: 10px;
 }
 </style>

--- a/src/components/ADempiere/FileRender/downloadFile.vue
+++ b/src/components/ADempiere/FileRender/downloadFile.vue
@@ -136,23 +136,3 @@ export default defineComponent({
 
 })
 </script>
-
-<style lang="scss" scoped>
-.html-content {
-  width: 100%;
-  height: inherit;
-  padding-left: 10px;
-  padding-right: 10px;
-
-  .sub-content-html {
-    min-height: inherit;
-    height: inherit;
-    max-height: -webkit-max-content;
-    max-height: -moz-max-content;
-    max-height: max-content;
-    width: 100%;
-    padding-bottom: 4%;
-  }
-
-}
-</style>

--- a/src/components/ADempiere/FileRender/downloadFile.vue
+++ b/src/components/ADempiere/FileRender/downloadFile.vue
@@ -15,7 +15,6 @@
 -->
 
 <template>
-  <!-- actions or process on container -->
   <el-dropdown
     style="margin:0 0 10px 20px;"
     :hide-on-click="true"

--- a/src/components/ADempiere/FileRender/index.vue
+++ b/src/components/ADempiere/FileRender/index.vue
@@ -45,7 +45,6 @@ export default defineComponent({
       type: [Object, Array, String],
       default: ''
     },
-    // excel file
     name: {
       type: String,
       default: undefined
@@ -76,6 +75,9 @@ export default defineComponent({
         case 'xlsx':
         case 'txt':
           viewer = () => import('@/components/ADempiere/FileRender/ExcelFile')
+          break
+        case 'xml':
+          viewer = () => import('@/components/ADempiere/FileRender/XmlFile')
           break
         default:
           viewer = () => import('@/components/ADempiere/FileRender/EmptyFile')

--- a/src/store/modules/ADempiere/reportManager.js
+++ b/src/store/modules/ADempiere/reportManager.js
@@ -210,7 +210,7 @@ const reportManager = {
                 type: output.mimeType
               })
 
-              // donwloaded not support render report
+              // donwload report file
               link.click()
             }
 

--- a/src/utils/ADempiere/dictionary/report.js
+++ b/src/utils/ADempiere/dictionary/report.js
@@ -24,7 +24,8 @@ export const viewerSupportedFormats = [
   'ssv',
   'txt',
   'xls',
-  'xlsx'
+  'xlsx',
+  'xml'
 ]
 
 export const reportFormatsList = [

--- a/src/views/ADempiere/ReportViewer/index.vue
+++ b/src/views/ADempiere/ReportViewer/index.vue
@@ -19,8 +19,6 @@
 
 <template>
   <div v-if="isLoading" key="report-viewer-loaded" style="min-height: inherit;">
-    <!-- TODO: Add action menu -->
-
     <el-row type="flex" style="min-height: inherit;">
       <el-col :span="24">
         <action-menu

--- a/yarn.lock
+++ b/yarn.lock
@@ -12578,7 +12578,15 @@ vue-workflow-chart@^0.4.5:
   dependencies:
     dagre "^0.8.4"
 
-vue@2.6.14, vue@^2.5.13:
+vue-xml-viewer@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/vue-xml-viewer/-/vue-xml-viewer-0.1.4.tgz#58a5c0b76d3391dc6174a2d730da6f393e25085e"
+  integrity sha512-Vum/s+Jq8r5Dm6k4uk5NUdhWFhgSLjlM2JPGWr5+PNaLS0w7K8WpUPMG82eBT605BQNUzFL5JKBCJrAQo0DhjA==
+  dependencies:
+    core-js "^3.6.5"
+    vue "^2.6.11"
+
+vue@2.6.14, vue@^2.5.13, vue@^2.6.11:
   version "2.6.14"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.14.tgz#e51aa5250250d569a3fbad3a8a5a687d6036e235"
   integrity sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ==


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open any report.
2. Generate as XML extension file.

#### Screenshot or Gif

https://user-images.githubusercontent.com/20288327/154307501-76d621c4-5569-4a38-8e93-67678f0bbc80.mp4

#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
Related issue https://github.com/adempiere/adempiere-vue/issues/1588
