### PR TITLE
fix: #1719 Enter key send values.

### DIFF
--- a/src/components/ADempiere/Field/mixin/mixinField.js
+++ b/src/components/ADempiere/Field/mixin/mixinField.js
@@ -247,6 +247,7 @@ export default {
           keyCode: value.keyCode
         })
       }
+      this.preHandleChange(value.target.value)
     },
     keyReleased(value) {
       if (this.metadata.handleKeyReleased) {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Product Group` window.
2. Create New.
3. Modify the value field.
4. Press Enter: Note that the validation message is showed.

#### Screenshot or Gif

https://user-images.githubusercontent.com/20288327/161968295-5363c5d6-8f63-41bf-a282-056214955e35.mp4

#### Other relevant information
- Your OS: Linux Mint 20.2 x64.
- Web Browser: Mozilla Firefox 92.0.1
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
fixes #1719
