### PR TITLE
fix: Overwrite records parent tab.

### DIFF
--- a/src/components/ADempiere/Field/FieldAutocomplete.vue
+++ b/src/components/ADempiere/Field/FieldAutocomplete.vue
@@ -136,7 +136,7 @@ export default {
     },
     value: {
       get() {
-        const value = this.$store.getters.getValueOfField({
+        const value = this.$store.getters.getValueOfFieldOnContainer({
           parentUuid: this.metadata.parentUuid,
           containerUuid: this.metadata.containerUuid,
           columnName: this.metadata.columnName
@@ -172,7 +172,7 @@ export default {
     },
     displayedValue: {
       get() {
-        return this.$store.getters.getValueOfField({
+        return this.$store.getters.getValueOfFieldOnContainer({
           parentUuid: this.metadata.parentUuid,
           containerUuid: this.metadata.containerUuid,
           // DisplayColumn_'ColumnName'

--- a/src/components/ADempiere/Field/FieldDate.vue
+++ b/src/components/ADempiere/Field/FieldDate.vue
@@ -207,7 +207,7 @@ export default {
         }
 
         // main panel values
-        let value = this.$store.getters.getValueOfField({
+        let value = this.$store.getters.getValueOfFieldOnContainer({
           parentUuid: this.metadata.parentUuid,
           containerUuid,
           columnName
@@ -216,7 +216,7 @@ export default {
           return this.parseValue(value)
         }
 
-        const valueTo = this.$store.getters.getValueOfField({
+        const valueTo = this.$store.getters.getValueOfFieldOnContainer({
           parentUuid: this.metadata.parentUuid,
           containerUuid,
           columnName: this.metadata.columnNameTo

--- a/src/components/ADempiere/Field/FieldLocation/index.vue
+++ b/src/components/ADempiere/Field/FieldLocation/index.vue
@@ -120,7 +120,7 @@ export default {
           return undefined
         }
 
-        return this.$store.getters.getValueOfField({
+        return this.$store.getters.getValueOfFieldOnContainer({
           parentUuid: this.metadata.parentUuid,
           containerUuid: this.metadata.containerUuid,
           // DisplayColumn_'ColumnName'

--- a/src/components/ADempiere/Field/FieldOptions/CalculatorField/index.vue
+++ b/src/components/ADempiere/Field/FieldOptions/CalculatorField/index.vue
@@ -175,7 +175,7 @@ export default {
       }
 
       // main panel values
-      return this.$store.getters.getValueOfField({
+      return this.$store.getters.getValueOfFieldOnContainer({
         parentUuid: this.fieldAttributes.parentUuid,
         containerUuid,
         columnName

--- a/src/components/ADempiere/Field/FieldOptions/ContextInfo/index.vue
+++ b/src/components/ADempiere/Field/FieldOptions/ContextInfo/index.vue
@@ -92,7 +92,7 @@ export default defineComponent({
   setup(props, { root }) {
     const fieldValue = computed(() => {
       const { parentUuid, containerUuid, columnName } = props.fieldAttributes
-      return root.$store.getters.getValueOfField({
+      return root.$store.getters.getValueOfFieldOnContainer({
         parentUuid,
         containerUuid,
         columnName

--- a/src/components/ADempiere/Field/FieldOptions/DocumentStatus/index.vue
+++ b/src/components/ADempiere/Field/FieldOptions/DocumentStatus/index.vue
@@ -124,7 +124,7 @@ export default defineComponent({
   setup(props, { root }) {
     const displayedValue = computed(() => {
       const { parentUuid, containerUuid, displayColumnName } = props.fieldAttributes
-      return root.$store.getters.getValueOfField({
+      return root.$store.getters.getValueOfFieldOnContainer({
         parentUuid,
         containerUuid,
         columnName: displayColumnName
@@ -133,7 +133,7 @@ export default defineComponent({
 
     const value = computed(() => {
       const { parentUuid, containerUuid, columnName } = props.fieldAttributes
-      return root.$store.getters.getValueOfField({
+      return root.$store.getters.getValueOfFieldOnContainer({
         parentUuid,
         containerUuid,
         columnName

--- a/src/components/ADempiere/Field/FieldOptions/OperatorComparison/index.vue
+++ b/src/components/ADempiere/Field/FieldOptions/OperatorComparison/index.vue
@@ -79,7 +79,7 @@ export default defineComponent({
       const { columnName, containerUuid, parentUuid } = props.fieldAttributes
 
       // main panel values
-      return root.$store.getters.getValueOfField({
+      return root.$store.getters.getValueOfFieldOnContainer({
         parentUuid,
         containerUuid,
         columnName

--- a/src/components/ADempiere/Field/FieldOptions/PreferenceValue/index.vue
+++ b/src/components/ADempiere/Field/FieldOptions/PreferenceValue/index.vue
@@ -180,7 +180,7 @@ export default {
         })
       }
 
-      return this.$store.getters.getValueOfField({
+      return this.$store.getters.getValueOfFieldOnContainer({
         parentUuid: this.fieldAttributes.parentUuid,
         containerUuid,
         columnName
@@ -198,7 +198,7 @@ export default {
         })
       }
 
-      return this.$store.getters.getValueOfField({
+      return this.$store.getters.getValueOfFieldOnContainer({
         parentUuid: this.fieldAttributes.parentUuid,
         containerUuid,
         columnName

--- a/src/components/ADempiere/Field/FieldOptions/index.vue
+++ b/src/components/ADempiere/Field/FieldOptions/index.vue
@@ -169,7 +169,7 @@ export default defineComponent({
 
     const valueField = computed(() => {
       const { parentUuid, containerUuid, columnName } = props.metadata
-      return root.$store.getters.getValueOfField({
+      return root.$store.getters.getValueOfFieldOnContainer({
         parentUuid,
         containerUuid,
         columnName

--- a/src/components/ADempiere/Field/FieldSelect.vue
+++ b/src/components/ADempiere/Field/FieldSelect.vue
@@ -155,7 +155,7 @@ export default {
           }
         }
 
-        return this.$store.getters.getValueOfField({
+        return this.$store.getters.getValueOfFieldOnContainer({
           parentUuid: this.metadata.parentUuid,
           containerUuid,
           columnName
@@ -194,7 +194,7 @@ export default {
         if (this.metadata.inTable) {
           return undefined
         }
-        return this.$store.getters.getValueOfField({
+        return this.$store.getters.getValueOfFieldOnContainer({
           parentUuid: this.metadata.parentUuid,
           containerUuid: this.metadata.containerUuid,
           // 'ColumnName'_UUID
@@ -230,7 +230,7 @@ export default {
           }
         }
 
-        return this.$store.getters.getValueOfField({
+        return this.$store.getters.getValueOfFieldOnContainer({
           parentUuid: this.metadata.parentUuid,
           containerUuid,
           columnName

--- a/src/components/ADempiere/Field/index.vue
+++ b/src/components/ADempiere/Field/index.vue
@@ -69,6 +69,7 @@
 import FieldOptions from '@/components/ADempiere/Field/FieldOptions/index.vue'
 
 // constants
+import { UUID } from '@/utils/ADempiere/constants/systemColumns'
 import { TEXT } from '@/utils/ADempiere/references'
 
 // utils and helper methods
@@ -252,10 +253,10 @@ export default {
 
     recordUuid() {
       // is active record
-      return this.$store.getters.getValueOfField({
+      return this.$store.getters.getValueOfFieldOnContainer({
         parentUuid: this.parentUuid,
         containerUuid: this.containerUuid,
-        columnName: 'UUID'
+        columnName: UUID
       })
     },
 

--- a/src/components/ADempiere/Field/mixin/mixinField.js
+++ b/src/components/ADempiere/Field/mixin/mixinField.js
@@ -75,7 +75,7 @@ export default {
         }
 
         // main panel values
-        return this.$store.getters.getValueOfField({
+        return this.$store.getters.getValueOfFieldOnContainer({
           parentUuid: this.metadata.parentUuid,
           containerUuid,
           columnName

--- a/src/components/ADempiere/Field/mixin/mixinFieldRange.js
+++ b/src/components/ADempiere/Field/mixin/mixinFieldRange.js
@@ -20,12 +20,12 @@ export default {
   computed: {
     value: {
       get() {
-        const value = this.$store.getters.getValueOfField({
+        const value = this.$store.getters.getValueOfFieldOnContainer({
           parentUuid: this.metadata.parentUuid,
           containerUuid: this.metadata.containerUuid,
           columnName: this.metadata.columnName
         })
-        const valueTo = this.$store.getters.getValueOfField({
+        const valueTo = this.$store.getters.getValueOfFieldOnContainer({
           parentUuid: this.metadata.parentUuid,
           containerUuid: this.metadata.containerUuid,
           columnName: this.metadata.columnName

--- a/src/store/modules/ADempiere/fieldValue.js
+++ b/src/store/modules/ADempiere/fieldValue.js
@@ -135,28 +135,63 @@ const value = {
   },
 
   getters: {
-    getValueOfField: (state) => ({
+    getValueOfField: (state, getters) => ({
       parentUuid,
       containerUuid,
       columnName
     }) => {
-      let key = ''
       let value
+      if (containerUuid) {
+        // get in tab level
+        value = getters.getValueOfFieldOnContainer({
+          containerUuid,
+          columnName
+        })
+      }
+
+      if (parentUuid && isEmptyValue(value)) {
+        // get in window level
+        value = getters.getValueOfFieldOnParent({
+          parentUuid,
+          columnName
+        })
+      }
+
+      return value
+    },
+
+    getValueOfFieldOnContainer: (state) => ({
+      containerUuid,
+      columnName
+    }) => {
+      let key = ''
       if (containerUuid) {
         // get in tab level
         key += containerUuid + '_'
       }
       key += columnName
-      value = state.field[key]
 
-      if (parentUuid && isEmptyValue(value)) {
-        // get in window level
-        key = parentUuid + '_' + columnName
-        value = state.field[parentUuid + '_' + columnName]
-      }
+      const value = state.field[key]
 
       return value
     },
+
+    getValueOfFieldOnParent: (state) => ({
+      parentUuid,
+      columnName
+    }) => {
+      let key = ''
+      if (parentUuid) {
+        // get in window level
+        key = parentUuid + '_'
+      }
+      key += columnName
+
+      const value = state.field[key]
+
+      return value
+    },
+
     /**
      * Get values and column's name as key (without parent uuid or container
      * uuid), from a view (container)

--- a/src/views/ADempiere/Window/MultiTabWindow.vue
+++ b/src/views/ADempiere/Window/MultiTabWindow.vue
@@ -159,7 +159,7 @@ export default defineComponent({
           parentUuid,
           containerUuid,
           attributes,
-          isOverWriteParent: true
+          isOverWriteParent: tab.isParentTab
         })
 
         // active logics with set records values


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open a window with similarly named fields in parent and child tabs, in this case description.
2. Select a parent record with data in the description field.
3. Switch to another record with no data in the description field.

#### Screenshot or Gif

Before this changes:

https://user-images.githubusercontent.com/20288327/159804231-bbf69410-d956-4ea3-9f18-a341151b987e.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/159804242-ceea14c3-8a43-4772-9bc8-eec794c3eb03.mp4



#### Expected behavior
Note how the value of the description field is overwritten when it should be empty.

#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

