### PR TITLE
fix: Disabled print formats with available options

### DIFF
--- a/src/store/modules/ADempiere/dictionary/report/actions.js
+++ b/src/store/modules/ADempiere/dictionary/report/actions.js
@@ -94,6 +94,8 @@ export default {
     const actionsList = []
     actionsList.push(runReport)
 
+    // destruct to avoid deleting the reference to the original variable and to avoid mutating
+    const actionExportType = { ...runReportAs }
     const runTypeChilds = []
     if (!isEmptyValue(reportDefinition.reportExportTypes)) {
       reportDefinition.reportExportTypes.forEach(reportType => {
@@ -114,12 +116,14 @@ export default {
         })
       })
 
-      runReportAs.childs = runTypeChilds
+      actionExportType.childs = runTypeChilds
     } else {
-      runReportAs.enabled = false
+      actionExportType.enabled = false
     }
-    actionsList.push(runReportAs)
+    actionsList.push(actionExportType)
 
+    // destruct to avoid deleting the reference to the original variable and to avoid mutating
+    const actionPrintFormat = { ...runReportAsPrintFormat }
     const printFormats = rootGetters.getPrintFormatList(containerUuid)
     if (!isEmptyValue(printFormats)) {
       const printFormatChilds = []
@@ -140,11 +144,11 @@ export default {
         })
       })
 
-      runReportAsPrintFormat.childs = printFormatChilds
+      actionPrintFormat.childs = printFormatChilds
     } else {
-      runReportAsPrintFormat.enabled = false
+      actionPrintFormat.enabled = false
     }
-    actionsList.push(runReportAsPrintFormat)
+    actionsList.push(actionPrintFormat)
 
     // action shared link
     actionsList.push(sharedLink)


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

#### Screenshot or Gif

https://user-images.githubusercontent.com/20288327/154391563-acd4111a-e195-4536-a6c7-955c47f20b15.mp4



#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
Related issue https://github.com/adempiere/adempiere-vue/issues/1598
