### PR TITLE
feat: Add process associated on Smart Browser

### DIFF
--- a/src/store/modules/ADempiere/browserManager.js
+++ b/src/store/modules/ADempiere/browserManager.js
@@ -60,6 +60,10 @@ const browserControl = {
       Vue.set(state.browserData, containerUuid, dataBrowser)
     },
 
+    clearBrowserData(state, { containerUuid }) {
+      Vue.set(state.browserData, containerUuid, undefined)
+    },
+
     setBrowserSelectionsList(state, {
       containerUuid,
       selectionsList

--- a/src/store/modules/ADempiere/dictionary/browser/actions.js
+++ b/src/store/modules/ADempiere/dictionary/browser/actions.js
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import router from '@/router'
+import store from '@/store'
 
 // api request methods
 import { requestBrowserMetadata } from '@/api/ADempiere/dictionary/smart-browser.js'
@@ -64,6 +65,32 @@ export default {
           })
 
           resolve(browserDefinition)
+
+          const { process } = browserDefinition
+          if (!isEmptyValue(process)) {
+            // get browser definition
+            /**
+             * TODO: Move to action only open process associated.
+             * Does load fields if move to action browsers.
+             */
+            store.dispatch('getProcessDefinitionFromServer', {
+              uuid: process.uuid
+            })
+
+            dispatch('setModalDialog', {
+              containerUuid: process.uuid,
+              title: process.name,
+              doneMethod: () => {
+                store.dispatch('startProcessOfBrowser', {
+                  parentUuid: browserDefinition.uuid,
+                  containerUuid: process.uuid
+                })
+              },
+              // TODO: Change to string and import dynamic in component
+              componentPath: () => import('@/components/ADempiere/PanelDefinition/index.vue'),
+              isShowed: false
+            })
+          }
         })
     })
   },
@@ -120,6 +147,7 @@ export default {
 
   /**
    * Set default values to panel
+   * TODO: Add dispatch default values to process associated
    * @param {string}  containerUuid
    * @param {array} fieldsList
    */

--- a/src/store/modules/ADempiere/dictionary/browser/actions.js
+++ b/src/store/modules/ADempiere/dictionary/browser/actions.js
@@ -147,7 +147,6 @@ export default {
 
   /**
    * Set default values to panel
-   * TODO: Add dispatch default values to process associated
    * @param {string}  containerUuid
    * @param {array} fieldsList
    */
@@ -156,8 +155,10 @@ export default {
     fieldsList = []
   }) {
     return new Promise(resolve => {
+      const browserDefinition = getters.getStoredBrowser(containerUuid)
+
       if (isEmptyValue(fieldsList)) {
-        fieldsList = getters.getStoredFieldsFromProcess(containerUuid)
+        fieldsList = browserDefinition.fieldsList
       }
 
       const currentRoute = router.app._route
@@ -174,6 +175,13 @@ export default {
       })
 
       resolve(defaultAttributes)
+
+      if (!isEmptyValue(browserDefinition.process)) {
+        // clear values to process associated
+        dispatch('setProcessDefaultValues', {
+          containerUuid: browserDefinition.process.uuid
+        })
+      }
     })
   },
 

--- a/src/store/modules/ADempiere/dictionary/browser/getters.js
+++ b/src/store/modules/ADempiere/dictionary/browser/getters.js
@@ -23,10 +23,6 @@ import { isNumberField } from '@/utils/ADempiere/references'
  * Dictionary Browser Getters
  */
 export default {
-  getStoredBrowsers: (state) => {
-    return state.storedBrowsers
-  },
-
   getStoredBrowser: (state) => (browserUuid) => {
     return state.storedBrowsers[browserUuid]
   },
@@ -37,6 +33,12 @@ export default {
       return browser.fieldsList
     }
     return undefined
+  },
+
+  getProcessOfBrowser: (state, getters, rootState, rootGetters) => (browserUuid) => {
+    const { process } = getters.getStoredBrowser(browserUuid)
+
+    return process
   },
 
   /**

--- a/src/store/modules/ADempiere/dictionary/process/getters.js
+++ b/src/store/modules/ADempiere/dictionary/process/getters.js
@@ -23,10 +23,6 @@ import { isNumberField } from '@/utils/ADempiere/references'
  * Dictionary Process Getters
  */
 export default {
-  getStoredProcesses: (state) => {
-    return state.storedProcesses
-  },
-
   getStoredProcess: (state) => (processUuid) => {
     return state.storedProcesses[processUuid]
   },

--- a/src/store/modules/ADempiere/processManager.js
+++ b/src/store/modules/ADempiere/processManager.js
@@ -119,7 +119,7 @@ const processManager = {
      * @param {string} containerUuid, process associated of browser
      * @returns
      */
-    startProcessOfBrowser({ dispatch, rootGetters }, {
+    startProcessOfBrowser({ commit, dispatch, rootGetters }, {
       parentUuid,
       containerUuid
     }) {
@@ -150,7 +150,7 @@ const processManager = {
 
         let isProcessedError = false
         let summary = ''
-
+        /*
         // close current page
         const currentRoute = router.app._route
         const tabViewsVisited = rootGetters.visitedViews
@@ -160,10 +160,12 @@ const processManager = {
         router.push({
           path: oldRouter.path
         }, () => {})
-
+        */
         requestRunProcess({
           uuid: containerUuid,
           parametersList,
+          // TODO: Add support to tableSelectedId
+          tableSelectedId: null,
           selectionsList
         })
           .then(runProcessRepsonse => {
@@ -177,6 +179,13 @@ const processManager = {
             console.warn(`Error getting print formats: ${error.message}. Code: ${error.code}.`)
           })
           .finally(() => {
+            commit('clearBrowserData', {
+              containerUuid: parentUuid
+            })
+            dispatch('setBrowserDefaultValues', {
+              containerUuid: parentUuid
+            })
+
             dispatch('finishProcess', {
               summary,
               name: processDefinition.name,

--- a/src/store/modules/ADempiere/processManager.js
+++ b/src/store/modules/ADempiere/processManager.js
@@ -113,6 +113,87 @@ const processManager = {
       })
     },
 
+    /**
+     * Start run process of browser
+     * @param {string} parentUuid, browser calling this process
+     * @param {string} containerUuid, process associated of browser
+     * @returns
+     */
+    startProcessOfBrowser({ dispatch, rootGetters }, {
+      parentUuid,
+      containerUuid
+    }) {
+      return new Promise(resolve => {
+        const browserDefinition = rootGetters.getStoredBrowser(parentUuid)
+        const { process: processDefinition } = browserDefinition
+
+        const parametersList = rootGetters.getProcessParameters({
+          containerUuid
+        })
+
+        const selectionsList = rootGetters.getBrowserSelectionToServer({
+          containerUuid: parentUuid
+        })
+
+        const isSession = !isEmptyValue(getToken())
+        let procesingNotification = {
+          close: () => false
+        }
+        if (isSession) {
+          procesingNotification = showNotification({
+            title: language.t('notifications.processing'),
+            message: processDefinition.name,
+            summary: processDefinition.description,
+            type: 'info'
+          })
+        }
+
+        let isProcessedError = false
+        let summary = ''
+
+        // close current page
+        const currentRoute = router.app._route
+        const tabViewsVisited = rootGetters.visitedViews
+        dispatch('tagsView/delView', currentRoute)
+        // go to back page
+        const oldRouter = tabViewsVisited[tabViewsVisited.length - 1]
+        router.push({
+          path: oldRouter.path
+        }, () => {})
+
+        requestRunProcess({
+          uuid: containerUuid,
+          parametersList,
+          selectionsList
+        })
+          .then(runProcessRepsonse => {
+            isProcessedError = runProcessRepsonse.isError
+            summary = runProcessRepsonse.summary
+
+            resolve(runProcessRepsonse)
+          })
+          .catch(error => {
+            isProcessedError = true
+            console.warn(`Error getting print formats: ${error.message}. Code: ${error.code}.`)
+          })
+          .finally(() => {
+            dispatch('finishProcess', {
+              summary,
+              name: processDefinition.name,
+              isError: isProcessedError
+            })
+              .then(() => {
+                // close runing process notification
+                if (!isEmptyValue(procesingNotification)) {
+                  setTimeout(() => {
+                    procesingNotification.close()
+                  }, 1000)
+                }
+              })
+          })
+      })
+    },
+
     finishProcess({ commit }, {
       name,
       summary,

--- a/src/utils/ADempiere/dictionary/browser.js
+++ b/src/utils/ADempiere/dictionary/browser.js
@@ -81,11 +81,11 @@ export const refreshBrowserSearh = {
   svg: false,
   icon: 'el-icon-refresh',
   actionName: 'refreshRecords',
-  refreshRecords: ({ root, containerUuid }) => {
+  refreshRecords: ({ containerUuid }) => {
     const fieldsEmpty = store.getters.getBrowserFieldsEmptyMandatory({
       containerUuid
     })
-    if (!root.isEmptyValue(fieldsEmpty)) {
+    if (!isEmptyValue(fieldsEmpty)) {
       showMessage({
         message: language.t('notifications.mandatoryFieldMissing') + fieldsEmpty,
         type: 'info'
@@ -113,7 +113,7 @@ export const runProcessOfBrowser = {
   icon: 'el-icon-setting',
   actionName: 'runProcessOfBrowser',
   uuid: null,
-  runProcessOfBrowser: ({ root, containerUuid, containerManager }) => {
+  runProcessOfBrowser: ({ containerUuid, containerManager }) => {
     const selection = containerManager.getSelection({
       containerUuid
     })
@@ -124,8 +124,20 @@ export const runProcessOfBrowser = {
       })
       return
     }
-    store.dispatch('startProcessOfBrowser', {
-      containerUuid
+
+    const process = store.getters.getProcessOfBrowser(containerUuid)
+    /*
+    const storedProcess = store.getters.getStoredProcess(process.uuid)
+    if (isEmptyValue(storedProcess)) {
+      store.dispatch('getProcessDefinitionFromServer', {
+        uuid: process.uuid
+      })
+    }
+    */
+
+    store.commit('setShowedModalDialog', {
+      containerUuid: process.uuid,
+      isShowed: true
     })
   }
 }

--- a/src/views/ADempiere/Process/mixinProcess.js
+++ b/src/views/ADempiere/Process/mixinProcess.js
@@ -1,0 +1,97 @@
+// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { computed, ref } from '@vue/composition-api'
+
+import store from '@/store'
+import lang from '@/lang'
+
+// utils and helper methods
+import {
+  isDisplayedField,
+  isMandatoryField,
+  isReadOnlyField
+} from '@/utils/ADempiere/dictionary/process.js'
+
+export default (processUuid) => {
+  const storedProcessDefinition = computed(() => {
+    return store.getters.getStoredProcess(processUuid)
+  })
+
+  const containerManager = {
+    getPanel({ containerUuid }) {
+      return store.getters.getStoredProcess(containerUuid)
+    },
+    getFieldsList({ containerUuid }) {
+      return store.getters.getStoredFieldsFromProcess(containerUuid)
+    },
+
+    actionPerformed: ({ field, value }) => {
+      // store.dispatch('processActionPerformed', {
+      //   field,
+      //   value
+      // })
+    },
+
+    setDefaultValues: ({ containerUuid }) => {
+      store.dispatch('setProcessDefaultValues', {
+        containerUuid
+      })
+    },
+
+    isDisplayedField,
+
+    isReadOnlyField({
+      field
+    }) {
+      return isReadOnlyField(field)
+    },
+
+    isMandatoryField,
+
+    changeFieldShowedFromUser({ containerUuid, fieldsShowed }) {
+      store.dispatch('changeProcessFieldShowedFromUser', {
+        containerUuid,
+        fieldsShowed
+      })
+    }
+  }
+
+  const actionsList = computed(() => {
+    return store.getters.getStoredActionsMenu({
+      containerUuid: processUuid
+    })
+  })
+
+  const actionsManager = ref({
+    containerUuid: processUuid,
+
+    defaultActionName: lang.t('actionMenu.runProcess'),
+
+    getActionList: () => actionsList.value
+  })
+
+  const relationsManager = ref({
+    // menuParentUuid: getCurrentInstance().$route.meta.parentUuid
+  })
+
+  return {
+    containerManager,
+    actionsManager,
+    relationsManager,
+    storedProcessDefinition
+  }
+}


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open any smart browse with process (`Process Orders of selections` for this case).
2. Start search and selected records result.
3. Select associated process and run.


#### Screenshot or Gif

https://user-images.githubusercontent.com/20288327/156931008-3a6bd545-6d1a-477a-ae06-81ec8101dd23.mp4


#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.


#### Additional context
Depends on changes: https://github.com/adempiere/gRPC-API/pull/10
