### PR TITLE
fix: Immediately close page when running process/report.

### DIFF
--- a/src/store/modules/ADempiere/processManager.js
+++ b/src/store/modules/ADempiere/processManager.js
@@ -70,6 +70,17 @@ const processManager = {
 
         let isProcessedError = false
         let summary = ''
+
+        // close current page
+        const currentRoute = router.app._route
+        const tabViewsVisited = rootGetters.visitedViews
+        dispatch('tagsView/delView', currentRoute)
+        // go to back page
+        const oldRouter = tabViewsVisited[tabViewsVisited.length - 1]
+        router.push({
+          path: oldRouter.path
+        }, () => {})
+
         requestRunProcess({
           uuid: containerUuid,
           parametersList
@@ -85,13 +96,6 @@ const processManager = {
             console.warn(`Error getting print formats: ${error.message}. Code: ${error.code}.`)
           })
           .finally(() => {
-            const currentRoute = router.app._route
-            // close view if is process or report panel
-            router.push({
-              path: '/dashboard'
-            }, () => {})
-            dispatch('tagsView/delView', currentRoute)
-
             dispatch('finishProcess', {
               summary,
               name: processDefinition.name,

--- a/src/store/modules/ADempiere/reportManager.js
+++ b/src/store/modules/ADempiere/reportManager.js
@@ -100,6 +100,16 @@ const reportManager = {
           })
         }
 
+        // close current page
+        const currentRoute = router.app._route
+        const tabViewsVisited = rootGetters.visitedViews
+        dispatch('tagsView/delView', currentRoute)
+        // go to back page
+        const oldRouter = tabViewsVisited[tabViewsVisited.length - 1]
+        router.push({
+          path: oldRouter.path
+        }, () => {})
+
         requestRunReport({
           uuid: containerUuid,
           reportType: reportFormat,
@@ -125,10 +135,6 @@ const reportManager = {
               if (!viewerSupportedFormats.includes(reportFormat)) {
                 link.click()
               }
-
-              const currentRoute = router.app._route
-              // close view if is report panel
-              dispatch('tagsView/delView', currentRoute)
 
               router.push({
                 name: 'Report Viewer',

--- a/src/views/ADempiere/ReportViewer/index.vue
+++ b/src/views/ADempiere/ReportViewer/index.vue
@@ -151,6 +151,7 @@ export default defineComponent({
               return runReport.uuid === reportUuid
             })
 
+            // empty report log
             if (isEmptyValue(currentReportLog)) {
               showNotification({
                 type: 'error',
@@ -160,13 +161,13 @@ export default defineComponent({
 
               root.$store.dispatch('tagsView/delView', root.$route)
                 .then(() => {
-                  this.$router.push('/', () => {})
+                  root.$router.push('/', () => {})
                 })
               return
             }
 
             const { output } = currentReportLog
-
+            // empty output in report log
             if (isEmptyValue(output.outputStream)) {
               const storedReportOutput = root.$store.getters.getReportOutput(instanceUuid)
               if (isEmptyValue(storedReportOutput)) {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Run any process/report.

#### Screenshot or Gif

https://user-images.githubusercontent.com/20288327/155231749-bfd9dab1-26af-4fe3-b387-b052f58b71ec.mp4

#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
Related issue https://github.com/adempiere/adempiere-vue/issues/1642
