### PR TITLE
feat: Add lookup item with contextColumnName.

### DIFF
--- a/src/api/ADempiere/window.js
+++ b/src/api/ADempiere/window.js
@@ -27,17 +27,16 @@ import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
  */
 export function requestLookup({
   contextAttributesList,
-  uuid,
+  fieldUuid,
+  processParameterUuid,
+  browseFieldUuid,
   id,
   //
   referenceUuid,
-  searchValue,
   //
   tableName,
   columnName,
-  columnUuid,
-  //
-  value
+  columnUuid
 }) {
   let contextAttributes = []
   if (!isEmptyValue(contextAttributesList)) {
@@ -54,17 +53,16 @@ export function requestLookup({
     method: 'get',
     params: {
       context_attributes: contextAttributes,
-      uuid,
+      field_uuid: fieldUuid,
+      process_parameter_uuid: processParameterUuid,
+      browse_field_uuid: browseFieldUuid,
       id,
       //
       reference_uuid: referenceUuid,
-      search_value: searchValue,
       //
       table_name: tableName,
       column_name: columnName,
-      column_uuid: columnUuid,
-      //
-      value
+      column_uuid: columnUuid
     }
   })
     .then(respose => {

--- a/src/api/ADempiere/window.js
+++ b/src/api/ADempiere/window.js
@@ -85,6 +85,7 @@ export function requestLookupList({
   fieldUuid,
   processParameterUuid,
   browseFieldUuid,
+  id,
   //
   referenceUuid,
   searchValue,
@@ -114,6 +115,7 @@ export function requestLookupList({
       field_uuid: fieldUuid,
       process_parameter_uuid: processParameterUuid,
       browse_field_uuid: browseFieldUuid,
+      id,
       //
       reference_uuid: referenceUuid,
       search_value: searchValue,

--- a/src/api/ADempiere/window.js
+++ b/src/api/ADempiere/window.js
@@ -28,6 +28,7 @@ import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 export function requestLookup({
   contextAttributesList,
   uuid,
+  id,
   //
   referenceUuid,
   searchValue,
@@ -54,6 +55,7 @@ export function requestLookup({
     params: {
       context_attributes: contextAttributes,
       uuid,
+      id,
       //
       reference_uuid: referenceUuid,
       search_value: searchValue,

--- a/src/api/ADempiere/window.js
+++ b/src/api/ADempiere/window.js
@@ -26,21 +26,43 @@ import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
  * @param {string|number} value
  */
 export function requestLookup({
+  contextAttributesList,
+  uuid,
+  //
+  referenceUuid,
+  searchValue,
+  //
   tableName,
-  directQuery,
+  columnName,
+  columnUuid,
+  //
   value
 }) {
-  const filters = [{
-    value
-  }]
+  let contextAttributes = []
+  if (!isEmptyValue(contextAttributesList)) {
+    contextAttributes = contextAttributesList.map(attribute => {
+      return {
+        key: attribute.columnName,
+        value: attribute.value
+      }
+    })
+  }
 
   return request({
     url: '/user-interface/window/lookup-item',
     method: 'get',
     params: {
+      context_attributes: contextAttributes,
+      uuid,
+      //
+      reference_uuid: referenceUuid,
+      search_value: searchValue,
+      //
       table_name: tableName,
-      query: directQuery,
-      filters
+      column_name: columnName,
+      column_uuid: columnUuid,
+      //
+      value
     }
   })
     .then(respose => {
@@ -63,10 +85,14 @@ export function requestLookupList({
   fieldUuid,
   processParameterUuid,
   browseFieldUuid,
+  //
   referenceUuid,
+  searchValue,
+  //
   tableName,
   columnName,
-  searchValue,
+  columnUuid,
+  //
   pageToken,
   pageSize
 }) {
@@ -74,7 +100,7 @@ export function requestLookupList({
   if (!isEmptyValue(contextAttributesList)) {
     contextAttributes = contextAttributesList.map(attribute => {
       return {
-        column_name: attribute.columnName,
+        key: attribute.columnName,
         value: attribute.value
       }
     })
@@ -84,15 +110,17 @@ export function requestLookupList({
     url: '/user-interface/window/lookup-items',
     method: 'get',
     params: {
-      context_attribures: contextAttributes,
+      context_attributes: contextAttributes,
       field_uuid: fieldUuid,
       process_parameter_uuid: processParameterUuid,
       browse_field_uuid: browseFieldUuid,
       //
       reference_uuid: referenceUuid,
       search_value: searchValue,
+      //
       table_name: tableName,
       column_name: columnName,
+      column_uuid: columnUuid,
       // Page Data
       pageToken,
       pageSize

--- a/src/components/ADempiere/Field/FieldAutocomplete.vue
+++ b/src/components/ADempiere/Field/FieldAutocomplete.vue
@@ -55,42 +55,26 @@
 <script>
 // mixins
 import fieldMixin from '@/components/ADempiere/Field/mixin/mixinField.js'
-
-// utils and helper methods
-import { convertBooleanToString } from '@/utils/ADempiere/formatValue/booleanFormat.js'
+import selectMixin from '@/components/ADempiere/Field/mixin/mixinSelect.js'
 
 export default {
   name: 'FieldAutocomplete',
 
   mixins: [
-    fieldMixin
+    fieldMixin,
+    selectMixin
   ],
 
   data() {
-    // label with '' value is assumed to be undefined non-existent
-    const label = ' '
-    const blankOption = {
-      label,
-      id: undefined,
-      uuid: undefined
-    }
-
     return {
       recordsBusinessPartners: [],
       controlDisplayed: this.displayedValue,
       isFocus: false,
-      isLoading: false,
-      optionsList: [blankOption],
-      blankValues: [null, undefined, -1],
-      blankOption,
       timeOut: null
     }
   },
 
   computed: {
-    isSelectMultiple() {
-      return ['IN', 'NOT_IN'].includes(this.metadata.operator) && this.metadata.isAdvancedQuery
-    },
     cssClassStyle() {
       let styleClass = this.metadata.cssClassName + ' custom-field-select'
       if (this.isSelectMultiple) {
@@ -104,36 +88,7 @@ export default {
       }
       return this.$t('quickAccess.searchWithEnter')
     },
-    getterLookupList() {
-      if (this.isEmptyValue(this.metadata.reference.query) ||
-        !this.metadata.displayed) {
-        return [this.blankOption]
-      }
-      return this.$store.getters.getLookupList({
-        parentUuid: this.metadata.parentUuid,
-        containerUuid: this.metadata.containerUuid,
-        query: this.metadata.reference.query,
-        tableName: this.metadata.reference.tableName
-      })
-    },
-    getterLookupAll() {
-      const allOptions = this.$store.getters.getLookupAll({
-        parentUuid: this.metadata.parentUuid,
-        containerUuid: this.metadata.containerUuid,
-        query: this.metadata.reference.query,
-        directQuery: this.metadata.reference.directQuery,
-        tableName: this.metadata.reference.tableName,
-        value: this.value
-      })
 
-      // sets the value to blank when the lookupList or lookupItem have no
-      // values, or if only lookupItem does have a value
-      if (this.isEmptyValue(allOptions) || (allOptions.length &&
-        (!this.blankValues.includes(allOptions[0].id)))) {
-        allOptions.unshift(this.blankOption)
-      }
-      return allOptions
-    },
     value: {
       get() {
         const value = this.$store.getters.getValueOfFieldOnContainer({
@@ -191,23 +146,7 @@ export default {
     }
   },
 
-  created() {
-    this.changeBlankOption()
-  },
-
   methods: {
-    parseValue(value) {
-      if (typeof value === 'boolean') {
-        // value ? 'Y' : 'N'
-        value = convertBooleanToString(value)
-      }
-      return value
-    },
-    changeBlankOption() {
-      if (Number(this.metadata.defaultValue) === -1) {
-        this.blankOption.id = -1
-      }
-    },
     setNewDisplayedValue() {
       this.isFocus = true
       const displayValue = this.displayedValue

--- a/src/components/ADempiere/Field/FieldOptions/index.vue
+++ b/src/components/ADempiere/Field/FieldOptions/index.vue
@@ -235,8 +235,9 @@ export default defineComponent({
         window = window[0]
       }
       let value = valueField.value
+
+      // TODO: Evaluate reference.keyColumnName: AD_Ref_List.Value
       let columnName = props.metadata.columnName
-      // TODO: Evaluate reference.keyColumnName
       if (props.metadata.displayType === LIST.id) {
         columnName = 'AD_Reference_ID'
         const valueQuery = props.metadata.reference.directQuery

--- a/src/components/ADempiere/Field/FieldSelect.vue
+++ b/src/components/ADempiere/Field/FieldSelect.vue
@@ -58,7 +58,6 @@ import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
  * - Table Direct
  *
  * TODO: String values add single quotation marks 'value'
- * TODO: Add support to valuesList filter on proxy-api
  * TODO: No blanck option enabled if is mandatory field
  * TODO: ALL: Although in the future these will have different components, and
  * are currently not supported is also displayed as a substitute for fields:
@@ -115,7 +114,9 @@ export default {
       return this.$store.getters.getStoredLookupList({
         parentUuid: this.metadata.parentUuid,
         containerUuid: this.metadata.containerUuid,
+        contextColumnNames: this.metadata.reference.contextColumnNames,
         uuid: this.metadata.uuid,
+        //
         tableName: this.metadata.reference.tableName,
         columnName: this.metadata.columnName
       })
@@ -124,11 +125,11 @@ export default {
       const allOptions = this.$store.getters.getStoredLookupAll({
         parentUuid: this.metadata.parentUuid,
         containerUuid: this.metadata.containerUuid,
+        contextColumnNames: this.metadata.reference.contextColumnNames,
         uuid: this.metadata.uuid,
+        //
         tableName: this.metadata.reference.tableName,
-        query: this.metadata.reference.query,
-        validationCode: this.metadata.reference.validationCode,
-        directQuery: this.metadata.reference.directQuery,
+        columnName: this.metadata.columnName,
         value: this.value
       })
 
@@ -377,16 +378,18 @@ export default {
       }
     },
     async getDataLookupItem() {
-      if (this.isEmptyValue(this.metadata.reference.directQuery) ||
-        (this.metadata.isAdvancedQuery && this.isSelectMultiple)) {
+      if (this.metadata.isAdvancedQuery && this.isSelectMultiple) {
         return
       }
       this.isLoading = true
       this.$store.dispatch('getLookupItemFromServer', {
         parentUuid: this.metadata.parentUuid,
         containerUuid: this.metadata.containerUuid,
+        contextColumnNames: this.metadata.reference.contextColumnNames,
+        uuid: this.metadata.uuid,
+        //
         tableName: this.metadata.reference.tableName,
-        directQuery: this.metadata.reference.directQuery,
+        columnName: this.metadata.columnName,
         value: this.value
       })
         .then(responseLookupItem => {
@@ -420,13 +423,15 @@ export default {
     },
     remoteMethod() {
       this.isLoading = true
+
       this.containerManager.getLookupList({
         parentUuid: this.metadata.parentUuid,
         containerUuid: this.metadata.containerUuid,
+        contextColumnNames: this.metadata.reference.contextColumnNames,
         uuid: this.metadata.uuid,
         //
-        columnName: this.metadata.columnName,
         tableName: this.metadata.reference.tableName,
+        columnName: this.metadata.columnName,
         // app attributes
         isAddBlankValue: true,
         blankValue: this.blankOption.value
@@ -443,14 +448,14 @@ export default {
         })
     },
     clearLookup() {
-      this.$store.dispatch('deleteLookupList', {
+      this.$store.dispatch('deleteLookup', {
         parentUuid: this.metadata.parentUuid,
         containerUuid: this.metadata.containerUuid,
+        contextColumnNames: this.metadata.reference.contextColumnNames,
         uuid: this.metadata.uuid,
+        //
         tableName: this.metadata.reference.tableName,
-        query: this.metadata.reference.query,
-        directQuery: this.metadata.reference.directQuery,
-        validationCode: this.metadata.reference.validationCode,
+        columnName: this.metadata.columnName,
         value: this.value
       })
         .then(() => {

--- a/src/components/ADempiere/Field/FieldSelect.vue
+++ b/src/components/ADempiere/Field/FieldSelect.vue
@@ -45,10 +45,10 @@
 
 <script>
 // components and mixins
-import FieldMixin from '@/components/ADempiere/Field/mixin/mixinField.js'
+import fieldMixin from '@/components/ADempiere/Field/mixin/mixinField.js'
+import selectMixin from '@/components/ADempiere/Field/mixin/mixinSelect.js'
 
 // utils and helper methods
-import { convertBooleanToString } from '@/utils/ADempiere/formatValue/booleanFormat.js'
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
 
 /**
@@ -67,30 +67,11 @@ export default {
   name: 'FieldSelect',
 
   mixins: [
-    FieldMixin
+    fieldMixin,
+    selectMixin
   ],
 
-  data() {
-    // label with '' value is assumed to be undefined non-existent
-    const label = ' '
-    const blankOption = {
-      label,
-      value: undefined,
-      uuid: undefined
-    }
-
-    return {
-      isLoading: false,
-      optionsList: [blankOption],
-      blankValues: [null, undefined, -1, '-1'],
-      blankOption
-    }
-  },
-
   computed: {
-    isSelectMultiple() {
-      return ['IN', 'NOT_IN'].includes(this.metadata.operator) && this.metadata.isAdvancedQuery
-    },
     cssClassStyle() {
       let styleClass = ' custom-field-select '
       if (this.isSelectMultiple) {
@@ -107,42 +88,7 @@ export default {
 
       return styleClass
     },
-    getLookupList() {
-      if (!this.metadata.displayed) {
-        return [this.blankOption]
-      }
-      return this.$store.getters.getStoredLookupList({
-        parentUuid: this.metadata.parentUuid,
-        containerUuid: this.metadata.containerUuid,
-        contextColumnNames: this.metadata.reference.contextColumnNames,
-        uuid: this.metadata.uuid,
-        id: this.metadata.id,
-        //
-        tableName: this.metadata.reference.tableName,
-        columnName: this.metadata.columnName
-      })
-    },
-    getLookupAll() {
-      const allOptions = this.$store.getters.getStoredLookupAll({
-        parentUuid: this.metadata.parentUuid,
-        containerUuid: this.metadata.containerUuid,
-        contextColumnNames: this.metadata.reference.contextColumnNames,
-        uuid: this.metadata.uuid,
-        id: this.metadata.id,
-        //
-        tableName: this.metadata.reference.tableName,
-        columnName: this.metadata.columnName,
-        value: this.value
-      })
 
-      // sets the value to blank when the lookupList or lookupItem have no
-      // values, or if only lookupItem does have a value
-      if (this.isEmptyValue(allOptions) || (allOptions.length &&
-        (!this.blankValues.includes(allOptions[0].value)))) {
-        allOptions.unshift(this.blankOption)
-      }
-      return allOptions
-    },
     value: {
       get() {
         const { columnName, containerUuid, inTable } = this.metadata
@@ -317,10 +263,6 @@ export default {
     }
   },
 
-  created() {
-    this.changeBlankOption()
-  },
-
   beforeMount() {
     if (this.metadata.displayed) {
       this.optionsList = this.getLookupAll
@@ -348,18 +290,6 @@ export default {
   },
 
   methods: {
-    parseValue(value) {
-      if (typeof value === 'boolean') {
-        // value ? 'Y' : 'N'
-        value = convertBooleanToString(value)
-      }
-      return value
-    },
-    changeBlankOption() {
-      if (Number(this.metadata.defaultValue) === -1) {
-        this.blankOption.value = this.metadata.defaultValue
-      }
-    },
     preHandleChange(value) {
       const { label } = this.findOption(value)
       this.displayedValue = label

--- a/src/components/ADempiere/Field/FieldSelect.vue
+++ b/src/components/ADempiere/Field/FieldSelect.vue
@@ -116,6 +116,7 @@ export default {
         containerUuid: this.metadata.containerUuid,
         contextColumnNames: this.metadata.reference.contextColumnNames,
         uuid: this.metadata.uuid,
+        id: this.metadata.id,
         //
         tableName: this.metadata.reference.tableName,
         columnName: this.metadata.columnName
@@ -127,6 +128,7 @@ export default {
         containerUuid: this.metadata.containerUuid,
         contextColumnNames: this.metadata.reference.contextColumnNames,
         uuid: this.metadata.uuid,
+        id: this.metadata.id,
         //
         tableName: this.metadata.reference.tableName,
         columnName: this.metadata.columnName,
@@ -387,6 +389,7 @@ export default {
         containerUuid: this.metadata.containerUuid,
         contextColumnNames: this.metadata.reference.contextColumnNames,
         uuid: this.metadata.uuid,
+        id: this.metadata.id,
         //
         tableName: this.metadata.reference.tableName,
         columnName: this.metadata.columnName,

--- a/src/components/ADempiere/Field/FieldSelect.vue
+++ b/src/components/ADempiere/Field/FieldSelect.vue
@@ -384,7 +384,8 @@ export default {
         return
       }
       this.isLoading = true
-      this.$store.dispatch('getLookupItemFromServer', {
+
+      this.containerManager.getLookupItem({
         parentUuid: this.metadata.parentUuid,
         containerUuid: this.metadata.containerUuid,
         contextColumnNames: this.metadata.reference.contextColumnNames,

--- a/src/components/ADempiere/Field/mixin/mixinSelect.js
+++ b/src/components/ADempiere/Field/mixin/mixinSelect.js
@@ -1,0 +1,100 @@
+// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// utils and helper methods
+import { convertBooleanToString } from '@/utils/ADempiere/formatValue/booleanFormat.js'
+import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
+
+export default {
+  name: 'MixinFieldSelect',
+
+  data() {
+    return {
+      isLoading: false,
+      optionsList: [],
+      blankValues: [null, undefined, -1, '-1']
+    }
+  },
+
+  computed: {
+    isSelectMultiple() {
+      return ['IN', 'NOT_IN'].includes(this.metadata.operator) && this.metadata.isAdvancedQuery
+    },
+
+    blankOption() {
+      let value
+      if (Number(this.metadata.defaultValue) === -1) {
+        value = this.metadata.defaultValue
+      }
+
+      return {
+        // label with '' value is assumed to be undefined non-existent
+        label: ' ',
+        id: undefined,
+        uuid: undefined,
+        value
+      }
+    },
+    getLookupList() {
+      if (!this.metadata.displayed) {
+        return [this.blankOption]
+      }
+      return this.$store.getters.getStoredLookupList({
+        parentUuid: this.metadata.parentUuid,
+        containerUuid: this.metadata.containerUuid,
+        contextColumnNames: this.metadata.reference.contextColumnNames,
+        uuid: this.metadata.uuid,
+        id: this.metadata.id,
+        //
+        tableName: this.metadata.reference.tableName,
+        columnName: this.metadata.columnName
+      })
+    },
+    getLookupAll() {
+      const allOptions = this.$store.getters.getStoredLookupAll({
+        parentUuid: this.metadata.parentUuid,
+        containerUuid: this.metadata.containerUuid,
+        contextColumnNames: this.metadata.reference.contextColumnNames,
+        uuid: this.metadata.uuid,
+        id: this.metadata.id,
+        //
+        tableName: this.metadata.reference.tableName,
+        columnName: this.metadata.columnName,
+        value: this.value
+      })
+
+      // sets the value to blank when the lookupList or lookupItem have no
+      // values, or if only lookupItem does have a value
+      if (isEmptyValue(allOptions) || (allOptions.length &&
+        // (!this.blankValues.includes(allOptions[0].id)))) {
+        (!this.blankValues.includes(allOptions[0].value)))) {
+        allOptions.unshift(this.blankOption)
+      }
+      return allOptions
+    }
+  },
+
+  methods: {
+    parseValue(value) {
+      if (typeof value === 'boolean') {
+        // value ? 'Y' : 'N'
+        value = convertBooleanToString(value)
+      }
+      return value
+    }
+  }
+
+}

--- a/src/store/modules/ADempiere/data/actions.js
+++ b/src/store/modules/ADempiere/data/actions.js
@@ -171,12 +171,15 @@ const actions = {
             }
 
             // get label (DisplayColumn) from vuex store
-            const options = rootGetters.getLookupAll({
+            const options = rootGetters.getStoredLookupAll({
               parentUuid,
               containerUuid,
+              contextColumnNames: itemField.reference.contextColumnNames,
+              //
+              id: itemField.id,
+              fieldUuid: itemField.uuid,
+              columnName: itemField.columnName,
               tableName: itemField.reference.tableName,
-              query: itemField.reference.query,
-              directQuery: itemField.reference.directQuery,
               value: valueGetDisplayColumn
             })
 
@@ -205,9 +208,12 @@ const actions = {
             const { label } = await dispatch('getLookupItemFromServer', {
               parentUuid,
               containerUuid,
+              contextColumnNames: itemField.reference.contextColumnNames,
+              //
+              id: itemField.id,
+              fieldUuid: itemField.uuid,
               columnName: itemField.columnName,
               tableName: itemField.reference.tableName,
-              directQuery: itemField.reference.directQuery,
               value: valueGetDisplayColumn
             })
             values[itemField.displayColumnName] = label

--- a/src/store/modules/ADempiere/data/actions.js
+++ b/src/store/modules/ADempiere/data/actions.js
@@ -26,7 +26,7 @@ import {
 
 // utils and helper methods
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
-import { convertArrayKeyValueToObject } from '@/utils/ADempiere/valueFormat.js'
+import { convertArrayKeyValueToObject } from '@/utils/ADempiere/formatValue/iterableFormat.js'
 import { typeValue } from '@/utils/ADempiere/valueUtils.js'
 import {
   getPreference

--- a/src/store/modules/ADempiere/lookupManager.js
+++ b/src/store/modules/ADempiere/lookupManager.js
@@ -107,19 +107,19 @@ const lookupManager = {
       parentUuid,
       containerUuid,
       contextColumnNames,
-      uuid,
+      fieldUuid,
+      processParameterUuid,
+      browseFieldUuid,
       id,
       //
       referenceUuid,
-      searchValue,
       //
       tableName,
       columnName,
-      columnUuid,
-      value
+      columnUuid
     }) {
       return new Promise(resolve => {
-        if (isEmptyValue(id) && isEmptyValue(uuid)) {
+        if (isEmptyValue(id) && isEmptyValue(fieldUuid)) {
           resolve()
           return
         }
@@ -133,17 +133,16 @@ const lookupManager = {
 
         requestLookup({
           contextAttributesList,
-          uuid,
+          fieldUuid,
+          processParameterUuid,
+          browseFieldUuid,
           id,
           //
           referenceUuid,
-          searchValue,
           //
           tableName,
           columnName,
-          columnUuid,
-          //
-          value
+          columnUuid
         })
           .then(lookupItemResponse => {
             const {
@@ -152,16 +151,22 @@ const lookupManager = {
             const option = {
               label: isEmptyValue(label) ? ' ' : label,
               uuid: lookupItemResponse.uuid,
-              value // lookupItemResponse.values.KeyColumn
+              value: lookupItemResponse.values.KeyColumn
             }
 
             const clientId = rootGetters.getPreferenceClientId
 
-            let key = `${clientId}|${uuid}`
+            let key = clientId
+            if (!isEmptyValue(fieldUuid)) {
+              key += `|${fieldUuid}`
+            } else if (!isEmptyValue(processParameterUuid)) {
+              key += `|${processParameterUuid}`
+            } else if (!isEmptyValue(browseFieldUuid)) {
+              key += `|${browseFieldUuid}`
+            }
 
             const contextKey = generateContextKey(contextAttributesList)
             key += contextKey
-            key += `|${value}`
 
             commit('setLookupItem', {
               parentUuid, // used by suscription filter
@@ -169,7 +174,7 @@ const lookupManager = {
               key,
               contextAttributesList,
               option,
-              value, // isNaN(value) ? value : parseInt(value, 10),
+              value: option.value, // isNaN(value) ? value : parseInt(value, 10),
               clientId: rootGetters.getPreferenceClientId
             })
 
@@ -336,8 +341,7 @@ const lookupManager = {
       containerUuid,
       contextColumnNames = [],
       contextAttributesList = [],
-      uuid,
-      value
+      uuid
     }) => {
       const clientId = rootGetters.getPreferenceClientId
       let key = `${clientId}|${uuid}`
@@ -352,8 +356,6 @@ const lookupManager = {
       }
       const contextKey = generateContextKey(contextAttributesList)
       key += contextKey
-
-      key += `|${value}`
 
       const lookupItem = state.lookupItem[key]
       if (lookupItem) {
@@ -399,8 +401,7 @@ const lookupManager = {
       parentUuid,
       containerUuid,
       contextColumnNames,
-      uuid,
-      value
+      uuid
     }) => {
       const contextAttributesList = getContextAttributes({
         parentUuid,
@@ -424,8 +425,7 @@ const lookupManager = {
           containerUuid,
           contextColumnNames,
           contextAttributesList,
-          uuid,
-          value
+          uuid
         })
 
         // add a item option

--- a/src/store/modules/ADempiere/lookupManager.js
+++ b/src/store/modules/ADempiere/lookupManager.js
@@ -21,11 +21,23 @@ import { requestLookup, requestLookupList } from '@/api/ADempiere/window.js'
 
 // utils and helper methods
 import { isEmptyValue } from '@/utils/ADempiere/valueUtils.js'
-import { parseContext, getContextAttributes } from '@/utils/ADempiere/contextUtils.js'
+import { getContextAttributes } from '@/utils/ADempiere/contextUtils.js'
 
 const initStateLookup = {
   lookupItem: {},
   lookupList: {}
+}
+
+function generateContextKey(contextAttributes = []) {
+  let contextKey = ''
+  if (isEmptyValue(contextAttributes)) {
+    return contextKey
+  }
+
+  contextAttributes.map(attribute => {
+    contextKey += '|' + attribute.columnName + '|' + attribute.value
+  })
+  return '_' + contextKey
 }
 
 const lookupManager = {
@@ -35,17 +47,13 @@ const lookupManager = {
   mutations: {
     setLookupItem(state, {
       clientId,
-      parsedDirectQuery,
-      tableName,
+      key,
       option,
       value
     }) {
-      const key = `${clientId}_${tableName}_${parsedDirectQuery}_${value}`
-
       Vue.set(state.lookupItem, key, {
         clientId,
-        tableName,
-        parsedDirectQuery,
+        key,
         option,
         value
       })
@@ -98,7 +106,15 @@ const lookupManager = {
     getLookupItemFromServer({ commit, rootGetters }, {
       parentUuid,
       containerUuid,
+      contextColumnNames,
+      uuid,
+      //
+      referenceUuid,
+      searchValue,
+      //
       tableName,
+      columnName,
+      columnUuid,
       directQuery,
       value
     }) {
@@ -108,19 +124,24 @@ const lookupManager = {
           return
         }
 
-        let parsedDirectQuery = directQuery
-        if (directQuery.includes('@')) {
-          parsedDirectQuery = parseContext({
-            parentUuid,
-            containerUuid,
-            value: directQuery,
-            isBooleanToString: true
-          }).value
-        }
+        const contextAttributesList = getContextAttributes({
+          parentUuid,
+          containerUuid,
+          contextColumnNames,
+          isBooleanToString: true
+        })
 
         requestLookup({
+          contextAttributesList,
+          uuid,
+          //
+          referenceUuid,
+          searchValue,
+          //
           tableName,
-          directQuery: parsedDirectQuery,
+          columnName,
+          columnUuid,
+          //
           value
         })
           .then(lookupItemResponse => {
@@ -133,13 +154,21 @@ const lookupManager = {
               value // lookupItemResponse.values.KeyColumn
             }
 
+            const clientId = rootGetters.getPreferenceClientId
+
+            let key = `${clientId}|${uuid}`
+
+            const contextKey = generateContextKey(contextAttributesList)
+            key += contextKey
+            key += `|${value}`
+
             commit('setLookupItem', {
               parentUuid, // used by suscription filter
               containerUuid, // used by suscription filter
+              key,
+              contextAttributesList,
               option,
               value, // isNaN(value) ? value : parseInt(value, 10),
-              parsedDirectQuery: directQuery,
-              tableName,
               clientId: rootGetters.getPreferenceClientId
             })
 
@@ -168,10 +197,13 @@ const lookupManager = {
       fieldUuid,
       processParameterUuid,
       browseFieldUuid,
+      //
       referenceUuid,
+      searchValue,
+      //
       tableName,
       columnName,
-      searchValue
+      columnUuid
     }) {
       return new Promise(resolve => {
         if (isEmptyValue(fieldUuid) && isEmptyValue(processParameterUuid) && isEmptyValue(browseFieldUuid)) {
@@ -182,7 +214,8 @@ const lookupManager = {
         const contextAttributesList = getContextAttributes({
           parentUuid,
           containerUuid,
-          contextColumnNames
+          contextColumnNames,
+          isBooleanToString: true
         })
 
         requestLookupList({
@@ -190,10 +223,13 @@ const lookupManager = {
           fieldUuid,
           processParameterUuid,
           browseFieldUuid,
+          //
           referenceUuid,
+          searchValue,
+          //
           tableName,
           columnName,
-          searchValue
+          columnUuid
         })
           .then(lookupListResponse => {
             const optionsList = []
@@ -224,21 +260,15 @@ const lookupManager = {
 
             let key = clientId
             if (!isEmptyValue(fieldUuid)) {
-              key += `_${fieldUuid}`
+              key += `|${fieldUuid}`
             } else if (!isEmptyValue(processParameterUuid)) {
-              key += `_${processParameterUuid}`
+              key += `|${processParameterUuid}`
             } else if (!isEmptyValue(browseFieldUuid)) {
-              key += `_${browseFieldUuid}`
+              key += `|${browseFieldUuid}`
             }
 
-            if (!isEmptyValue(contextAttributesList)) {
-              let contextKey = ''
-              contextAttributesList.map(attribute => {
-                contextKey += '_' + attribute.columnName + '_' + attribute.value
-              })
-
-              key += '_' + contextKey
-            }
+            const contextKey = generateContextKey(contextAttributesList)
+            key += contextKey
 
             commit('setLookupList', {
               clientId,
@@ -257,54 +287,41 @@ const lookupManager = {
       })
     },
 
-    deleteLookupList({ commit, rootGetters }, {
+    deleteLookup({ commit, rootGetters }, {
       parentUuid,
       containerUuid,
       uuid,
       contextColumnNames = [],
-      tableName,
-      directQuery,
       value
     }) {
       return new Promise(resolve => {
         const clientId = rootGetters.getPreferenceClientId
 
-        let parsedDirectQuery = directQuery
-        if (directQuery && parsedDirectQuery.includes('@')) {
-          parsedDirectQuery = parseContext({
-            parentUuid,
-            containerUuid,
-            value: directQuery,
-            isBooleanToString: true
-          }).value
-        }
-        commit('deleteLookupItem', {
-          clientId,
-          tableName,
-          parsedDirectQuery,
-          value
-        })
-
-        let key = clientId
-        if (!isEmptyValue(uuid)) {
-          key += `_${uuid}`
-        }
-
         const contextAttributesList = getContextAttributes({
           parentUuid,
           containerUuid,
-          contextColumnNames
+          contextColumnNames,
+          isBooleanToString: true
         })
-        if (!isEmptyValue(contextAttributesList)) {
-          let contextKey = ''
-          contextAttributesList.map(attribute => {
-            contextKey += '_' + attribute.columnName + '_' + attribute.value
-          })
+        let keyItem = `${clientId}|${uuid}`
 
-          key += '_' + contextKey
+        const contextKey = generateContextKey(contextAttributesList)
+        keyItem += contextKey
+        keyItem += `|${value}`
+
+        commit('deleteLookupItem', {
+          key: keyItem
+        })
+
+        let keyList = clientId
+        if (!isEmptyValue(uuid)) {
+          keyList += `|${uuid}`
         }
+
+        keyList += contextKey
+
         commit('deleteLookupList', {
-          key
+          key: keyList
         })
 
         resolve()
@@ -316,22 +333,26 @@ const lookupManager = {
     getStoredLookupItem: (state, getters, rootState, rootGetters) => ({
       parentUuid,
       containerUuid,
-      tableName,
-      directQuery,
+      contextColumnNames = [],
+      contextAttributesList = [],
+      uuid,
       value
     }) => {
-      let parsedDirectQuery = directQuery
-      if (!isEmptyValue(parsedDirectQuery) && parsedDirectQuery.includes('@')) {
-        parsedDirectQuery = parseContext({
+      const clientId = rootGetters.getPreferenceClientId
+      let key = `${clientId}|${uuid}`
+
+      if (isEmptyValue(contextAttributesList) && !isEmptyValue(contextColumnNames)) {
+        contextAttributesList = getContextAttributes({
           parentUuid,
           containerUuid,
-          value: directQuery,
+          contextColumnNames,
           isBooleanToString: true
-        }).value
+        })
       }
+      const contextKey = generateContextKey(contextAttributesList)
+      key += contextKey
 
-      const clientId = rootGetters.getPreferenceClientId
-      const key = `${clientId}_${tableName}_${parsedDirectQuery}_${value}`
+      key += `|${value}`
 
       const lookupItem = state.lookupItem[key]
       if (lookupItem) {
@@ -343,28 +364,25 @@ const lookupManager = {
     getStoredLookupList: (state, getters, rootState, rootGetters) => ({
       parentUuid,
       containerUuid,
-      uuid,
-      contextColumnNames = []
+      contextColumnNames = [],
+      contextAttributesList = [],
+      uuid
     }) => {
       let key = rootGetters.getPreferenceClientId
       if (!isEmptyValue(uuid)) {
-        key += `_${uuid}`
+        key += `|${uuid}`
       }
 
-      const contextAttributesList = getContextAttributes({
-        parentUuid,
-        containerUuid,
-        contextColumnNames
-      })
-
-      if (!isEmptyValue(contextAttributesList)) {
-        let contextKey = ''
-        contextAttributesList.map(attribute => {
-          contextKey += '_' + attribute.columnName + '_' + attribute.value
+      if (isEmptyValue(contextAttributesList) && !isEmptyValue(contextColumnNames)) {
+        contextAttributesList = getContextAttributes({
+          parentUuid,
+          containerUuid,
+          contextColumnNames,
+          isBooleanToString: true
         })
-
-        key += '_' + contextKey
       }
+      const contextKey = generateContextKey(contextAttributesList)
+      key += contextKey
 
       const lookupList = state.lookupList[key]
       if (lookupList) {
@@ -379,15 +397,23 @@ const lookupManager = {
     getStoredLookupAll: (state, getters) => ({
       parentUuid,
       containerUuid,
+      contextColumnNames,
       uuid,
-      tableName,
-      directQuery,
       value
     }) => {
+      const contextAttributesList = getContextAttributes({
+        parentUuid,
+        containerUuid,
+        contextColumnNames,
+        isBooleanToString: true
+      })
+
       const optionsList = getters.getStoredLookupList({
         parentUuid,
         containerUuid,
-        uuid
+        uuid,
+        contextColumnNames,
+        contextAttributesList
       })
 
       // set item values getter from server into list
@@ -395,8 +421,9 @@ const lookupManager = {
         const option = getters.getStoredLookupItem({
           parentUuid,
           containerUuid,
-          tableName,
-          directQuery,
+          contextColumnNames,
+          contextAttributesList,
+          uuid,
           value
         })
 

--- a/src/store/modules/ADempiere/lookupManager.js
+++ b/src/store/modules/ADempiere/lookupManager.js
@@ -203,6 +203,7 @@ const lookupManager = {
       fieldUuid,
       processParameterUuid,
       browseFieldUuid,
+      id,
       //
       referenceUuid,
       searchValue,
@@ -229,6 +230,7 @@ const lookupManager = {
           fieldUuid,
           processParameterUuid,
           browseFieldUuid,
+          id,
           //
           referenceUuid,
           searchValue,

--- a/src/store/modules/ADempiere/lookupManager.js
+++ b/src/store/modules/ADempiere/lookupManager.js
@@ -108,6 +108,7 @@ const lookupManager = {
       containerUuid,
       contextColumnNames,
       uuid,
+      id,
       //
       referenceUuid,
       searchValue,
@@ -115,11 +116,10 @@ const lookupManager = {
       tableName,
       columnName,
       columnUuid,
-      directQuery,
       value
     }) {
       return new Promise(resolve => {
-        if (isEmptyValue(directQuery)) {
+        if (isEmptyValue(id) && isEmptyValue(uuid)) {
           resolve()
           return
         }
@@ -134,6 +134,7 @@ const lookupManager = {
         requestLookup({
           contextAttributesList,
           uuid,
+          id,
           //
           referenceUuid,
           searchValue,

--- a/src/store/modules/ADempiere/panel/getters.js
+++ b/src/store/modules/ADempiere/panel/getters.js
@@ -324,13 +324,14 @@ const getters = {
           const { displayColumnName } = fieldItem
           let displayedValue
           if (!isEmptyValue(parsedDefaultValue)) {
-            const { tableName, directQuery, query } = fieldItem.reference
+            const { tableName, contextColumnNames } = fieldItem.reference
             const optionsList = rootGetters.getStoredLookupAll({
               parentUuid,
               containerUuid,
-              directQuery,
+              contextColumnNames,
+              id: fieldItem.id,
+              uuid: fieldItem.uuid,
               tableName,
-              query,
               value: parsedDefaultValue
             })
             if (!isEmptyValue(optionsList)) {

--- a/src/utils/ADempiere/apiConverts/persistence.js
+++ b/src/utils/ADempiere/apiConverts/persistence.js
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { convertArrayKeyValueToObject } from '@/utils/ADempiere/valueFormat.js'
+import { convertArrayKeyValueToObject } from '@/utils/ADempiere/formatValue/iterableFormat.js'
 import { camelizeObjectKeys } from '../transformObject'
 
 export function convertEntityList(entityList) {

--- a/src/utils/ADempiere/contextUtils.js
+++ b/src/utils/ADempiere/contextUtils.js
@@ -38,6 +38,7 @@ export const getContext = ({
   parentUuid,
   containerUuid,
   isBooleanToString = false,
+  isForceBoolean = true,
   columnName
 }) => {
   let value
@@ -62,7 +63,7 @@ export const getContext = ({
   }
 
   if (isBooleanToString) {
-    return convertBooleanToString(value)
+    return convertBooleanToString(value, isForceBoolean)
   }
 
   return value
@@ -313,7 +314,9 @@ export function parseContext({
 export function getContextAttributes({
   parentUuid,
   containerUuid,
-  contextColumnNames = []
+  contextColumnNames = [],
+  isBooleanToString = false,
+  isForceBoolean = false
 }) {
   const contextAttributesList = []
   if (isEmptyValue(contextColumnNames)) {
@@ -324,7 +327,9 @@ export function getContextAttributes({
     const value = getContext({
       parentUuid,
       containerUuid,
-      columnName
+      columnName,
+      isBooleanToString,
+      isForceBoolean
     })
 
     contextAttributesList.push({

--- a/src/utils/ADempiere/contextUtils.js
+++ b/src/utils/ADempiere/contextUtils.js
@@ -138,7 +138,7 @@ export function getPreference({
  * @param {string} displayLogic
  * @param {string} mandatoryLogic
  * @param {string} readOnlyLogic
- * @param {object} reference
+ * @param {object} reference.contextColumnNames array
  * @param {string} defaultValue
  * @returns {array} List column name of parent fields
  */
@@ -149,12 +149,10 @@ export function getParentFields({
   reference,
   defaultValue
 }) {
-  const validationCode = []
+  let contextColumnNames = []
   //  Validate reference
-  if (!isEmptyValue(reference) && !isEmptyValue(reference.validationCode)) {
-    validationCode.push(
-      ...evaluator.parseDepends(reference.validationCode)
-    )
+  if (!isEmptyValue(reference) && !isEmptyValue(reference.contextColumnNames)) {
+    contextColumnNames = reference.contextColumnNames
   }
   const parentFields = Array.from(new Set([
     //  For Display logic
@@ -165,8 +163,8 @@ export function getParentFields({
     ...evaluator.parseDepends(readOnlyLogic),
     //  For Default Value
     ...evaluator.parseDepends(defaultValue),
-    //  For Validation Code
-    ...validationCode
+    //  For Validation Code / SQL values
+    ...contextColumnNames
   ]))
 
   return parentFields

--- a/src/utils/ADempiere/formatValue/booleanFormat.js
+++ b/src/utils/ADempiere/formatValue/booleanFormat.js
@@ -31,15 +31,19 @@ export const convertBooleanToTranslationLang = (booleanValue) => {
 
 /**
  * Convert boolean value to string value
- * @param {boolean} booleanValue
+ * @param {boolean|string} booleanValue
+ * @param {boolean} isForce
  * @returns {strin}
  */
-export const convertBooleanToString = (booleanValue) => {
+export const convertBooleanToString = (booleanValue, isForce = true) => {
   if (booleanValue === true || booleanValue === 'true' || booleanValue === 'Y') {
     return 'Y'
   }
+  if (isForce) {
+    return 'N'
+  }
 
-  return 'N'
+  return booleanValue
 }
 
 /**

--- a/src/utils/ADempiere/formatValue/iterableFormat.js
+++ b/src/utils/ADempiere/formatValue/iterableFormat.js
@@ -1,0 +1,59 @@
+// ADempiere-Vue (Frontend) for ADempiere ERP & CRM Smart Business Solution
+// Copyright (C) 2017-Present E.R.P. Consultores y Asociados, C.A.
+// Contributor(s): Edwin Betancourt EdwinBetanc0urt@outlook.com www.erpya.com
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { isEmptyValue } from '@/utils/ADempiere/valueUtils'
+
+/**
+ * Convert array pairs of object to literal object { key: value }
+ * @param {array} array, Array to convert
+ * @param {string} keyName, name from key in pairs
+ * @param {string} valueName, name from value in pairs
+ * @returns {object} { key: value, key2: value2 }
+ */
+export function convertArrayKeyValueToObject({
+  array,
+  keyName = 'columnName',
+  valueName = 'value'
+}) {
+  const result = {}
+  array.forEach(element => {
+    result[element[keyName]] = element[valueName]
+  })
+
+  return result
+}
+
+/**
+ * Return key_value_key2_value_2
+ * @param {object} object
+ * @param {string} separathor
+ * @returns {string}
+ */
+export function convertObjectToString({
+  object = {},
+  separathor = ''
+}) {
+  if (isEmptyValue(object)) {
+    return separathor
+  }
+
+  let str = ''
+  Object.keys(key => {
+    str += separathor + key + object[key]
+  })
+
+  return str
+}

--- a/src/utils/ADempiere/lookupFactory.js
+++ b/src/utils/ADempiere/lookupFactory.js
@@ -319,9 +319,8 @@ export function getFieldTemplate(overwriteDefinition) {
     reference: {
       tableName: '',
       keyColumnName: '',
-      query: '',
-      directQuery: '',
-      validationCode: '',
+      displayColumnName: '',
+      contextColumnNames: [],
       zoomWindows: []
     },
     contextInfo: undefined,

--- a/src/utils/ADempiere/valueFormat.js
+++ b/src/utils/ADempiere/valueFormat.js
@@ -45,26 +45,6 @@ export function convertObjectToKeyValue({
 }
 
 /**
- * Convert array pairs of object to literal object { key: value }
- * @param {array} array, Array to convert
- * @param {string} keyName, name from key in pairs
- * @param {string} valueName, name from value in pairs
- * @returns {object} { key: value, key2: value2 }
- */
-export function convertArrayKeyValueToObject({
-  array,
-  keyName = 'columnName',
-  valueName = 'value'
-}) {
-  const result = {}
-  array.forEach(element => {
-    result[element[keyName]] = element[valueName]
-  })
-
-  return result
-}
-
-/**
  * Convert map of pairs to literal object
  * @param {object} object
  * @returns {map}

--- a/src/views/ADempiere/Browser/index.vue
+++ b/src/views/ADempiere/Browser/index.vue
@@ -312,6 +312,17 @@ export default defineComponent({
         })
       },
 
+      getLookupItem({ parentUuid, containerUuid, uuid, id, contextColumnNames, columnName }) {
+        return store.dispatch('getLookupItemFromServer', {
+          parentUuid,
+          containerUuid,
+          contextColumnNames,
+          browseFieldUuid: uuid,
+          id,
+          //
+          columnName
+        })
+      },
       getLookupList({ parentUuid, containerUuid, contextColumnNames, uuid }) {
         return store.dispatch('getLookupListFromServer', {
           parentUuid,

--- a/src/views/ADempiere/Browser/index.vue
+++ b/src/views/ADempiere/Browser/index.vue
@@ -312,10 +312,11 @@ export default defineComponent({
         })
       },
 
-      getLookupList({ parentUuid, containerUuid, uuid }) {
+      getLookupList({ parentUuid, containerUuid, contextColumnNames, uuid }) {
         return store.dispatch('getLookupListFromServer', {
           parentUuid,
           containerUuid,
+          contextColumnNames,
           browseFieldUuid: uuid
         })
       }

--- a/src/views/ADempiere/Process/mixinProcess.js
+++ b/src/views/ADempiere/Process/mixinProcess.js
@@ -65,6 +65,17 @@ export default (processUuid) => {
       })
     },
 
+    getLookupItem({ parentUuid, containerUuid, uuid, id, contextColumnNames, columnName }) {
+      return store.dispatch('getLookupItemFromServer', {
+        parentUuid,
+        containerUuid,
+        contextColumnNames,
+        processParameterUuid: uuid,
+        id,
+        //
+        columnName
+      })
+    },
     getLookupList({ parentUuid, containerUuid, contextColumnNames, uuid }) {
       return store.dispatch('getLookupListFromServer', {
         parentUuid,

--- a/src/views/ADempiere/Process/mixinProcess.js
+++ b/src/views/ADempiere/Process/mixinProcess.js
@@ -65,10 +65,11 @@ export default (processUuid) => {
       })
     },
 
-    getLookupList({ parentUuid, containerUuid, uuid }) {
+    getLookupList({ parentUuid, containerUuid, contextColumnNames, uuid }) {
       return store.dispatch('getLookupListFromServer', {
         parentUuid,
         containerUuid,
+        contextColumnNames,
         processParameterUuid: uuid
       })
     }

--- a/src/views/ADempiere/Report/mixinReport.js
+++ b/src/views/ADempiere/Report/mixinReport.js
@@ -65,10 +65,11 @@ export default (reportUuid) => {
       })
     },
 
-    getLookupList({ parentUuid, containerUuid, uuid }) {
+    getLookupList({ parentUuid, containerUuid, contextColumnNames, uuid }) {
       return store.dispatch('getLookupListFromServer', {
         parentUuid,
         containerUuid,
+        contextColumnNames,
         processParameterUuid: uuid
       })
     }

--- a/src/views/ADempiere/Report/mixinReport.js
+++ b/src/views/ADempiere/Report/mixinReport.js
@@ -65,6 +65,17 @@ export default (reportUuid) => {
       })
     },
 
+    getLookupItem({ parentUuid, containerUuid, uuid, id, contextColumnNames, columnName }) {
+      return store.dispatch('getLookupItemFromServer', {
+        parentUuid,
+        containerUuid,
+        contextColumnNames,
+        processParameterUuid: uuid,
+        id,
+        //
+        columnName
+      })
+    },
     getLookupList({ parentUuid, containerUuid, contextColumnNames, uuid }) {
       return store.dispatch('getLookupListFromServer', {
         parentUuid,

--- a/src/views/ADempiere/Window/index.vue
+++ b/src/views/ADempiere/Window/index.vue
@@ -294,10 +294,11 @@ export default defineComponent({
         })
       },
 
-      getLookupList({ parentUuid, containerUuid, uuid }) {
+      getLookupList({ parentUuid, containerUuid, uuid, contextColumnNames }) {
         return store.dispatch('getLookupListFromServer', {
           parentUuid,
           containerUuid,
+          contextColumnNames,
           fieldUuid: uuid
         })
       }

--- a/src/views/ADempiere/Window/index.vue
+++ b/src/views/ADempiere/Window/index.vue
@@ -294,12 +294,24 @@ export default defineComponent({
         })
       },
 
-      getLookupList({ parentUuid, containerUuid, uuid, contextColumnNames }) {
+      getLookupItem({ parentUuid, containerUuid, uuid, id, contextColumnNames, columnName }) {
+        return store.dispatch('getLookupItemFromServer', {
+          parentUuid,
+          containerUuid,
+          contextColumnNames,
+          fieldUuid: uuid,
+          id,
+          //
+          columnName
+        })
+      },
+      getLookupList({ parentUuid, containerUuid, uuid, id, contextColumnNames }) {
         return store.dispatch('getLookupListFromServer', {
           parentUuid,
           containerUuid,
           contextColumnNames,
-          fieldUuid: uuid
+          fieldUuid: uuid,
+          id
         })
       }
 


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open any window.
2. Select `Create New` action menu.
3. See `Client` and `Organization` fields.


Previously the lookup display value was implemented using sql, now only the context columns are used and their values are sent to the server, reducing the use of sql on the client side and making the application more secure.

#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
fix https://github.com/adempiere/adempiere-vue/issues/1722
