### PR TITLE
fix: Router link deprecated prop.

### DIFF
--- a/src/layout/components/Sidebar/Link.vue
+++ b/src/layout/components/Sidebar/Link.vue
@@ -1,7 +1,12 @@
 <template>
-  <component :is="type" v-bind="linkProps(to)">
+  <a v-if="isExternal" :href="to" target="_blank" rel="noopener">
     <slot />
-  </component>
+  </a>
+  <router-link v-else v-slot="{ navigate }" :to="to" custom>
+    <span role="link" @click="navigate" @keypress.enter="navigate">
+      <slot />
+    </span>
+  </router-link>
 </template>
 
 <script>

--- a/src/layout/components/TagsView/index.vue
+++ b/src/layout/components/TagsView/index.vue
@@ -10,8 +10,10 @@
       >
         <router-link
           v-for="tag in visitedViews"
+          v-slot="{ navigate }"
           ref="tag"
           :key="tag.path"
+          custom
           :class="isActive(tag)?'active':''"
           :to="{
             name: tag.name,
@@ -25,15 +27,21 @@
           @click.middle.native="!isAffix(tag) ? closeSelectedTag(tag) : ''"
           @contextmenu.prevent.native="openMenu(tag,$event)"
         >
-          <div class="tag-title">{{ generateTitle(tag.title) }}</div>
-          <div v-if="!tag.meta.affix" class="el-icon-close" @click.prevent.stop="closeSelectedTag(tag)" />
+          <span role="link" @click="navigate" @keypress.enter="navigate">
+            <div class="tag-title">
+              {{ generateTitle(tag.title) }}
+            </div>
+            <div v-if="!tag.meta.affix" class="el-icon-close" @click.prevent.stop="closeSelectedTag(tag)" />
+          </span>
         </router-link>
       </draggable>
       <router-link
         v-for="tag in visitedViews"
         v-else
+        v-slot="{ navigate }"
         ref="tag"
         :key="tag.path"
+        custom
         :class="isActive(tag)?'active':''"
         :to="{ name: tag.name, path: tag.path, query: tag.query, fullPath: tag.fullPath, params: tag.params }"
         tag="span"
@@ -41,8 +49,10 @@
         @click.middle.native="!isAffix(tag)?closeSelectedTag(tag):''"
         @contextmenu.prevent.native="openMenu(tag,$event)"
       >
-        {{ generateTitle(tag.title) }}
-        <span v-if="!isAffix(tag)" class="el-icon-close" @click.prevent.stop="closeSelectedTag(tag)" />
+        <span role="link" @click="navigate" @keypress.enter="navigate">
+          {{ generateTitle(tag.title) }}
+          <span v-if="!isAffix(tag)" class="el-icon-close" @click.prevent.stop="closeSelectedTag(tag)" />
+        </span>
       </router-link>
     </scroll-pane>
     <ul v-show="visible" :style="{left:left+'px',top:top+'px'}" class="contextmenu">


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Login with any role.

#### Screenshot or Gif
Before this changes:

https://user-images.githubusercontent.com/20288327/161530553-854df958-4fd7-496d-a518-cf7527354e60.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/161530609-9b534945-ca2c-4e1d-8dcd-9d08975bfce6.mp4


#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.


#### Additional context
```[vue-router] <router-link>'s tag prop is deprecated and has been removed in Vue Router 4. Use the v-slot API to remove this warning: https://next.router.vuejs.org/guide/migration/#removal-of-event-and-tag-props-in-router-link.```
