### PR TITLE
feat: Add support to read only tab.

### DIFF
--- a/src/components/ADempiere/Field/index.vue
+++ b/src/components/ADempiere/Field/index.vue
@@ -70,9 +70,6 @@ import FieldOptions from '@/components/ADempiere/Field/FieldOptions/index.vue'
 
 // constants
 import { TEXT } from '@/utils/ADempiere/references'
-import {
-  ACTIVE, CLIENT, PROCESSING, PROCESSED
-} from '@/utils/ADempiere/constants/systemColumns'
 
 // utils and helper methods
 import { evalutateTypeField } from '@/utils/ADempiere/dictionaryUtils'
@@ -245,21 +242,8 @@ export default {
         return false
       }
 
-      // TODO: Add validate method to record uuid uuid without route.action
-      // edit mode is diferent to create new
-      const isWithRecord = this.recordUuid !== 'create-new' &&
-        !this.isEmptyValue(this.recordUuid)
-
       // validate with container manager
-      return this.containerManager.isReadOnlyField({
-        field: this.field,
-        // record values
-        clientId: this.containerClientId,
-        isActive: this.containerIsActive,
-        isProcessing: this.containerIsProcessing,
-        isProcessed: this.containerIsProcessed,
-        isWithRecord
-      })
+      return this.containerManager.isReadOnlyField(this.field)
     },
     isMandatoryField() {
       // validate with container manager
@@ -272,38 +256,6 @@ export default {
         parentUuid: this.parentUuid,
         containerUuid: this.containerUuid,
         columnName: 'UUID'
-      })
-    },
-    containerIsActive() {
-      // panel processing value
-      return this.$store.getters.getValueOfField({
-        parentUuid: this.parentUuid,
-        containerUuid: this.containerUuid,
-        columnName: ACTIVE
-      })
-    },
-    containerIsProcessing() {
-      // panel processing value
-      return this.$store.getters.getValueOfField({
-        parentUuid: this.parentUuid,
-        containerUuid: this.containerUuid,
-        columnName: PROCESSING
-      })
-    },
-    containerIsProcessed() {
-      // panel processed value
-      return this.$store.getters.getValueOfField({
-        parentUuid: this.parentUuid,
-        containerUuid: this.containerUuid,
-        columnName: PROCESSED
-      })
-    },
-    containerClientId() {
-      // panel client value
-      return this.$store.getters.getValueOfField({
-        parentUuid: this.parentUuid,
-        containerUuid: this.containerUuid,
-        columnName: CLIENT
       })
     },
 

--- a/src/store/modules/ADempiere/dictionary/window/getters.js
+++ b/src/store/modules/ADempiere/dictionary/window/getters.js
@@ -30,6 +30,10 @@ export default {
     return state.storedWindows[windowUuid]
   },
 
+  getParentTabUuid: (state) => (windowUuid) => {
+    return state.storedWindows[windowUuid].firstTabUuid
+  },
+
   getStoredTabs: (state) => (windowUuid) => {
     return state.storedWindows[windowUuid].tabsList
   },
@@ -71,7 +75,8 @@ export default {
   getStoredFieldFromTab: (state, getters) => ({ windowUuid, tabUuid, columnName, fieldUuid }) => {
     return getters.getStoredFieldsFromTab(windowUuid, tabUuid)
       .find(field => {
-        return field.columnName === columnName || field.uuid === fieldUuid
+        return field.columnName === columnName ||
+          field.uuid === fieldUuid
       })
   },
 

--- a/src/utils/ADempiere/dictionary/window.js
+++ b/src/utils/ADempiere/dictionary/window.js
@@ -312,7 +312,8 @@ export function generateTabs({
       isAddFieldUuid: true,
       isAddLinkColumn: true,
       fieldOverwrite: {
-        isReadOnlyFromForm: true
+        isReadOnlyFromForm: true,
+        firstTabUuid
       }
     })
   })

--- a/src/views/ADempiere/Browser/index.vue
+++ b/src/views/ADempiere/Browser/index.vue
@@ -84,6 +84,7 @@
 
 <script>
 import { computed, defineComponent, ref } from '@vue/composition-api'
+
 import lang from '@/lang'
 import store from '@/store'
 
@@ -285,9 +286,7 @@ export default defineComponent({
 
       isMandatoryField,
 
-      isReadOnlyField({ field }) {
-        return isReadOnlyField(field)
-      },
+      isReadOnlyField,
 
       changeFieldShowedFromUser({ containerUuid, fieldsShowed }) {
         store.dispatch('changeBrowserFieldShowedFromUser', {

--- a/src/views/ADempiere/Process/mixinProcess.js
+++ b/src/views/ADempiere/Process/mixinProcess.js
@@ -54,11 +54,7 @@ export default (processUuid) => {
 
     isDisplayedField,
 
-    isReadOnlyField({
-      field
-    }) {
-      return isReadOnlyField(field)
-    },
+    isReadOnlyField,
 
     isMandatoryField,
 

--- a/src/views/ADempiere/Report/index.vue
+++ b/src/views/ADempiere/Report/index.vue
@@ -60,6 +60,7 @@
 
 <script>
 import { defineComponent, computed, ref } from '@vue/composition-api'
+
 import lang from '@/lang'
 import store from '@/store'
 
@@ -167,11 +168,7 @@ export default defineComponent({
       },
 
       actionPerformed: ({ field, value }) => {
-        // let action = 'reportActionPerformed'
-        // if (field.isReport) {
-        //   action = 'reportActionPerformed'
-        // }
-        // store.dispatch(action, {
+        // store.dispatch('reportActionPerformed', {
         //   field,
         //   value
         // })
@@ -185,11 +182,7 @@ export default defineComponent({
 
       isDisplayedField,
 
-      isReadOnlyField({
-        field
-      }) {
-        return isReadOnlyField(field)
-      },
+      isReadOnlyField,
 
       isMandatoryField,
 

--- a/src/views/ADempiere/Report/mixinReport.js
+++ b/src/views/ADempiere/Report/mixinReport.js
@@ -1,4 +1,21 @@
+// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import { computed, ref } from '@vue/composition-api'
+
 import store from '@/store'
 import lang from '@/lang'
 
@@ -23,11 +40,7 @@ export default (reportUuid) => {
     },
 
     actionPerformed: ({ field, value }) => {
-      // let action = 'reportActionPerformed'
-      // if (field.isReport) {
-      //   action = 'reportActionPerformed'
-      // }
-      // root.$store.dispatch(action, {
+      // store.dispatch('reportActionPerformed', {
       //   field,
       //   value
       // })
@@ -41,11 +54,7 @@ export default (reportUuid) => {
 
     isDisplayedField,
 
-    isReadOnlyField({
-      field
-    }) {
-      return isReadOnlyField(field)
-    },
+    isReadOnlyField,
 
     isMandatoryField,
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

Case A:
1. Open window `Element`.
2. Change single record in tab `Used in Process Parameter`.

Case B:
1. Open window `Tab and Column`.
2. Select `Create New` option in actions menu.


#### Screenshot or Gif
Before this changes:

https://user-images.githubusercontent.com/20288327/159037668-2f57bb01-2365-43f9-983b-ac39f1ffd83a.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/159037460-3314e808-8441-4ba9-b3e1-19d18922a41c.mp4


#### Expected behavior
Case A:
The tab `Used in Process Parameter` is read only, and all fields within it must be read-only.

Case B:
If the parent tab is in create new record, the fields inside the other child tabs must be read-only.

#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

