### PR TITLE
fix: Preference context values.

### DIFF
--- a/src/store/modules/ADempiere/preference.js
+++ b/src/store/modules/ADempiere/preference.js
@@ -165,23 +165,30 @@ const preference = {
       columnName
     }) => {
       let key = ''
+      let value
 
       if (parentUuid) {
         key += parentUuid + '|'
 
         // context for window
         const keyParent = key + columnName
-        const valueParent = state.preference[keyParent]
-        if (!isEmptyValue(valueParent)) {
-          return valueParent
+        value = state.preference[keyParent]
+        if (!isEmptyValue(value)) {
+          return value
         }
       }
+
       if (containerUuid) {
         key += containerUuid + '|'
       }
       key += columnName
+      value = state.preference[key]
+      if (!isEmptyValue(value)) {
+        return value
+      }
 
-      return state.preference[key]
+      value = state.preference[columnName]
+      return value
     },
     getAllPreference: (state) => {
       return state.preference


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open window `Setup Definition`.
2. Show networks request.

#### Screenshot or Gif
Before this changes:

![preference-context-error](https://user-images.githubusercontent.com/20288327/159903298-5cbe67db-e160-4c72-a40f-16e34c882bdc.png)

After this changesÑ

![preference-context-fix](https://user-images.githubusercontent.com/20288327/159903301-9c22f9a1-1445-454d-b029-d5181aecc64a.png)


#### Expected behavior
The contextAttributes and filters structure is expected to send the array structure `{ columnName, value }`.

#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
Server-side parsing of $, # and P column name prefixes

