### PR TITLE
fix: Validate context columns.

### DIFF
--- a/src/api/ADempiere/user-interface/persistence.js
+++ b/src/api/ADempiere/user-interface/persistence.js
@@ -32,7 +32,7 @@ export function getEntities({
   tabUuid,
   conditions = [],
   columns = [],
-  attributes = [],
+  contextAttributesList = [],
   sorting = [],
   filters,
   pageToken,
@@ -52,13 +52,13 @@ export function getEntities({
   }
 
   // context attributes
-  if (!isEmptyValue(attributes)) {
-    attributes.forEach(attributeValue => {
-      filters.push({
-        column_name: attributeValue.columnName,
-        operator: attributeValue.operator,
-        value: attributeValue.value
-      })
+  let contextAttributes = []
+  if (!isEmptyValue(contextAttributesList)) {
+    contextAttributes = contextAttributesList.map(attribute => {
+      return {
+        key: attribute.columnName,
+        value: attribute.value
+      }
     })
   }
 
@@ -78,6 +78,7 @@ export function getEntities({
     params: {
       window_uuid: windowUuid,
       tab_uuid: tabUuid,
+      context_attributes: contextAttributes,
       // DSL Query
       filters,
       columns,

--- a/src/store/modules/ADempiere/windowManager.js
+++ b/src/store/modules/ADempiere/windowManager.js
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import Vue from 'vue'
+import language from '@/lang'
 import router from '@/router'
 
 // api request methods
@@ -31,6 +32,7 @@ import { ROW_ATTRIBUTES } from '@/utils/ADempiere/constants/table'
 // utils and helper methods
 import { getContextAttributes } from '@/utils/ADempiere/contextUtils.js'
 import { isEmptyValue, generatePageToken } from '@/utils/ADempiere/valueUtils.js'
+import { showMessage } from '@/utils/ADempiere/notification'
 
 const initState = {
   tabData: {}
@@ -95,23 +97,34 @@ const windowManager = {
       filters = [],
       pageNumber
     }) {
-      let pageToken
-      if (!isEmptyValue(pageNumber)) {
-        pageNumber-- // TODO: Remove with fix in backend
-        const token = getters.getTabPageToken({ containerUuid })
-        pageToken = generatePageToken({ pageNumber, token })
-      }
-
-      const { contextColumnNames } = rootGetters.getStoredTab(parentUuid, containerUuid)
-
-      // get context values
-      const contextAttributesList = getContextAttributes({
-        parentUuid,
-        containerUuid,
-        contextColumnNames
-      })
-
       return new Promise(resolve => {
+        let pageToken
+        if (!isEmptyValue(pageNumber)) {
+          pageNumber-- // TODO: Remove with fix in backend
+          const token = getters.getTabPageToken({ containerUuid })
+          pageToken = generatePageToken({ pageNumber, token })
+        }
+
+        const { contextColumnNames } = rootGetters.getStoredTab(parentUuid, containerUuid)
+
+        // get context values
+        const contextAttributesList = getContextAttributes({
+          parentUuid,
+          containerUuid,
+          contextColumnNames
+        })
+
+        const isWithoutValues = contextAttributesList.find(attribute => isEmptyValue(attribute.value))
+        if (isWithoutValues) {
+          console.warn(`Without response, fill the ${isWithoutValues.columnName} field.`)
+          showMessage({
+            message: language.t('notifications.mandatoryFieldMissing') + isWithoutValues.columnName,
+            type: 'info'
+          })
+          resolve([])
+          return
+        }
+
         getEntities({
           windowUuid: parentUuid,
           tabUuid: containerUuid,

--- a/src/store/modules/ADempiere/windowManager.js
+++ b/src/store/modules/ADempiere/windowManager.js
@@ -105,7 +105,7 @@ const windowManager = {
           pageToken = generatePageToken({ pageNumber, token })
         }
 
-        const { contextColumnNames } = rootGetters.getStoredTab(parentUuid, containerUuid)
+        const { contextColumnNames, name } = rootGetters.getStoredTab(parentUuid, containerUuid)
 
         // get context values
         const contextAttributesList = getContextAttributes({
@@ -116,7 +116,7 @@ const windowManager = {
 
         const isWithoutValues = contextAttributesList.find(attribute => isEmptyValue(attribute.value))
         if (isWithoutValues) {
-          console.warn(`Without response, fill the ${isWithoutValues.columnName} field.`)
+          console.warn(`Without response, fill the **${isWithoutValues.columnName}** field in **${name}** tab.`)
           showMessage({
             message: language.t('notifications.mandatoryFieldMissing') + isWithoutValues.columnName,
             type: 'info'
@@ -128,7 +128,7 @@ const windowManager = {
         getEntities({
           windowUuid: parentUuid,
           tabUuid: containerUuid,
-          attributes: contextAttributesList,
+          contextAttributesList,
           filters,
           pageToken
         })


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Entity Type` window.
2. Show console and network in devtools web browser.

`
org.postgresql.util.PSQLException: ERROR: column ad_modification.ad_entitytype_id does not exist  Position: 185, SQL=SELECT COUNT(*) FROM AD_Modification AS AD_Modification LEFT JOIN AD_EntityType AS EntityType_AD_EntityType ON(EntityType_AD_EntityType.EntityType = AD_Modification.EntityType) WHERE (AD_Modification.AD_EntityType_ID=?) AND AD_Modification.AD_Client_ID=0 AND AD_Modification.AD_Org_ID=0 AND (AD_Modification.AD_Modification_ID IS NULL OR AD_Modification.AD_Modification_ID NOT IN ( SELECT Record_ID FROM AD_Private_Access WHERE AD_Table_ID = 883 AND AD_User_ID <> 100 AND IsActive = 'Y' ))
`

#### Screenshot or Gif
Before this changes

https://user-images.githubusercontent.com/20288327/161890888-26ff5655-fc62-42a0-8d69-40972c41b0e3.mp4

After this changes

https://user-images.githubusercontent.com/20288327/161890550-cf8dd452-bc53-4514-9b87-2122c5c43fb5.mp4

#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
Depends on https://github.com/adempiere/gRPC-API/pull/12
