### PR TITLE
Support Connection Timeout

### DIFF
--- a/src/components/ADempiere/ModalIdle/index.vue
+++ b/src/components/ADempiere/ModalIdle/index.vue
@@ -16,18 +16,19 @@
  along with this program.  If not, see <https:www.gnu.org/licenses/>.
 -->
 <template>
-  <div v-loading.fullscreen.lock="isIdle" />
+  <div v-if="userTimeout > 0" v-loading.fullscreen.lock="isIdle" />
 </template>
 
 <script>
-import { config } from '@/utils/ADempiere/config'
 import Vue from 'vue'
 import IdleVue from 'idle-vue'
 import store from '../../../store'
+
+const connectionTimeout = (store.getters['user/userInfo'].connection_timeout > 0) ? store.getters['user/userInfo'].connection_timeout : 1000
 Vue.use(IdleVue, {
   eventEmitter: new Vue(),
   store,
-  idleTime: `${config.session.timeout}`,
+  idleTime: `${connectionTimeout}`,
   startAtIdle: false
 })
 export default {
@@ -64,9 +65,9 @@ export default {
   },
   created() {
     setInterval(() => {
-      this.time -= 1000
+      this.time -= this.userTimeout
       if (!this.$store.state.idleVue.isIdle) clearInterval()
-      if (this.time < 1 && this.isSession && this.userTimeout > 0) {
+      if (this.time < 1 && this.isSession) {
         clearInterval()
         this.logout()
       }


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature
Support Connection Timeout
when the session time is up the screen turns white but the session does not close
#### Screenshot or Gif


#### Link to minimal reproduction
https://demo-ui.erpya.com/
<!--
Please only use Codepen, JSFiddle, CodeSandbox or a github repo
-->


#### Other relevant information
- Your OS: Debian 9
- Web Browser: Chrome
- Node.js version: v 14.18.0
- Yarn version: v 1.22.0
- adempiere-vue version: v 4.4.0.
